### PR TITLE
fix(tui): eliminate eprintln during TUI to prevent garbled display

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -146,11 +146,7 @@ pub fn promote_lazy_to_eager(scripts: &mut [PluginScripts]) -> std::collections:
             break;
         }
 
-        for (name, reason) in &to_promote {
-            eprintln!(
-                "Note: '{}' is lazy but {} — promoting to eager.",
-                name, reason
-            );
+        for (name, _reason) in &to_promote {
             if let Some(s) = scripts.iter_mut().find(|s| s.name == *name) {
                 s.lazy = false;
                 promoted.insert(name.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,16 +310,17 @@ use crossterm::{
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
 
-/// cond + merge=true の組み合わせを検出し、merge を無効化して警告する。
-fn warn_and_disable_merge_if_cond(plugin: &mut crate::config::Plugin) {
+/// cond + merge=true の組み合わせを検出し、merge を無効化する。
+/// 警告メッセージを返す (呼び出し元でまとめて表示)。
+fn warn_and_disable_merge_if_cond(plugin: &mut crate::config::Plugin) -> Option<String> {
     if plugin.cond.is_some() && plugin.merge {
-        eprintln!(
-            "Warning: plugin '{}' has both `cond` and `merge = true`. \
-             merge is disabled for cond plugins (runtime condition cannot be \
-             evaluated at generate time).",
-            plugin.display_name()
-        );
         plugin.merge = false;
+        Some(format!(
+            "{}: cond + merge=true -> merge disabled",
+            plugin.display_name()
+        ))
+    } else {
+        None
     }
 }
 
@@ -394,6 +395,13 @@ async fn run_sync(prune: bool) -> Result<()> {
 
     let mut config_data = parse_config(&toml_content)?;
     crate::config::sort_plugins(&mut config_data.plugins)?;
+    // TUI 開始前に cond+merge を処理 (警告は後でまとめて出す)
+    let mut cond_warnings: Vec<String> = Vec::new();
+    for plugin in config_data.plugins.iter_mut() {
+        if let Some(w) = warn_and_disable_merge_if_cond(plugin) {
+            cond_warnings.push(w);
+        }
+    }
     let config = Arc::new(config_data);
 
     let base_dir = resolve_base_dir(config.options.base_dir.as_deref());
@@ -419,11 +427,10 @@ async fn run_sync(prune: bool) -> Result<()> {
     let mut set = JoinSet::new();
 
     for plugin in config.plugins.iter() {
-        let mut plugin = plugin.clone();
+        let plugin = plugin.clone();
         let base_dir = base_dir.clone();
         let tx = tx.clone();
         let sem = semaphore.clone();
-        warn_and_disable_merge_if_cond(&mut plugin);
 
         let config_for_build = config.clone();
         set.spawn(async move {
@@ -566,6 +573,18 @@ async fn run_sync(prune: bool) -> Result<()> {
         eprintln!("\n{} build warning(s):", build_warnings.len());
         for (url, msg) in &build_warnings {
             eprintln!("  \u{26a0} {}: {}", url, msg);
+        }
+    }
+    if !promoted.is_empty() {
+        eprintln!("\n{} plugin(s) promoted lazy -> eager:", promoted.len());
+        for name in &promoted {
+            eprintln!("  -> {}", name);
+        }
+    }
+    if !cond_warnings.is_empty() {
+        eprintln!("\n{} cond/merge warning(s):", cond_warnings.len());
+        for w in &cond_warnings {
+            eprintln!("  \u{26a0} {}", w);
         }
     }
 
@@ -1159,7 +1178,9 @@ async fn run_add(
     let merged_dir = base_dir.join("merged");
 
     if let Some(mut plugin) = config_data.plugins.iter().find(|p| p.url == repo).cloned() {
-        warn_and_disable_merge_if_cond(&mut plugin);
+        if let Some(w) = warn_and_disable_merge_if_cond(&mut plugin) {
+            eprintln!("Warning: {}", w);
+        }
         let dst_path = resolve_plugin_dst(&plugin, &base_dir);
 
         println!("Syncing {}...", plugin.display_name());

--- a/src/main.rs
+++ b/src/main.rs
@@ -576,8 +576,10 @@ async fn run_sync(prune: bool) -> Result<()> {
         }
     }
     if !promoted.is_empty() {
+        let mut sorted_promoted: Vec<_> = promoted.iter().collect();
+        sorted_promoted.sort();
         eprintln!("\n{} plugin(s) promoted lazy -> eager:", promoted.len());
-        for name in &promoted {
+        for name in &sorted_promoted {
             eprintln!("  -> {}", name);
         }
     }
@@ -648,8 +650,13 @@ async fn run_generate() -> Result<()> {
     let toml_content = std::fs::read_to_string(&config_path)
         .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
     let mut config = parse_config(&toml_content)?;
-    // depends に基づいた依存順に並べる (run_sync と同じ扱い)
     crate::config::sort_plugins(&mut config.plugins)?;
+    // cond + merge=true を正規化 (run_sync と同じ)
+    for plugin in config.plugins.iter_mut() {
+        if let Some(w) = warn_and_disable_merge_if_cond(plugin) {
+            eprintln!("Warning: {}", w);
+        }
+    }
     let base_dir = resolve_base_dir(config.options.base_dir.as_deref());
     let merged_dir = base_dir.join("merged");
     let loader_path = resolve_loader_path(config.options.loader_path.as_deref(), &base_dir);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -312,11 +312,11 @@ impl TuiState {
                     .unwrap_or(PluginStatus::Waiting);
                 let (icon, color, msg) = match &status {
                     PluginStatus::Waiting => {
-                        ("\u{25cb}", Color::DarkGray, "Waiting...".to_string()) // ○
+                        ("\u{f0292}", Color::DarkGray, "Waiting...".to_string())
                     }
-                    PluginStatus::Syncing(m) => ("\u{21bb}", Color::Cyan, m.clone()), // ↻
-                    PluginStatus::Finished => ("\u{2713}", Color::Green, "Finished".to_string()), // ✓
-                    PluginStatus::Failed(e) => ("\u{2717}", Color::Red, e.clone()), // ✗
+                    PluginStatus::Syncing(m) => ("\u{21bb}", Color::Cyan, m.clone()),
+                    PluginStatus::Finished => ("\u{f00c}", Color::Green, "Finished".to_string()),
+                    PluginStatus::Failed(e) => ("\u{2716}", Color::Red, e.clone()),
                 };
                 Row::new(vec![
                     Cell::from(format!(" {} ", icon)).style(Style::default().fg(color)),


### PR DESCRIPTION
## Summary
`eprintln!` calls during TUI alternate screen corrupted the display with garbled characters.

- Remove `eprintln` from `promote_lazy_to_eager`, show promoted plugins in post-sync summary
- Move `warn_and_disable_merge_if_cond` before TUI start, collect warnings for later display
- Show all diagnostics as a unified post-sync summary:
  - Sync errors
  - Build warnings
  - Lazy -> eager promotions
  - Cond/merge warnings

## Test plan
- [x] All 149 tests pass
- [x] `cargo clippy` and `cargo fmt` pass
- [x] Manual: `rvpm sync` — no garbled characters in TUI, summary shown after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual status icons in the plugin table for improved clarity during sync operations.

* **Improvements**
  * Diagnostics for promoted plugins and merge-condition warnings are now summarized and reported at the end of sync instead of inline.
  * Merge/condition warnings are collected during operations and emitted as summarized messages; adding or generating plugins now reports relevant warnings immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->