### PR TITLE
feat(config): add dev option to skip sync/update for local plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ cond = "{{ is_windows }}"  # runtime cond: included in loader but guarded
 | `depends` | `string[]` | none | Plugins that must be loaded before this one. Accepts `display_name` (e.g. `"snacks.nvim"`) or `url` (e.g. `"folke/snacks.nvim"`). **Eager plugin depending on a lazy plugin:** the lazy dep is auto-promoted to eager (a warning is printed to stderr). **Lazy plugin depending on a lazy plugin:** the dep(s) are loaded first inside the trigger callback via a `load_lazy` chain guarded against double-loading |
 | `cond` | `string` | none | Lua expression. When set, the plugin's loader code is wrapped in `if <cond> then ... end` |
 | `build` | `string` | none | Shell command to run after clone (not yet implemented) |
+| `dev` | `bool` | `false` | When `true`, `sync` and `update` skip this plugin entirely (no clone/fetch/reset). Use for local development — the plugin stays on the rtp but rvpm won't touch the working tree |
 
 ### Lazy trigger fields
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,10 @@ pub struct Plugin {
     pub build: Option<String>,
     pub rev: Option<String>,
     pub cond: Option<String>,
+    /// dev = true のプラグインは sync/update をスキップする。
+    /// ローカル開発中のプラグインに使う。
+    #[serde(default)]
+    pub dev: bool,
 }
 
 /// TOML 上で `on_cmd = "Foo"` (単一文字列) または `on_cmd = ["Foo", "Bar"]` (配列)
@@ -1029,5 +1033,31 @@ url = "owner/win-only"
         } else {
             assert_eq!(config.plugins.len(), 1);
         }
+    }
+
+    #[test]
+    fn test_parse_config_dev_defaults_to_false() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(!config.plugins[0].dev);
+    }
+
+    #[test]
+    fn test_parse_config_dev_option() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+dev = true
+dst = "~/src/owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(config.plugins[0].dev);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,7 +431,18 @@ async fn run_sync(prune: bool) -> Result<()> {
     for plugin in config.plugins.iter() {
         // dev プラグインは sync をスキップ (ローカル開発中のためリセットしない)
         if plugin.dev {
-            let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
+            let dst_path = resolve_plugin_dst(plugin, &base_dir);
+            if !dst_path.exists() {
+                let _ = tx.try_send((
+                    plugin.url.clone(),
+                    PluginStatus::Failed(format!(
+                        "dev directory not found: {}",
+                        dst_path.display()
+                    )),
+                ));
+            } else {
+                let _ = tx.try_send((plugin.url.clone(), PluginStatus::Finished));
+            }
             continue;
         }
         let plugin = plugin.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,6 +429,11 @@ async fn run_sync(prune: bool) -> Result<()> {
     let mut set = JoinSet::new();
 
     for plugin in config.plugins.iter() {
+        // dev プラグインは sync をスキップ (ローカル開発中のためリセットしない)
+        if plugin.dev {
+            let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
+            continue;
+        }
         let plugin = plugin.clone();
         let base_dir = base_dir.clone();
         let tx = tx.clone();
@@ -487,10 +492,22 @@ async fn run_sync(prune: bool) -> Result<()> {
     // これにより全タスク完了後に rx が閉じ、channel のリークを防ぐ。
     drop(tx);
 
+    // dev プラグインは sync しないが loader には含めるので先に scripts を作る
     let mut plugin_scripts = Vec::new();
+    let config_root = resolve_config_root(config.options.config_root.as_deref());
+    for plugin in config.plugins.iter().filter(|p| p.dev) {
+        let dst_path = resolve_plugin_dst(plugin, &base_dir);
+        let plugin_config_dir = config_root.join(plugin.canonical_path());
+        if plugin.merge && !plugin.lazy {
+            let _ = merge_plugin(&dst_path, &merged_dir);
+        }
+        plugin_scripts.push(build_plugin_scripts(plugin, &dst_path, &plugin_config_dir));
+    }
+
     let mut build_warnings: Vec<(String, String)> = Vec::new();
     let mut finished_tasks = 0;
-    let total_tasks = config.plugins.len();
+    let dev_count = config.plugins.iter().filter(|p| p.dev).count();
+    let total_tasks = config.plugins.len() - dev_count;
 
     while finished_tasks < total_tasks {
         terminal.draw(|f| tui_state.draw(f, "syncing...", &icons))?;
@@ -1022,6 +1039,10 @@ async fn run_update(query: Option<String>) -> Result<()> {
         .plugins
         .iter()
         .filter(|p| {
+            // dev プラグインは update スキップ
+            if p.dev {
+                return false;
+            }
             if let Some(q) = &query {
                 p.url.contains(q.as_str())
                     || p.name

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -547,7 +547,9 @@ impl TuiState {
                     PluginStatus::Waiting => ("Checking...".to_string(), Color::DarkGray),
                 };
 
-                let mode = if p.lazy {
+                let mode = if p.dev {
+                    ("Dev", Color::Magenta)
+                } else if p.lazy {
                     ("Lazy", Color::Yellow)
                 } else {
                     ("Eager", Color::Green)


### PR DESCRIPTION
## Summary
Plugins with `dev = true` are skipped during sync and update, preventing rvpm from overwriting local changes in development repositories.

```toml
[[plugins]]
url = "yukimemi/autocursor.vim"
dst = "~/src/github.com/yukimemi/autocursor.vim"
dev = true
```

- Sync: skip clone/fetch/reset, immediately mark as Finished
- Update: excluded from target list
- List TUI: show "Dev" in magenta in Mode column
- Loader: dev plugins still included in loader.lua (rtp set up normally)

## Test plan
- [x] 163 tests pass (2 new config parsing tests)
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: set `dev = true` on a local plugin, verify sync skips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)