### PR TITLE
feat(config): add icons option for TUI icon style (nerd/unicode/ascii)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,19 @@ pub struct Config {
     pub plugins: Vec<Plugin>,
 }
 
+/// TUI で使用するアイコンスタイル。
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum IconStyle {
+    /// Nerd Font アイコン (デフォルト)
+    #[default]
+    Nerd,
+    /// 標準 Unicode 記号 (○ ↻ ✓ ✗ 等)
+    Unicode,
+    /// ASCII のみ (. * + x 等)
+    Ascii,
+}
+
 #[derive(Debug, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct Options {
     pub config_root: Option<String>,
@@ -20,6 +33,9 @@ pub struct Options {
     /// 全てがこの配下にまとまる。`loader_path` が別途指定されていればそちらが優先。
     /// `~/...` 形式を受け付ける。
     pub base_dir: Option<String>,
+    /// TUI アイコンスタイル: "nerd" (default), "unicode", "ascii"
+    #[serde(default)]
+    pub icons: IconStyle,
 }
 
 /// Keymap 仕様. TOML では文字列 (`"<leader>f"`) またはテーブル
@@ -380,6 +396,44 @@ url = "owner/repo"
 "#;
         let config = parse_config(toml).unwrap();
         assert_eq!(config.options.base_dir, None);
+    }
+
+    #[test]
+    fn test_parse_config_icons_defaults_to_nerd() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.options.icons, IconStyle::Nerd);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_icons_unicode() {
+        let toml = r#"
+[options]
+icons = "unicode"
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.options.icons, IconStyle::Unicode);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_icons_ascii() {
+        let toml = r#"
+[options]
+icons = "ascii"
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.options.icons, IconStyle::Ascii);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -746,7 +746,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
     let mut config = parse_config(&toml_content)?;
     let base_dir = resolve_base_dir(config.options.base_dir.as_deref());
     let config_root = resolve_config_root(config.options.config_root.as_deref());
-    let icons = crate::tui::Icons::from_style(config.options.icons);
+    let mut icons = crate::tui::Icons::from_style(config.options.icons);
 
     if no_tui {
         // 非対話モード: plain text 出力 (旧 status コマンド相当)
@@ -924,6 +924,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                             let _ = run_sync(false).await;
                         }
                         let (c, s) = reload_state(&config_path, &base_dir, &mut terminal).await?;
+                        icons = crate::tui::Icons::from_style(c.options.icons);
                         config = c;
                         tui_state = s;
                     }
@@ -950,6 +951,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                             let _ = run_sync(false).await;
                         }
                         let (c, s) = reload_state(&config_path, &base_dir, &mut terminal).await?;
+                        icons = crate::tui::Icons::from_style(c.options.icons);
                         config = c;
                         tui_state = s;
                     }
@@ -970,6 +972,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                         terminal.show_cursor()?;
                         let _ = run_update(Some(url)).await;
                         let (c, s) = reload_state(&config_path, &base_dir, &mut terminal).await?;
+                        icons = crate::tui::Icons::from_style(c.options.icons);
                         config = c;
                         tui_state = s;
                     }
@@ -990,6 +993,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                         terminal.show_cursor()?;
                         let _ = run_remove(Some(url)).await;
                         let (c, s) = reload_state(&config_path, &base_dir, &mut terminal).await?;
+                        icons = crate::tui::Icons::from_style(c.options.icons);
                         config = c;
                         tui_state = s;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,8 @@ async fn run_sync(prune: bool) -> Result<()> {
     }
     std::fs::create_dir_all(&merged_dir)?;
 
+    let icons = crate::tui::Icons::from_style(config.options.icons);
+
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -491,7 +493,7 @@ async fn run_sync(prune: bool) -> Result<()> {
     let total_tasks = config.plugins.len();
 
     while finished_tasks < total_tasks {
-        terminal.draw(|f| tui_state.draw(f, "syncing..."))?;
+        terminal.draw(|f| tui_state.draw(f, "syncing...", &icons))?;
 
         // sync/update 中のイベントキューを drain してスクロール操作を受け付ける
         while crossterm::event::poll(std::time::Duration::from_millis(0))? {
@@ -546,7 +548,7 @@ async fn run_sync(prune: bool) -> Result<()> {
         }
     }
 
-    terminal.draw(|f| tui_state.draw(f, "syncing..."))?;
+    terminal.draw(|f| tui_state.draw(f, "syncing...", &icons))?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     // TUI cleanup — 各ステップが失敗しても次を続行してターミナルを確実に復元する
     let _ = disable_raw_mode();
@@ -744,6 +746,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
     let mut config = parse_config(&toml_content)?;
     let base_dir = resolve_base_dir(config.options.base_dir.as_deref());
     let config_root = resolve_config_root(config.options.config_root.as_deref());
+    let icons = crate::tui::Icons::from_style(config.options.icons);
 
     if no_tui {
         // 非対話モード: plain text 出力 (旧 status コマンド相当)
@@ -835,7 +838,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
             while let Some(Ok(_)) = set.try_join_next() {}
         }
 
-        terminal.draw(|f| tui_state.draw_list(f, &config, &config_root))?;
+        terminal.draw(|f| tui_state.draw_list(f, &config, &config_root, &icons))?;
 
         if crossterm::event::poll(std::time::Duration::from_millis(50))?
             && let crossterm::event::Event::Key(key) = crossterm::event::read()?
@@ -1007,6 +1010,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
     let toml_content = std::fs::read_to_string(&config_path)
         .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
     let config_data = parse_config(&toml_content)?;
+    let icons = crate::tui::Icons::from_style(config_data.options.icons);
     let config = Arc::new(config_data);
     let base_dir = resolve_base_dir(config.options.base_dir.as_deref());
 
@@ -1088,7 +1092,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
     let mut finished_tasks = 0;
 
     while finished_tasks < total_tasks {
-        terminal.draw(|f| tui_state.draw(f, "updating..."))?;
+        terminal.draw(|f| tui_state.draw(f, "updating...", &icons))?;
 
         // sync/update 中のイベントキューを drain してスクロール操作を受け付ける
         while crossterm::event::poll(std::time::Duration::from_millis(0))? {
@@ -1103,7 +1107,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
             _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
         }
     }
-    terminal.draw(|f| tui_state.draw(f, "updating..."))?;
+    terminal.draw(|f| tui_state.draw(f, "updating...", &icons))?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -515,7 +515,7 @@ impl TuiState {
                         (icons.modified, Color::Yellow)
                     }
                     PluginStatus::Syncing(_) => (icons.syncing, Color::Cyan),
-                    PluginStatus::Waiting => ("?", Color::DarkGray),
+                    PluginStatus::Waiting => (icons.waiting, Color::DarkGray),
                 };
 
                 // 詳細列: エラー/変更時はその内容、正常時はトリガー情報

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,6 +7,60 @@ use ratatui::{
 };
 use std::collections::HashMap;
 
+/// TUI で使用するアイコンセット。IconStyle に応じて切り替える。
+pub struct Icons {
+    pub waiting: &'static str,
+    pub syncing: &'static str,
+    pub finished: &'static str,
+    pub failed: &'static str,
+    /// list TUI 用
+    pub installed: &'static str,
+    pub missing: &'static str,
+    pub modified: &'static str,
+    pub hook_on: &'static str,
+    pub hook_off: &'static str,
+}
+
+impl Icons {
+    pub fn from_style(style: crate::config::IconStyle) -> Self {
+        match style {
+            crate::config::IconStyle::Nerd => Self {
+                waiting: "\u{f0292}",  // 󰊒
+                syncing: "\u{21bb}",   // ↻
+                finished: "\u{f00c}",  //
+                failed: "\u{2716}",    // ✖
+                installed: "\u{f00c}", //
+                missing: "\u{f05e}",   //
+                modified: "\u{f071}",  //
+                hook_on: "\u{25cf}",   // ●
+                hook_off: "\u{25cb}",  // ○
+            },
+            crate::config::IconStyle::Unicode => Self {
+                waiting: "\u{25cb}",   // ○
+                syncing: "\u{21bb}",   // ↻
+                finished: "\u{2713}",  // ✓
+                failed: "\u{2717}",    // ✗
+                installed: "\u{2713}", // ✓
+                missing: "\u{2718}",   // ✘
+                modified: "\u{26a0}",  // ⚠
+                hook_on: "\u{25cf}",   // ●
+                hook_off: "\u{25cb}",  // ○
+            },
+            crate::config::IconStyle::Ascii => Self {
+                waiting: ".",
+                syncing: "*",
+                finished: "+",
+                failed: "x",
+                installed: "+",
+                missing: "!",
+                modified: "~",
+                hook_on: "o",
+                hook_off: "-",
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PluginStatus {
     Waiting,
@@ -233,7 +287,7 @@ impl TuiState {
         }
     }
 
-    pub fn draw(&mut self, f: &mut Frame, message: &str) {
+    pub fn draw(&mut self, f: &mut Frame, message: &str, icons: &Icons) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -312,11 +366,13 @@ impl TuiState {
                     .unwrap_or(PluginStatus::Waiting);
                 let (icon, color, msg) = match &status {
                     PluginStatus::Waiting => {
-                        ("\u{f0292}", Color::DarkGray, "Waiting...".to_string())
+                        (icons.waiting, Color::DarkGray, "Waiting...".to_string())
                     }
-                    PluginStatus::Syncing(m) => ("\u{21bb}", Color::Cyan, m.clone()),
-                    PluginStatus::Finished => ("\u{f00c}", Color::Green, "Finished".to_string()),
-                    PluginStatus::Failed(e) => ("\u{2716}", Color::Red, e.clone()),
+                    PluginStatus::Syncing(m) => (icons.syncing, Color::Cyan, m.clone()),
+                    PluginStatus::Finished => {
+                        (icons.finished, Color::Green, "Finished".to_string())
+                    }
+                    PluginStatus::Failed(e) => (icons.failed, Color::Red, e.clone()),
                 };
                 Row::new(vec![
                     Cell::from(format!(" {} ", icon)).style(Style::default().fg(color)),
@@ -364,6 +420,7 @@ impl TuiState {
         f: &mut Frame,
         config: &crate::config::Config,
         config_root: &std::path::Path,
+        icons: &Icons,
     ) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -451,13 +508,13 @@ impl TuiState {
                     .cloned()
                     .unwrap_or(PluginStatus::Waiting);
                 let (inst_icon, inst_color) = match &install_status {
-                    PluginStatus::Finished => ("\u{f00c}", Color::Green), //
-                    PluginStatus::Failed(m) if m == "Missing" => ("\u{f05e}", Color::Red), //
-                    PluginStatus::Failed(_) => ("\u{2716}", Color::Red),  // ✖
+                    PluginStatus::Finished => (icons.installed, Color::Green),
+                    PluginStatus::Failed(m) if m == "Missing" => (icons.missing, Color::Red),
+                    PluginStatus::Failed(_) => (icons.failed, Color::Red),
                     PluginStatus::Syncing(m) if m.contains("Modified") => {
-                        ("\u{f071}", Color::Yellow)
-                    } //
-                    PluginStatus::Syncing(_) => ("\u{21bb}", Color::Cyan), // ↻
+                        (icons.modified, Color::Yellow)
+                    }
+                    PluginStatus::Syncing(_) => (icons.syncing, Color::Cyan),
                     PluginStatus::Waiting => ("?", Color::DarkGray),
                 };
 
@@ -496,7 +553,7 @@ impl TuiState {
                     ("Eager", Color::Green)
                 };
                 let merged = if p.merge {
-                    ("\u{2713}", Color::Cyan) // ✓
+                    (icons.installed, Color::Cyan)
                 } else {
                     ("-", Color::DarkGray)
                 };
@@ -505,19 +562,19 @@ impl TuiState {
                 // I B A 列: init/before/after.lua の存在チェック
                 let pcdir = config_root.join(p.canonical_path());
                 let hook_i = if pcdir.join("init.lua").exists() {
-                    "\u{25cf}"
+                    icons.hook_on
                 } else {
-                    "\u{25cb}"
+                    icons.hook_off
                 };
                 let hook_b = if pcdir.join("before.lua").exists() {
-                    "\u{25cf}"
+                    icons.hook_on
                 } else {
-                    "\u{25cb}"
+                    icons.hook_off
                 };
                 let hook_a = if pcdir.join("after.lua").exists() {
-                    "\u{25cf}"
+                    icons.hook_on
                 } else {
-                    "\u{25cb}"
+                    icons.hook_off
                 };
                 let hooks_text = format!("{} {} {}", hook_i, hook_b, hook_a);
                 let has_hooks = pcdir.join("init.lua").exists()
@@ -769,5 +826,28 @@ mod tests {
             matches!(&state.status_map["c"], PluginStatus::Syncing(m) if m.contains("Modified"))
         );
         assert!(matches!(&state.status_map["d"], PluginStatus::Failed(m) if m != "Missing"));
+    }
+
+    #[test]
+    fn test_icons_nerd_uses_private_use_area() {
+        let icons = Icons::from_style(crate::config::IconStyle::Nerd);
+        assert!(icons.finished.contains('\u{f00c}'));
+    }
+
+    #[test]
+    fn test_icons_unicode_uses_standard_symbols() {
+        let icons = Icons::from_style(crate::config::IconStyle::Unicode);
+        assert_eq!(icons.finished, "\u{2713}"); // ✓
+        assert_eq!(icons.failed, "\u{2717}"); // ✗
+        assert_eq!(icons.waiting, "\u{25cb}"); // ○
+    }
+
+    #[test]
+    fn test_icons_ascii_uses_only_ascii() {
+        let icons = Icons::from_style(crate::config::IconStyle::Ascii);
+        assert!(icons.finished.is_ascii());
+        assert!(icons.failed.is_ascii());
+        assert!(icons.waiting.is_ascii());
+        assert!(icons.syncing.is_ascii());
     }
 }


### PR DESCRIPTION
## Summary
Add `icons` field to `[options]` in config.toml to control TUI icon style:

```toml
[options]
icons = "nerd"     # default - Nerd Font icons
# icons = "unicode"  # standard Unicode (✓ ✗ ○ etc.)
# icons = "ascii"    # ASCII only (+ x . * etc.)
```

- `IconStyle` enum in config.rs with serde deserialization
- `Icons` struct in tui.rs with `from_style` constructor
- All TUI views (sync, update, list) respect this setting
- 6 new tests (3 config parsing + 3 icon set verification)

## Test plan
- [x] All 155 tests pass
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: set `icons = "ascii"` and verify all views use ASCII

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure icon styles (Nerd, Unicode, or ASCII) to customize the appearance of status indicators and plugin symbols throughout the interface. The Nerd style is used by default when no preference is specified in the configuration.

* **Tests**
  * Added comprehensive tests to verify icon style configuration parsing behavior across all supported styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->