### PR TITLE
feat(cli): default to list TUI when no subcommand is given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ generated loader.lua into your Neovim init.lua.",
 )]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -230,7 +230,7 @@ enum Commands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    match cli.command {
+    match cli.command.unwrap_or(Commands::List { no_tui: false }) {
         Commands::Sync { prune } => {
             run_sync(prune).await?;
         }


### PR DESCRIPTION
## Summary
Running `rvpm` with no arguments now opens the interactive list TUI (equivalent to `rvpm list`), making it the natural starting point for all plugin management tasks.

2-line change: `command: Commands` → `command: Option<Commands>`, default to `Commands::List { no_tui: false }`.

## Test plan
- [x] All 161 tests pass
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: run `rvpm` with no args → list TUI opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * The command-line interface now supports running without an explicit subcommand. When no command is provided, the application automatically defaults to displaying a list view with the interactive interface enabled, improving the experience for new users and simplifying basic usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->