### PR TITLE
feat(config): full Tera template support ({% if %}, vars cross-refs, forward refs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,92 @@ on_map = [
 | `base_dir` | `string` | `~/.cache/rvpm` | Root for all rvpm data (repos, merged, loader.lua). Setting this moves everything together |
 | `loader_path` | `string` | `{base_dir}/loader.lua` | Override only the loader.lua output path. Takes precedence over `base_dir` for the loader file |
 
+### Tera templates
+
+The entire `config.toml` is processed by [Tera](https://keats.github.io/tera/) before TOML parsing. You can use `{{ vars.xxx }}`, `{{ env.HOME }}`, `{{ is_windows }}`, `{% if %}` blocks, and more.
+
+#### Available context
+
+| Variable | Type | Description |
+|---|---|---|
+| `vars.*` | any | User-defined variables from `[vars]` |
+| `env.*` | string | Environment variables (e.g. `{{ env.HOME }}`) |
+| `is_windows` | bool | `true` on Windows, `false` otherwise |
+
+#### Variables referencing other variables
+
+Variables can reference each other — including forward references:
+
+```toml
+[vars]
+base = "~/.cache/rvpm"
+full = "{{ vars.base }}/custom"   # → "~/.cache/rvpm/custom"
+
+# Forward reference works too
+greeting = "Hello {{ vars.name }}"
+name = "yukimemi"
+# greeting → "Hello yukimemi"
+```
+
+#### Conditional plugin inclusion
+
+Use `{% if %}` to completely exclude plugins from `loader.lua` at generate time:
+
+```toml
+[vars]
+use_blink = true
+use_cmp = false
+use_telescope = false
+use_snacks = true
+
+[options]
+
+# ── Completion: pick one ─────────────────────────
+{% if vars.use_blink %}
+[[plugins]]
+url = "saghen/blink.cmp"
+on_event = ["InsertEnter", "CmdlineEnter"]
+{% endif %}
+
+{% if vars.use_cmp %}
+[[plugins]]
+url = "hrsh7th/nvim-cmp"
+on_event = "InsertEnter"
+{% endif %}
+
+# ── Fuzzy finder: pick one ───────────────────────
+{% if vars.use_telescope %}
+[[plugins]]
+url = "nvim-telescope/telescope.nvim"
+on_cmd = "Telescope"
+{% endif %}
+
+{% if vars.use_snacks %}
+[[plugins]]
+url = "folke/snacks.nvim"
+{% endif %}
+```
+
+#### Platform-specific plugins
+
+```toml
+[options]
+
+{% if is_windows %}
+[[plugins]]
+url = "thinca/vim-winenv"
+{% endif %}
+
+[[plugins]]
+url = "folke/snacks.nvim"
+cond = "{{ is_windows }}"  # runtime cond: included in loader but guarded
+```
+
+> **`{% if %}` vs `cond`**: `{% if %}` removes the plugin entirely at generate
+> time — it won't be cloned, merged, or appear in `loader.lua`. `cond` keeps
+> the plugin in `loader.lua` but wraps it in `if <expr> then ... end` for
+> runtime evaluation.
+
 ### `[[plugins]]` reference
 
 | Key | Type | Default | Description |

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,32 +202,74 @@ impl Plugin {
     }
 }
 
+/// [vars] セクションを TOML 全体パースなしでテキストから抽出する。
+/// `{% if %}` 等の Tera 構文が含まれていても安全。
+fn extract_vars_section(toml_str: &str) -> String {
+    let mut in_vars = false;
+    let mut vars_lines = vec!["[vars]".to_string()];
+    for line in toml_str.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[vars]" {
+            in_vars = true;
+            continue;
+        }
+        if in_vars {
+            // 次のセクション開始 or Tera ブロックタグで vars 終了
+            if (trimmed.starts_with('[') && !trimmed.starts_with("[[")) || trimmed.starts_with("{%")
+            {
+                break;
+            }
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                vars_lines.push(line.to_string());
+            }
+        }
+    }
+    vars_lines.join("\n")
+}
+
 pub fn parse_config(toml_str: &str) -> Result<Config> {
-    // 1. Raw Parse
+    // 1. [vars] セクションをテキストベースで抽出 (TOML パーサー不要)
+    let vars_toml = extract_vars_section(toml_str);
+
+    // 2. vars を TOML パースして初期値を取得
     #[derive(Deserialize)]
-    struct Raw {
+    struct VarsOnly {
         vars: Option<serde_json::Value>,
     }
-    let raw: Raw = toml::from_str(toml_str)?;
+    let vars_parsed: VarsOnly = toml::from_str(&vars_toml).unwrap_or(VarsOnly { vars: None });
 
-    // 2. Tera Context の構築
-    let mut context = Context::new();
-    if let Some(v) = raw.vars.as_ref() {
-        context.insert("vars", v);
+    // 3. vars 内の相互参照を反復レンダリングで解決
+    let mut vars_value = vars_parsed
+        .vars
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+    for _ in 0..10 {
+        // 安全ガード: 最大 10 回で収束
+        let mut ctx = Context::new();
+        ctx.insert("vars", &vars_value);
+        let vars_str = serde_json::to_string(&vars_value)?;
+        let rendered_str = Tera::one_off(&vars_str, &ctx, false)?;
+        let new_value: serde_json::Value = serde_json::from_str(&rendered_str)?;
+        if new_value == vars_value {
+            break;
+        }
+        vars_value = new_value;
     }
+
+    // 4. Tera Context の構築 (解決済み vars + env + is_windows)
+    let mut context = Context::new();
+    context.insert("vars", &vars_value);
     context.insert("is_windows", &cfg!(windows));
 
-    // 環境変数の追加
     let mut env_map = std::collections::HashMap::new();
     for (key, value) in std::env::vars() {
         env_map.insert(key, value);
     }
     context.insert("env", &env_map);
 
-    // 3. Tera でレンダリング
+    // 5. 全体を Tera でレンダリング ({% if %} 等が動く)
     let rendered = Tera::one_off(toml_str, &context, false)?;
 
-    // 4. Final Parse
+    // 6. TOML パース
     let mut config: Config = toml::from_str(&rendered)?;
 
     // 5. lazy 自動解決: on_* トリガーがあれば lazy = true にする (明示 false は尊重)
@@ -799,5 +841,105 @@ merge = false
 
         // No explicit name → default_name
         assert_eq!(p1.display_name(), "plenary.nvim");
+    }
+
+    // ========================================================
+    // Tera テンプレート拡張テスト
+    // ========================================================
+
+    #[test]
+    fn test_tera_if_block_excludes_plugin() {
+        let toml = r#"
+[vars]
+use_blink = false
+
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+{% if vars.use_blink %}
+[[plugins]]
+url = "owner/blink"
+{% endif %}
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].url, "owner/always");
+    }
+
+    #[test]
+    fn test_tera_if_block_includes_plugin_when_true() {
+        let toml = r#"
+[vars]
+use_blink = true
+
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+{% if vars.use_blink %}
+[[plugins]]
+url = "owner/blink"
+{% endif %}
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 2);
+    }
+
+    #[test]
+    fn test_vars_reference_other_vars() {
+        let toml = r#"
+[vars]
+base = "/tmp"
+full = "{{ vars.base }}/plugins"
+
+[options]
+
+[[plugins]]
+url = "owner/repo"
+dst = "{{ vars.full }}/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins[0].dst, Some("/tmp/plugins/repo".to_string()));
+    }
+
+    #[test]
+    fn test_vars_forward_reference() {
+        let toml = r#"
+[vars]
+full = "{{ vars.base }}/plugins"
+base = "/tmp"
+
+[options]
+
+[[plugins]]
+url = "owner/repo"
+dst = "{{ vars.full }}/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins[0].dst, Some("/tmp/plugins/repo".to_string()));
+    }
+
+    #[test]
+    fn test_tera_is_windows_in_if_block() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+{% if is_windows %}
+[[plugins]]
+url = "owner/win-only"
+{% endif %}
+"#;
+        let config = parse_config(toml).unwrap();
+        if cfg!(windows) {
+            assert_eq!(config.plugins.len(), 2);
+        } else {
+            assert_eq!(config.plugins.len(), 1);
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -207,6 +207,7 @@ const MAX_VARS_RESOLVE_ITERATIONS: usize = 10;
 
 /// [vars] セクションを TOML 全体パースなしでテキストから抽出する。
 /// `{% if %}` 等の Tera 構文が含まれていても安全。
+/// `[vars.sub]` のようなサブテーブルも正しく含める。
 fn extract_vars_section(toml_str: &str) -> String {
     let mut in_vars = false;
     let mut vars_lines = vec!["[vars]".to_string()];
@@ -226,13 +227,25 @@ fn extract_vars_section(toml_str: &str) -> String {
             }
             continue;
         }
-        // 次のセクション開始 ([options], [[plugins]] 等) or Tera ブロックタグで vars 終了
-        if trimmed.starts_with('[') || trimmed.starts_with("{%") {
+        // [vars] or [vars.xxx] のサブテーブルは含める
+        // それ以外のセクション ([options], [[plugins]] 等) or Tera ブロックタグで終了
+        if trimmed.starts_with('[') {
+            let section_name = trimmed
+                .split('#')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .replace(' ', "");
+            if section_name.starts_with("[vars.") || section_name.starts_with("[vars]") {
+                vars_lines.push(line.to_string());
+                continue;
+            }
             break;
         }
-        if !trimmed.is_empty() && !trimmed.starts_with('#') {
-            vars_lines.push(line.to_string());
+        if trimmed.starts_with("{%") {
+            break;
         }
+        vars_lines.push(line.to_string());
     }
     vars_lines.join("\n")
 }
@@ -249,34 +262,45 @@ pub fn parse_config(toml_str: &str) -> Result<Config> {
     let vars_parsed: VarsOnly = toml::from_str(&vars_toml)
         .map_err(|e| anyhow::anyhow!("Failed to parse [vars] section: {}", e))?;
 
-    // 3. vars 内の相互参照を反復レンダリングで解決
-    let mut vars_value = vars_parsed
-        .vars
-        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-    for _ in 0..MAX_VARS_RESOLVE_ITERATIONS {
-        let mut ctx = Context::new();
-        ctx.insert("vars", &vars_value);
-        let vars_str = serde_json::to_string(&vars_value)?;
-        let rendered_str = Tera::one_off(&vars_str, &ctx, false)?;
-        let new_value: serde_json::Value = serde_json::from_str(&rendered_str)?;
-        if new_value == vars_value {
-            break;
-        }
-        vars_value = new_value;
-    }
-
-    // 4. Tera Context の構築 (解決済み vars + env + is_windows)
-    let mut context = Context::new();
-    context.insert("vars", &vars_value);
-    context.insert("is_windows", &cfg!(windows));
-
+    // 3. env + is_windows を先に用意 (vars 内でも参照可能にする)
     let mut env_map = std::collections::HashMap::new();
     for (key, value) in std::env::vars() {
         env_map.insert(key, value);
     }
+
+    // 4. vars 内の相互参照を反復レンダリングで解決
+    let mut vars_value = vars_parsed
+        .vars
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+    let mut converged = false;
+    for _ in 0..MAX_VARS_RESOLVE_ITERATIONS {
+        let mut ctx = Context::new();
+        ctx.insert("vars", &vars_value);
+        ctx.insert("env", &env_map);
+        ctx.insert("is_windows", &cfg!(windows));
+        let vars_str = serde_json::to_string(&vars_value)?;
+        let rendered_str = Tera::one_off(&vars_str, &ctx, false)?;
+        let new_value: serde_json::Value = serde_json::from_str(&rendered_str)?;
+        if new_value == vars_value {
+            converged = true;
+            break;
+        }
+        vars_value = new_value;
+    }
+    if !converged {
+        eprintln!(
+            "Warning: [vars] cross-references did not converge after {} iterations",
+            MAX_VARS_RESOLVE_ITERATIONS
+        );
+    }
+
+    // 5. Tera Context の構築 (解決済み vars + env + is_windows)
+    let mut context = Context::new();
+    context.insert("vars", &vars_value);
+    context.insert("is_windows", &cfg!(windows));
     context.insert("env", &env_map);
 
-    // 5. 全体を Tera でレンダリング ({% if %} 等が動く)
+    // 6. 全体を Tera でレンダリング ({% if %} 等が動く)
     let rendered = Tera::one_off(toml_str, &context, false)?;
 
     // 6. TOML パース

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,9 @@ impl Plugin {
     }
 }
 
+/// vars 内の相互参照を解決する最大反復回数。
+const MAX_VARS_RESOLVE_ITERATIONS: usize = 10;
+
 /// [vars] セクションを TOML 全体パースなしでテキストから抽出する。
 /// `{% if %}` 等の Tera 構文が含まれていても安全。
 fn extract_vars_section(toml_str: &str) -> String {
@@ -209,19 +212,26 @@ fn extract_vars_section(toml_str: &str) -> String {
     let mut vars_lines = vec!["[vars]".to_string()];
     for line in toml_str.lines() {
         let trimmed = line.trim();
-        if trimmed == "[vars]" {
-            in_vars = true;
+        // [vars] セクション開始を検出 (空白やコメント付きにも対応)
+        if !in_vars {
+            let stripped = trimmed
+                .split('#')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .replace(' ', "");
+            if stripped == "[vars]" {
+                in_vars = true;
+                continue;
+            }
             continue;
         }
-        if in_vars {
-            // 次のセクション開始 or Tera ブロックタグで vars 終了
-            if (trimmed.starts_with('[') && !trimmed.starts_with("[[")) || trimmed.starts_with("{%")
-            {
-                break;
-            }
-            if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                vars_lines.push(line.to_string());
-            }
+        // 次のセクション開始 ([options], [[plugins]] 等) or Tera ブロックタグで vars 終了
+        if trimmed.starts_with('[') || trimmed.starts_with("{%") {
+            break;
+        }
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            vars_lines.push(line.to_string());
         }
     }
     vars_lines.join("\n")
@@ -236,14 +246,14 @@ pub fn parse_config(toml_str: &str) -> Result<Config> {
     struct VarsOnly {
         vars: Option<serde_json::Value>,
     }
-    let vars_parsed: VarsOnly = toml::from_str(&vars_toml).unwrap_or(VarsOnly { vars: None });
+    let vars_parsed: VarsOnly = toml::from_str(&vars_toml)
+        .map_err(|e| anyhow::anyhow!("Failed to parse [vars] section: {}", e))?;
 
     // 3. vars 内の相互参照を反復レンダリングで解決
     let mut vars_value = vars_parsed
         .vars
         .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-    for _ in 0..10 {
-        // 安全ガード: 最大 10 回で収束
+    for _ in 0..MAX_VARS_RESOLVE_ITERATIONS {
         let mut ctx = Context::new();
         ctx.insert("vars", &vars_value);
         let vars_str = serde_json::to_string(&vars_value)?;


### PR DESCRIPTION
## Summary
Enable full Tera template support in config.toml by extracting `[vars]` via text parsing instead of TOML parsing.

### New capabilities
- **`{% if %}` blocks**: conditionally include/exclude entire plugin blocks at generate time
- **Vars cross-references**: `full = "{{ vars.base }}/plugins"`
- **Forward references**: `a = "{{ vars.b }}"` declared before `b = "value"`
- **All Tera features**: `{% for %}`, filters, etc.

### How it works
1. Extract `[vars]` section via line-by-line text parsing (safe with Tera syntax)
2. Iteratively render vars values with Tera until convergence (resolves cross-refs)
3. Render full config with completed context (`{% if %}` blocks work)
4. Parse rendered TOML as Config

### Example
```toml
[vars]
use_blink = true
use_cmp = false

{% if vars.use_blink %}
[[plugins]]
url = "saghen/blink.cmp"
{% endif %}

{% if vars.use_cmp %}
[[plugins]]
url = "hrsh7th/nvim-cmp"
{% endif %}
```

Also adds Tera template documentation to README with practical examples.

## Test plan
- [x] 154 tests pass (5 new Tera template tests)
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: use `{% if %}` in config.toml, verify excluded plugins don't appear in loader.lua

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config files now support Tera templating, including generate-time conditional plugin inclusion via `{% if %}`.
  * Variable references within config files, including forward references across keys, are supported.

* **Documentation**
  * Added guide documenting Tera templating for config.toml: template context (`vars`, `env`, `is_windows`), variable cross-references, and Windows-specific examples; clarifies generate-time `{% if %}` vs runtime `cond`.

* **Tests**
  * Added tests validating conditional inclusion and variable resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->