### PR TITLE
fix(tui): use standard Unicode icons in sync view + post-sync summary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -450,10 +450,10 @@ async fn run_sync(prune: bool) -> Result<()> {
                             ))
                             .await;
                     }
-                    if let Some(err) =
+                    let build_warn =
                         execute_build_command(&plugin, &dst_path, &config_for_build, &base_dir)
-                            .await
-                    {
+                            .await;
+                    if let Some(ref err) = build_warn {
                         let _ = tx
                             .send((
                                 plugin.url.clone(),
@@ -462,7 +462,7 @@ async fn run_sync(prune: bool) -> Result<()> {
                             .await;
                     }
                     let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
-                    Ok((plugin, dst_path))
+                    Ok((plugin, dst_path, build_warn))
                 }
                 Err(e) => {
                     let _ = tx
@@ -479,6 +479,7 @@ async fn run_sync(prune: bool) -> Result<()> {
     drop(tx);
 
     let mut plugin_scripts = Vec::new();
+    let mut build_warnings: Vec<(String, String)> = Vec::new();
     let mut finished_tasks = 0;
     let total_tasks = config.plugins.len();
 
@@ -496,7 +497,10 @@ async fn run_sync(prune: bool) -> Result<()> {
             Some((url, status)) = rx.recv() => { tui_state.update_status(&url, status); }
             Some(res) = set.join_next() => {
                 finished_tasks += 1;
-                if let Ok(Ok((plugin, dst_path))) = res {
+                if let Ok(Ok((plugin, dst_path, build_warn))) = res {
+                    if let Some(warn) = build_warn {
+                        build_warnings.push((plugin.url.clone(), warn));
+                    }
                     // lazy プラグインは merge しない (trigger 前に merged/ 経由で
                     // lua モジュールが rtp に漏れて lazy の意味がなくなるため)
                     if plugin.merge && !plugin.lazy {
@@ -543,21 +547,12 @@ async fn run_sync(prune: bool) -> Result<()> {
     let _ = terminal.show_cursor();
 
     // sync 結果のサマリーを出力 (TUI 閉じた後なので見える)
+    // plugins 順で出力して決定的な順序を保つ
     let failed: Vec<_> = tui_state
-        .status_map
+        .plugins
         .iter()
-        .filter_map(|(url, status)| match status {
-            PluginStatus::Failed(msg) => Some((url.clone(), msg.clone())),
-            _ => None,
-        })
-        .collect();
-    let warned: Vec<_> = tui_state
-        .status_map
-        .iter()
-        .filter_map(|(url, status)| match status {
-            PluginStatus::Syncing(msg) if msg.starts_with("Build warning:") => {
-                Some((url.clone(), msg.clone()))
-            }
+        .filter_map(|url| match tui_state.status_map.get(url) {
+            Some(PluginStatus::Failed(msg)) => Some((url.as_str(), msg.as_str())),
             _ => None,
         })
         .collect();
@@ -567,9 +562,9 @@ async fn run_sync(prune: bool) -> Result<()> {
             eprintln!("  \u{2717} {}: {}", url, msg);
         }
     }
-    if !warned.is_empty() {
-        eprintln!("\n{} warning(s):", warned.len());
-        for (url, msg) in &warned {
+    if !build_warnings.is_empty() {
+        eprintln!("\n{} build warning(s):", build_warnings.len());
+        for (url, msg) in &build_warnings {
             eprintln!("  \u{26a0} {}: {}", url, msg);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -541,6 +541,39 @@ async fn run_sync(prune: bool) -> Result<()> {
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
     let _ = terminal.show_cursor();
+
+    // sync 結果のサマリーを出力 (TUI 閉じた後なので見える)
+    let failed: Vec<_> = tui_state
+        .status_map
+        .iter()
+        .filter_map(|(url, status)| match status {
+            PluginStatus::Failed(msg) => Some((url.clone(), msg.clone())),
+            _ => None,
+        })
+        .collect();
+    let warned: Vec<_> = tui_state
+        .status_map
+        .iter()
+        .filter_map(|(url, status)| match status {
+            PluginStatus::Syncing(msg) if msg.starts_with("Build warning:") => {
+                Some((url.clone(), msg.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    if !failed.is_empty() {
+        eprintln!("\n{} error(s):", failed.len());
+        for (url, msg) in &failed {
+            eprintln!("  \u{2717} {}: {}", url, msg);
+        }
+    }
+    if !warned.is_empty() {
+        eprintln!("\n{} warning(s):", warned.len());
+        for (url, msg) in &warned {
+            eprintln!("  \u{26a0} {}: {}", url, msg);
+        }
+    }
+
     println!("Generating loader.lua...");
     let loader_path = resolve_loader_path(config.options.loader_path.as_deref(), &base_dir);
     write_loader_to_path(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -312,11 +312,11 @@ impl TuiState {
                     .unwrap_or(PluginStatus::Waiting);
                 let (icon, color, msg) = match &status {
                     PluginStatus::Waiting => {
-                        ("\u{f0292}", Color::DarkGray, "Waiting...".to_string())
+                        ("\u{25cb}", Color::DarkGray, "Waiting...".to_string()) // ○
                     }
-                    PluginStatus::Syncing(m) => ("\u{21bb}", Color::Cyan, m.clone()),
-                    PluginStatus::Finished => ("\u{f00c}", Color::Green, "Finished".to_string()),
-                    PluginStatus::Failed(e) => ("\u{2716}", Color::Red, e.clone()),
+                    PluginStatus::Syncing(m) => ("\u{21bb}", Color::Cyan, m.clone()), // ↻
+                    PluginStatus::Finished => ("\u{2713}", Color::Green, "Finished".to_string()), // ✓
+                    PluginStatus::Failed(e) => ("\u{2717}", Color::Red, e.clone()), // ✗
                 };
                 Row::new(vec![
                     Cell::from(format!(" {} ", icon)).style(Style::default().fg(color)),
@@ -344,8 +344,7 @@ impl TuiState {
             Style::default()
                 .bg(Color::Indexed(237))
                 .add_modifier(Modifier::BOLD),
-        )
-        .highlight_symbol("\u{25b8} ");
+        );
         f.render_stateful_widget(table, chunks[1], &mut self.table_state);
 
         let ratio = if !self.plugins.is_empty() {


### PR DESCRIPTION
## Summary
- Replace Nerd Font private-use-area icons (U+F0292, U+F00C) with standard Unicode (○ ↻ ✓ ✗) in sync/update TUI to fix garbled characters caused by inconsistent cell-width rendering
- Remove `highlight_symbol` from sync view (unnecessary during progress display)
- Print error/warning summary to stderr after TUI closes, so messages that were only visible in the alternate screen are now readable

## Test plan
- [x] All 149 tests pass
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: `rvpm sync` — verify no garbled icons
- [ ] Manual: `rvpm sync` with a failing plugin — verify error summary printed after TUI closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)