### PR TITLE
fix(loader): replay operator and count in on_map lazy trigger

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -454,11 +454,12 @@ end
                 };
                 body.push_str(&format!(
                     "vim.keymap.set({modes}, \"{lhs}\", function()\n\
-                     \x20 local op = vim.v.operator or \"\"\n\
-                     \x20 local cnt = vim.v.count1 ~= 1 and vim.v.count1 or \"\"\n\
+                     \x20 local op = vim.v.operator\n\
+                     \x20 local cnt = vim.v.count1\n\
+                     \x20 local reg = vim.v.register\n\
                      \x20 vim.keymap.del({modes}, \"{lhs}\")\n\
                      \x20 {load}\n\
-                     \x20 local prefix = (op ~= \"\" and op or \"\") .. (cnt ~= \"\" and tostring(cnt) or \"\")\n\
+                     \x20 local prefix = (reg ~= '\"' and '\"' .. reg or \"\") .. op .. (cnt > 1 and cnt or \"\")\n\
                      \x20 local feed = vim.api.nvim_replace_termcodes(\"<Ignore>\" .. prefix .. \"{lhs}\", true, true, true)\n\
                      \x20 vim.api.nvim_feedkeys(feed, \"m\", false)\n\
                      end{opts})\n",
@@ -1464,8 +1465,8 @@ mod tests {
             desc: None,
         }]);
         let lua = gen_loader(Path::new("/merged"), &[s]);
-        // operator-pending mode で yae / dae 等が動くように
-        // vim.v.operator と vim.v.count1 を保存してリプレイに含める
+        // operator-pending mode で yae / dae / "ayae 等が動くように
+        // vim.v.operator, vim.v.count1, vim.v.register を保存してリプレイに含める
         assert!(
             lua.contains("vim.v.operator"),
             "on_map must capture vim.v.operator for operator-pending replay"
@@ -1473,6 +1474,10 @@ mod tests {
         assert!(
             lua.contains("vim.v.count1"),
             "on_map must capture count for replay"
+        );
+        assert!(
+            lua.contains("vim.v.register"),
+            "on_map must capture register for replay"
         );
     }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -454,9 +454,12 @@ end
                 };
                 body.push_str(&format!(
                     "vim.keymap.set({modes}, \"{lhs}\", function()\n\
+                     \x20 local op = vim.v.operator or \"\"\n\
+                     \x20 local cnt = vim.v.count1 ~= 1 and vim.v.count1 or \"\"\n\
                      \x20 vim.keymap.del({modes}, \"{lhs}\")\n\
                      \x20 {load}\n\
-                     \x20 local feed = vim.api.nvim_replace_termcodes(\"<Ignore>{lhs}\", true, true, true)\n\
+                     \x20 local prefix = (op ~= \"\" and op or \"\") .. (cnt ~= \"\" and tostring(cnt) or \"\")\n\
+                     \x20 local feed = vim.api.nvim_replace_termcodes(\"<Ignore>\" .. prefix .. \"{lhs}\", true, true, true)\n\
                      \x20 vim.api.nvim_feedkeys(feed, \"m\", false)\n\
                      end{opts})\n",
                     modes = modes_lua,
@@ -1449,6 +1452,27 @@ mod tests {
         assert!(
             lua.contains("desc = \"Grep files\""),
             "desc should be emitted in keymap opts"
+        );
+    }
+
+    #[test]
+    fn test_on_map_replays_operator_and_count() {
+        let mut s = make_lazy_plugin("textobj-entire");
+        s.on_map = Some(vec![MapSpec {
+            lhs: "ae".to_string(),
+            mode: vec!["x".to_string(), "o".to_string()],
+            desc: None,
+        }]);
+        let lua = gen_loader(Path::new("/merged"), &[s]);
+        // operator-pending mode で yae / dae 等が動くように
+        // vim.v.operator と vim.v.count1 を保存してリプレイに含める
+        assert!(
+            lua.contains("vim.v.operator"),
+            "on_map must capture vim.v.operator for operator-pending replay"
+        );
+        assert!(
+            lua.contains("vim.v.count1"),
+            "on_map must capture count for replay"
         );
     }
 


### PR DESCRIPTION
## Summary
When a lazy-loaded textobj/operator plugin is triggered via `on_map` in operator-pending mode (e.g. `yae`, `dae`, `3yae`), the operator context was lost because the stub function cancelled the pending operator.

Now captures `vim.v.operator` and `vim.v.count1` before loading, and prepends them to the `feedkeys` replay so the full `operator + count + motion` sequence is re-executed.

### Before
```
yae → loads plugin → feedkeys("ae") → ae in normal mode (no-op)
```

### After
```
yae → captures op="y", loads plugin → feedkeys("y" .. "ae") → yae works
3dae → captures op="d" cnt=3, loads → feedkeys("d3ae") → 3dae works
```

## Test plan
- [x] 150 tests pass (1 new)
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: `yae` on first use with lazy textobj-entire

🤖 Generated with [Claude Code](https://claude.com/claude-code)