### PR TITLE
fix(sync): prevent hang after sync completion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -363,13 +363,17 @@ async fn execute_build_command(
         }
     }
     let (prog, args) = parse_build_command(build_cmd, &rtp_dirs);
-    match tokio::process::Command::new(&prog)
-        .args(&args)
-        .current_dir(dst_path)
-        .output()
-        .await
+    let build_timeout = std::time::Duration::from_secs(300); // 5 minutes
+    match tokio::time::timeout(
+        build_timeout,
+        tokio::process::Command::new(&prog)
+            .args(&args)
+            .current_dir(dst_path)
+            .output(),
+    )
+    .await
     {
-        Ok(o) if !o.status.success() => {
+        Ok(Ok(o)) if !o.status.success() => {
             let stderr = String::from_utf8_lossy(&o.stderr);
             eprintln!(
                 "Warning: build failed for '{}': {}",
@@ -377,11 +381,18 @@ async fn execute_build_command(
                 stderr.trim()
             );
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             eprintln!(
                 "Warning: build command failed for '{}': {}",
                 plugin.display_name(),
                 e
+            );
+        }
+        Err(_) => {
+            eprintln!(
+                "Warning: build timed out for '{}' ({}s)",
+                plugin.display_name(),
+                build_timeout.as_secs()
             );
         }
         _ => {}
@@ -465,6 +476,10 @@ async fn run_sync(prune: bool) -> Result<()> {
         });
     }
 
+    // 全タスクを spawn し終えたので元の tx を drop。
+    // これにより全タスク完了後に rx が閉じ、channel のリークを防ぐ。
+    drop(tx);
+
     let mut plugin_scripts = Vec::new();
     let mut finished_tasks = 0;
     let total_tasks = config.plugins.len();
@@ -503,9 +518,10 @@ async fn run_sync(prune: bool) -> Result<()> {
 
     terminal.draw(|f| tui_state.draw(f, "syncing..."))?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
+    // TUI cleanup — 各ステップが失敗しても次を続行してターミナルを確実に復元する
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
     println!("Generating loader.lua...");
     let loader_path = resolve_loader_path(config.options.loader_path.as_deref(), &base_dir);
     write_loader_to_path(

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,16 +333,14 @@ fn resolve_plugin_dst(plugin: &crate::config::Plugin, base_dir: &Path) -> PathBu
 }
 
 /// プラグインの build コマンドを実行する (依存 rtp 解決込み)。
-/// build が未設定なら何もしない。
+/// build が未設定なら None を返す。失敗時はエラーメッセージを返す。
 async fn execute_build_command(
     plugin: &crate::config::Plugin,
     dst_path: &Path,
     config: &crate::config::Config,
     base_dir: &Path,
-) {
-    let Some(build_cmd) = &plugin.build else {
-        return;
-    };
+) -> Option<String> {
+    let build_cmd = plugin.build.as_ref()?;
     let mut rtp_dirs = vec![dst_path.to_path_buf()];
     let mut visited = std::collections::HashSet::new();
     let mut stack: Vec<String> = plugin.depends.iter().flatten().cloned().collect();
@@ -364,38 +362,28 @@ async fn execute_build_command(
     }
     let (prog, args) = parse_build_command(build_cmd, &rtp_dirs);
     let build_timeout = std::time::Duration::from_secs(300); // 5 minutes
-    match tokio::time::timeout(
-        build_timeout,
-        tokio::process::Command::new(&prog)
-            .args(&args)
-            .current_dir(dst_path)
-            .output(),
-    )
-    .await
+    let mut child = match tokio::process::Command::new(&prog)
+        .args(&args)
+        .current_dir(dst_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
     {
-        Ok(Ok(o)) if !o.status.success() => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            eprintln!(
-                "Warning: build failed for '{}': {}",
-                plugin.display_name(),
-                stderr.trim()
-            );
+        Ok(c) => c,
+        Err(e) => {
+            return Some(format!("build spawn failed: {}", e));
         }
-        Ok(Err(e)) => {
-            eprintln!(
-                "Warning: build command failed for '{}': {}",
-                plugin.display_name(),
-                e
-            );
+    };
+    match tokio::time::timeout(build_timeout, child.wait()).await {
+        Ok(Ok(status)) if !status.success() => {
+            Some(format!("build failed (exit code: {:?})", status.code()))
         }
+        Ok(Err(e)) => Some(format!("build error: {}", e)),
         Err(_) => {
-            eprintln!(
-                "Warning: build timed out for '{}' ({}s)",
-                plugin.display_name(),
-                build_timeout.as_secs()
-            );
+            let _ = child.kill().await;
+            Some(format!("build timed out ({}s)", build_timeout.as_secs()))
         }
-        _ => {}
+        _ => None,
     }
 }
 
@@ -462,7 +450,17 @@ async fn run_sync(prune: bool) -> Result<()> {
                             ))
                             .await;
                     }
-                    execute_build_command(&plugin, &dst_path, &config_for_build, &base_dir).await;
+                    if let Some(err) =
+                        execute_build_command(&plugin, &dst_path, &config_for_build, &base_dir)
+                            .await
+                    {
+                        let _ = tx
+                            .send((
+                                plugin.url.clone(),
+                                PluginStatus::Syncing(format!("Build warning: {}", err)),
+                            ))
+                            .await;
+                    }
                     let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
                     Ok((plugin, dst_path))
                 }
@@ -1094,7 +1092,11 @@ async fn run_add(
         if let Err(e) = git_repo.sync().await {
             eprintln!("Warning: failed to sync '{}': {}", plugin.display_name(), e);
         } else {
-            execute_build_command(&plugin, &dst_path, &config_data, &base_dir).await;
+            if let Some(err) =
+                execute_build_command(&plugin, &dst_path, &config_data, &base_dir).await
+            {
+                eprintln!("Warning: {}: {}", plugin.display_name(), err);
+            }
 
             if plugin.merge && !plugin.lazy {
                 std::fs::create_dir_all(&merged_dir).ok();


### PR DESCRIPTION
## Summary
- Drop the original `tx` sender after spawning all tasks to properly close the channel
- Add 5-minute timeout to build commands (`execute_build_command`) to prevent indefinite blocking
- Use `let _ =` for TUI cleanup (`disable_raw_mode`, `LeaveAlternateScreen`, `show_cursor`) to ensure terminal is restored even if a cleanup step fails

## Root cause analysis
Three potential hang sources identified:
1. **Channel sender leak**: Original `tx` was never dropped, keeping the channel open after all tasks complete
2. **Build command without timeout**: `cargo build --release` or other build commands could block forever if stuck
3. **TUI cleanup with `?`**: If `disable_raw_mode()` failed, `LeaveAlternateScreen` and `show_cursor` would never run, leaving the terminal in raw/alternate mode

## Test plan
- [x] All 146 tests pass
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: run `rvpm sync` with a large config and verify prompt returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)