### PR TITLE
feat(store): browse and install Neovim plugins from GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +777,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1900,19 +1925,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2175,6 +2215,25 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2466,6 +2525,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2612,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2712,12 @@ checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2688,6 +2825,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2815,7 +2958,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3059,10 +3202,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3073,6 +3218,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -3128,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring",
@@ -3152,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3179,7 +3325,9 @@ dependencies = [
  "gix",
  "indicatif",
  "junction",
+ "open",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -3206,10 +3354,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3494,7 +3674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3727,6 +3907,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3983,6 +4173,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1.0"
 toml = "1.1"
 toml_edit = "0.25"
 
+# HTTP client (for store)
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+open = "5"
+
 # File System & Path
 dirs = "6.0"
 junction = "1.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ mod config;
 mod git;
 mod link;
 mod loader;
+mod store;
+mod store_tui;
 mod tui;
 
 use crate::config::parse_config;
@@ -224,6 +226,8 @@ enum Commands {
         #[arg(long)]
         write: bool,
     },
+    /// Browse and install Neovim plugins from GitHub
+    Store,
 }
 
 #[tokio::main]
@@ -296,6 +300,9 @@ async fn main() -> Result<()> {
         }
         Commands::Init { write } => {
             run_init(write).await?;
+        }
+        Commands::Store => {
+            run_store().await?;
         }
     }
 
@@ -2560,6 +2567,207 @@ fn build_plugin_scripts(
         colorschemes: collect_colorschemes(plugin_path),
         cond: plugin.cond.clone(),
     }
+}
+
+/// `rvpm store` — GitHub からプラグインを検索して追加する TUI。
+async fn run_store() -> Result<()> {
+    use crate::store_tui::StoreTuiState;
+
+    let mut state = StoreTuiState::new();
+
+    // 初期表示: 人気プラグインをバックグラウンドで取得
+    let popular = tokio::task::spawn_blocking(crate::store::fetch_popular);
+
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = ratatui::Terminal::new(backend)?;
+
+    // 人気プラグインの結果を待つ
+    if let Ok(Ok(repos)) = popular.await {
+        state.set_plugins(repos);
+    }
+
+    // README を非同期で取得するためのチャネル
+    let (readme_tx, mut readme_rx) = tokio::sync::mpsc::channel::<(String, String)>(1);
+    let mut last_selected: Option<String> = None;
+
+    loop {
+        terminal.draw(|f| state.draw(f))?;
+
+        // README 非同期受信
+        if let Ok((full_name, content)) = readme_rx.try_recv()
+            && state
+                .selected_repo()
+                .map(|r| r.full_name == full_name)
+                .unwrap_or(false)
+        {
+            state.readme_content = Some(content);
+            state.readme_loading = false;
+        }
+
+        // 選択変更時に README を非同期取得
+        let current_selected = state.selected_repo().map(|r| r.full_name.clone());
+        if current_selected != last_selected {
+            last_selected = current_selected.clone();
+            if let Some(repo) = state.selected_repo().cloned() {
+                state.readme_loading = true;
+                state.readme_content = None;
+                state.readme_scroll = 0;
+                let tx = readme_tx.clone();
+                tokio::task::spawn_blocking(move || {
+                    let content = crate::store::fetch_readme(&repo)
+                        .unwrap_or_else(|e| format!("Error: {}", e));
+                    let _ = tx.blocking_send((repo.full_name.clone(), content));
+                });
+            }
+        }
+
+        // キー入力処理
+        if crossterm::event::poll(std::time::Duration::from_millis(50))?
+            && let crossterm::event::Event::Key(key) = crossterm::event::read()?
+        {
+            if key.kind != crossterm::event::KeyEventKind::Press {
+                continue;
+            }
+
+            if state.search_mode {
+                match key.code {
+                    crossterm::event::KeyCode::Esc => {
+                        state.search_mode = false;
+                    }
+                    crossterm::event::KeyCode::Enter => {
+                        state.search_mode = false;
+                        let query = state.search_input.clone();
+                        state.message = Some(format!("Searching '{}'...", query));
+                        terminal.draw(|f| state.draw(f))?;
+                        let result = tokio::task::spawn_blocking(move || {
+                            crate::store::search_plugins(&query)
+                        })
+                        .await;
+                        match result {
+                            Ok(Ok(repos)) => {
+                                state.message = Some(format!("{} results", repos.len()));
+                                state.set_plugins(repos);
+                            }
+                            Ok(Err(e)) => {
+                                state.message = Some(format!("Error: {}", e));
+                            }
+                            Err(e) => {
+                                state.message = Some(format!("Error: {}", e));
+                            }
+                        }
+                    }
+                    crossterm::event::KeyCode::Backspace => {
+                        state.search_input.pop();
+                    }
+                    crossterm::event::KeyCode::Char(c) => {
+                        state.search_input.push(c);
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            match key.code {
+                crossterm::event::KeyCode::Char('q') | crossterm::event::KeyCode::Esc => break,
+                crossterm::event::KeyCode::Char('/') => {
+                    state.search_mode = true;
+                    state.search_input.clear();
+                    state.message = None;
+                }
+                crossterm::event::KeyCode::Char('j') | crossterm::event::KeyCode::Down => {
+                    state.next();
+                }
+                crossterm::event::KeyCode::Char('k') | crossterm::event::KeyCode::Up => {
+                    state.previous();
+                }
+                crossterm::event::KeyCode::Char('d')
+                    if key
+                        .modifiers
+                        .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                {
+                    state.scroll_readme_down(10);
+                }
+                crossterm::event::KeyCode::Char('u')
+                    if key
+                        .modifiers
+                        .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                {
+                    state.scroll_readme_up(10);
+                }
+                crossterm::event::KeyCode::Char('s') => {
+                    state.sort_mode = state.sort_mode.next();
+                    state.sort_plugins();
+                    state.message = Some(format!("Sort: {}", state.sort_mode.label()));
+                }
+                crossterm::event::KeyCode::Char('R') => {
+                    crate::store::clear_search_cache();
+                    state.message = Some("Cache cleared. Searching...".to_string());
+                    terminal.draw(|f| state.draw(f))?;
+                    let result = tokio::task::spawn_blocking(crate::store::fetch_popular).await;
+                    match result {
+                        Ok(Ok(repos)) => {
+                            state.message = Some(format!("{} plugins", repos.len()));
+                            state.set_plugins(repos);
+                        }
+                        _ => {
+                            state.message = Some("Refresh failed".to_string());
+                        }
+                    }
+                }
+                crossterm::event::KeyCode::Char('o') => {
+                    // ブラウザで開く
+                    if let Some(repo) = state.selected_repo() {
+                        let url = repo.html_url.clone();
+                        let _ = open::that(&url);
+                    }
+                }
+                crossterm::event::KeyCode::Enter => {
+                    // config.toml に追加
+                    if let Some(repo) = state.selected_repo() {
+                        let url = repo.full_name.clone();
+                        let _ = disable_raw_mode();
+                        let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+                        let _ = terminal.show_cursor();
+
+                        println!("Adding {}...", url);
+                        // run_add の最小版: config.toml に追記して sync
+                        let result =
+                            run_add(url.clone(), None, None, None, None, None, None, None).await;
+                        match result {
+                            Ok(_) => println!("Added {} successfully!", url),
+                            Err(e) => eprintln!("Failed to add {}: {}", url, e),
+                        }
+
+                        // TUI に戻る
+                        print!("\nPress any key to return to store...");
+                        use std::io::Write;
+                        std::io::stdout().flush().ok();
+                        enable_raw_mode()?;
+                        loop {
+                            if let crossterm::event::Event::Key(k) = crossterm::event::read()?
+                                && k.kind == crossterm::event::KeyEventKind::Press
+                            {
+                                break;
+                            }
+                        }
+                        disable_raw_mode()?;
+                        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+                        enable_raw_mode()?;
+                        state.message = Some(format!("Added {}", url));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2650,6 +2650,7 @@ async fn run_store() -> Result<()> {
                             Ok(Ok(repos)) => {
                                 state.message = Some(format!("{} results", repos.len()));
                                 state.set_plugins(repos);
+                                last_selected = None; // 新しい結果で README 再取得を強制
                             }
                             Ok(Err(e)) => {
                                 state.message = Some(format!("Error: {}", e));
@@ -2711,6 +2712,7 @@ async fn run_store() -> Result<()> {
                         Ok(Ok(repos)) => {
                             state.message = Some(format!("{} plugins", repos.len()));
                             state.set_plugins(repos);
+                            last_selected = None; // 新しい結果で README 再取得を強制
                         }
                         _ => {
                             state.message = Some("Refresh failed".to_string());

--- a/src/store.rs
+++ b/src/store.rs
@@ -50,10 +50,11 @@ impl GitHubRepo {
     }
 }
 
-/// キャッシュディレクトリ。
+/// キャッシュディレクトリ。rvpm の他の cache と同じ ~/.cache/rvpm/ 配下に置く。
 fn store_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".cache")
         .join("rvpm")
         .join("store")
 }
@@ -101,23 +102,27 @@ pub fn search_plugins(query: &str) -> Result<Vec<GitHubRepo>> {
         return Ok(repos);
     }
 
-    // GitHub API 検索
+    // GitHub API 検索 — reqwest の query() で安全にエンコード
     let search_query = if query.is_empty() {
         "topic:neovim-plugin".to_string()
     } else {
         format!("topic:neovim-plugin {}", query)
     };
 
-    let url = format!(
-        "https://api.github.com/search/repositories?q={}&sort=stars&order=desc&per_page=100",
-        urlencoding(&search_query)
-    );
-
     let client = reqwest::blocking::Client::builder()
         .user_agent("rvpm")
         .build()?;
 
-    let resp: SearchResponse = client.get(&url).send()?.json()?;
+    let resp: SearchResponse = client
+        .get("https://api.github.com/search/repositories")
+        .query(&[
+            ("q", search_query.as_str()),
+            ("sort", "stars"),
+            ("order", "desc"),
+            ("per_page", "100"),
+        ])
+        .send()?
+        .json()?;
 
     // キャッシュに保存
     if let Some(parent) = cache_path.parent() {
@@ -169,11 +174,6 @@ pub fn fetch_readme(repo: &GitHubRepo) -> Result<String> {
     std::fs::write(&cache_path, &text).ok();
 
     Ok(text)
-}
-
-/// 簡易 URL エンコード。
-fn urlencoding(s: &str) -> String {
-    s.replace(' ', "+").replace(':', "%3A").replace('#', "%23")
 }
 
 /// 検索キャッシュをクリア (強制リフレッシュ用)。
@@ -234,13 +234,5 @@ mod tests {
         assert!(name.starts_with("search_"));
         assert!(!name.contains(' '));
         assert!(!name.contains(':'));
-    }
-
-    #[test]
-    fn test_urlencoding() {
-        assert_eq!(
-            urlencoding("topic:neovim-plugin foo"),
-            "topic%3Aneovim-plugin+foo"
-        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,246 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// GitHub Search API のレスポンス。
+#[derive(Debug, Deserialize)]
+pub struct SearchResponse {
+    #[allow(dead_code)]
+    pub total_count: u64,
+    pub items: Vec<GitHubRepo>,
+}
+
+/// GitHub リポジトリ情報。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubRepo {
+    pub full_name: String,
+    pub html_url: String,
+    pub description: Option<String>,
+    pub stargazers_count: u64,
+    pub updated_at: String,
+    pub topics: Vec<String>,
+    pub default_branch: Option<String>,
+}
+
+impl GitHubRepo {
+    /// プラグイン名 (repo 部分)。
+    pub fn plugin_name(&self) -> &str {
+        self.full_name
+            .split('/')
+            .next_back()
+            .unwrap_or(&self.full_name)
+    }
+
+    /// stars を人間可読な形式に。
+    pub fn stars_display(&self) -> String {
+        if self.stargazers_count >= 1000 {
+            format!("{:.1}k", self.stargazers_count as f64 / 1000.0)
+        } else {
+            self.stargazers_count.to_string()
+        }
+    }
+
+    /// README の raw URL。
+    pub fn readme_url(&self) -> String {
+        let branch = self.default_branch.as_deref().unwrap_or("main");
+        format!(
+            "https://raw.githubusercontent.com/{}/{}/README.md",
+            self.full_name, branch
+        )
+    }
+}
+
+/// キャッシュディレクトリ。
+fn store_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("rvpm")
+        .join("store")
+}
+
+/// 検索結果のキャッシュパス。
+fn search_cache_path(query: &str) -> PathBuf {
+    let safe_name: String = query
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect();
+    store_cache_dir().join(format!("search_{}.json", safe_name))
+}
+
+/// README のキャッシュパス。
+fn readme_cache_path(full_name: &str) -> PathBuf {
+    let safe_name = full_name.replace('/', "__");
+    store_cache_dir()
+        .join("readme")
+        .join(format!("{}.md", safe_name))
+}
+
+/// キャッシュファイルが有効期間内か。
+fn is_cache_valid(path: &Path, max_age: std::time::Duration) -> bool {
+    path.metadata()
+        .and_then(|m| m.modified())
+        .map(|t| {
+            t.elapsed()
+                .unwrap_or(max_age + std::time::Duration::from_secs(1))
+                < max_age
+        })
+        .unwrap_or(false)
+}
+
+const SEARCH_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(86400); // 24h
+const README_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(604800); // 7 days
+
+/// GitHub Search API でプラグインを検索。キャッシュがあればそれを返す。
+pub fn search_plugins(query: &str) -> Result<Vec<GitHubRepo>> {
+    // キャッシュチェック
+    let cache_path = search_cache_path(query);
+    if is_cache_valid(&cache_path, SEARCH_CACHE_TTL)
+        && let Ok(data) = std::fs::read_to_string(&cache_path)
+        && let Ok(repos) = serde_json::from_str::<Vec<GitHubRepo>>(&data)
+    {
+        return Ok(repos);
+    }
+
+    // GitHub API 検索
+    let search_query = if query.is_empty() {
+        "topic:neovim-plugin".to_string()
+    } else {
+        format!("topic:neovim-plugin {}", query)
+    };
+
+    let url = format!(
+        "https://api.github.com/search/repositories?q={}&sort=stars&order=desc&per_page=100",
+        urlencoding(&search_query)
+    );
+
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("rvpm")
+        .build()?;
+
+    let resp: SearchResponse = client.get(&url).send()?.json()?;
+
+    // キャッシュに保存
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let json = serde_json::to_string(&resp.items)?;
+    std::fs::write(&cache_path, json).ok();
+
+    Ok(resp.items)
+}
+
+/// 人気プラグインのランキングを取得。
+pub fn fetch_popular() -> Result<Vec<GitHubRepo>> {
+    search_plugins("")
+}
+
+/// README を取得。キャッシュがあればそれを返す。
+pub fn fetch_readme(repo: &GitHubRepo) -> Result<String> {
+    let cache_path = readme_cache_path(&repo.full_name);
+    if is_cache_valid(&cache_path, README_CACHE_TTL)
+        && let Ok(data) = std::fs::read_to_string(&cache_path)
+    {
+        return Ok(data);
+    }
+
+    let url = repo.readme_url();
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("rvpm")
+        .build()?;
+
+    let resp = client.get(&url).send()?;
+    let text = if resp.status().is_success() {
+        resp.text()?
+    } else {
+        // main で見つからない場合は master を試す
+        let url_master = url.replace("/main/README.md", "/master/README.md");
+        let resp2 = client.get(&url_master).send()?;
+        if resp2.status().is_success() {
+            resp2.text()?
+        } else {
+            "README not found.".to_string()
+        }
+    };
+
+    // キャッシュに保存
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&cache_path, &text).ok();
+
+    Ok(text)
+}
+
+/// 簡易 URL エンコード。
+fn urlencoding(s: &str) -> String {
+    s.replace(' ', "+").replace(':', "%3A").replace('#', "%23")
+}
+
+/// 検索キャッシュをクリア (強制リフレッシュ用)。
+pub fn clear_search_cache() {
+    let dir = store_cache_dir();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path
+                .file_name()
+                .map(|n| n.to_string_lossy().starts_with("search_"))
+                .unwrap_or(false)
+            {
+                std::fs::remove_file(path).ok();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_repo_display() {
+        let repo = GitHubRepo {
+            full_name: "folke/snacks.nvim".to_string(),
+            html_url: "https://github.com/folke/snacks.nvim".to_string(),
+            description: Some("snacks".to_string()),
+            stargazers_count: 1500,
+            updated_at: "2026-04-14".to_string(),
+            topics: vec![],
+            default_branch: Some("main".to_string()),
+        };
+        assert_eq!(repo.plugin_name(), "snacks.nvim");
+        assert_eq!(repo.stars_display(), "1.5k");
+        assert!(repo.readme_url().contains("raw.githubusercontent.com"));
+    }
+
+    #[test]
+    fn test_stars_display_under_1k() {
+        let repo = GitHubRepo {
+            full_name: "test/test".to_string(),
+            html_url: String::new(),
+            description: None,
+            stargazers_count: 42,
+            updated_at: String::new(),
+            topics: vec![],
+            default_branch: None,
+        };
+        assert_eq!(repo.stars_display(), "42");
+    }
+
+    #[test]
+    fn test_cache_path_sanitizes_query() {
+        let path = search_cache_path("foo bar:baz");
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert!(name.starts_with("search_"));
+        assert!(!name.contains(' '));
+        assert!(!name.contains(':'));
+    }
+
+    #[test]
+    fn test_urlencoding() {
+        assert_eq!(
+            urlencoding("topic:neovim-plugin foo"),
+            "topic%3Aneovim-plugin+foo"
+        );
+    }
+}

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -75,7 +75,11 @@ impl StoreTuiState {
                 .plugins
                 .sort_by(|a, b| b.stargazers_count.cmp(&a.stargazers_count)),
             SortMode::Updated => self.plugins.sort_by(|a, b| b.updated_at.cmp(&a.updated_at)),
-            SortMode::Name => self.plugins.sort_by(|a, b| a.full_name.cmp(&b.full_name)),
+            SortMode::Name => self.plugins.sort_by(|a, b| {
+                a.plugin_name()
+                    .cmp(b.plugin_name())
+                    .then_with(|| a.full_name.cmp(&b.full_name))
+            }),
         }
     }
 

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -1,0 +1,375 @@
+use crate::store::GitHubRepo;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Row, Table, TableState, Wrap},
+};
+
+pub struct StoreTuiState {
+    pub plugins: Vec<GitHubRepo>,
+    pub table_state: TableState,
+    pub search_mode: bool,
+    pub search_input: String,
+    pub readme_content: Option<String>,
+    pub readme_loading: bool,
+    pub readme_scroll: u16,
+    pub sort_mode: SortMode,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SortMode {
+    Stars,
+    Updated,
+    Name,
+}
+
+impl SortMode {
+    pub fn label(&self) -> &str {
+        match self {
+            SortMode::Stars => "stars",
+            SortMode::Updated => "updated",
+            SortMode::Name => "name",
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            SortMode::Stars => SortMode::Updated,
+            SortMode::Updated => SortMode::Name,
+            SortMode::Name => SortMode::Stars,
+        }
+    }
+}
+
+impl StoreTuiState {
+    pub fn new() -> Self {
+        Self {
+            plugins: Vec::new(),
+            table_state: TableState::default(),
+            search_mode: false,
+            search_input: String::new(),
+            readme_content: None,
+            readme_loading: false,
+            readme_scroll: 0,
+            sort_mode: SortMode::Stars,
+            message: None,
+        }
+    }
+
+    pub fn set_plugins(&mut self, plugins: Vec<GitHubRepo>) {
+        self.plugins = plugins;
+        self.sort_plugins();
+        if !self.plugins.is_empty() {
+            self.table_state.select(Some(0));
+        }
+        self.readme_content = None;
+        self.readme_scroll = 0;
+    }
+
+    pub fn sort_plugins(&mut self) {
+        match self.sort_mode {
+            SortMode::Stars => self
+                .plugins
+                .sort_by(|a, b| b.stargazers_count.cmp(&a.stargazers_count)),
+            SortMode::Updated => self.plugins.sort_by(|a, b| b.updated_at.cmp(&a.updated_at)),
+            SortMode::Name => self.plugins.sort_by(|a, b| a.full_name.cmp(&b.full_name)),
+        }
+    }
+
+    pub fn selected_repo(&self) -> Option<&GitHubRepo> {
+        self.table_state
+            .selected()
+            .and_then(|i| self.plugins.get(i))
+    }
+
+    pub fn next(&mut self) {
+        if self.plugins.is_empty() {
+            return;
+        }
+        let i = self
+            .table_state
+            .selected()
+            .map(|i| {
+                if i >= self.plugins.len() - 1 {
+                    0
+                } else {
+                    i + 1
+                }
+            })
+            .unwrap_or(0);
+        self.table_state.select(Some(i));
+        self.readme_content = None;
+        self.readme_scroll = 0;
+    }
+
+    pub fn previous(&mut self) {
+        if self.plugins.is_empty() {
+            return;
+        }
+        let i = self
+            .table_state
+            .selected()
+            .map(|i| {
+                if i == 0 {
+                    self.plugins.len() - 1
+                } else {
+                    i - 1
+                }
+            })
+            .unwrap_or(0);
+        self.table_state.select(Some(i));
+        self.readme_content = None;
+        self.readme_scroll = 0;
+    }
+
+    pub fn scroll_readme_down(&mut self, n: u16) {
+        self.readme_scroll = self.readme_scroll.saturating_add(n);
+    }
+
+    pub fn scroll_readme_up(&mut self, n: u16) {
+        self.readme_scroll = self.readme_scroll.saturating_sub(n);
+    }
+
+    pub fn draw(&mut self, f: &mut Frame) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // title + search
+                Constraint::Min(10),   // main content
+                Constraint::Length(3), // footer
+            ])
+            .split(f.area());
+
+        // ── Title / Search bar ──
+        let title_content = if self.search_mode {
+            let match_info = format!(" ({} results)", self.plugins.len());
+            Line::from(vec![
+                Span::styled(
+                    " rvpm store ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " / ",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(&self.search_input, Style::default().fg(Color::White)),
+                Span::styled("\u{2588}", Style::default().fg(Color::Yellow)), // cursor
+                Span::styled(match_info, Style::default().fg(Color::DarkGray)),
+            ])
+        } else {
+            let info = if let Some(msg) = &self.message {
+                Span::styled(format!("  {}", msg), Style::default().fg(Color::Green))
+            } else {
+                Span::styled(
+                    format!(
+                        "  {} plugins  sort:{}",
+                        self.plugins.len(),
+                        self.sort_mode.label()
+                    ),
+                    Style::default().fg(Color::DarkGray),
+                )
+            };
+            Line::from(vec![
+                Span::styled(
+                    " rvpm store ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                info,
+            ])
+        };
+        let title = Paragraph::new(title_content).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
+        f.render_widget(title, chunks[0]);
+
+        // ── Main: left (list) + right (readme) ──
+        let main_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+            .split(chunks[1]);
+
+        // Left: plugin list
+        let rows: Vec<Row> = self
+            .plugins
+            .iter()
+            .map(|repo| {
+                let desc = repo.description.as_deref().unwrap_or("");
+                let desc_truncated: String = desc.chars().take(40).collect();
+                Row::new(vec![
+                    ratatui::widgets::Cell::from(format!(" \u{2605}{}", repo.stars_display()))
+                        .style(Style::default().fg(Color::Yellow)),
+                    ratatui::widgets::Cell::from(repo.plugin_name().to_string())
+                        .style(Style::default().fg(Color::White)),
+                    ratatui::widgets::Cell::from(desc_truncated)
+                        .style(Style::default().fg(Color::DarkGray)),
+                ])
+            })
+            .collect();
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(8),
+                Constraint::Length(30),
+                Constraint::Min(10),
+            ],
+        )
+        .block(
+            Block::default()
+                .title(" Plugins ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow)),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::Indexed(237))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("\u{25b8} ");
+        f.render_stateful_widget(table, main_chunks[0], &mut self.table_state);
+
+        // Right: README preview
+        let readme_text = if self.readme_loading {
+            "Loading README...".to_string()
+        } else {
+            self.readme_content.clone().unwrap_or_else(|| {
+                if self.plugins.is_empty() {
+                    "Press / to search for plugins".to_string()
+                } else {
+                    "Loading...".to_string()
+                }
+            })
+        };
+
+        let readme_title = self
+            .selected_repo()
+            .map(|r| format!(" {} ", r.full_name))
+            .unwrap_or_else(|| " README ".to_string());
+
+        let readme = Paragraph::new(readme_text)
+            .block(
+                Block::default()
+                    .title(readme_title)
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .wrap(Wrap { trim: false })
+            .scroll((self.readme_scroll, 0));
+        f.render_widget(readme, main_chunks[1]);
+
+        // ── Footer ──
+        let footer = if self.search_mode {
+            Paragraph::new(Line::from(vec![
+                Span::styled(" Enter", Style::default().fg(Color::Yellow)),
+                Span::styled(":search ", Style::default().fg(Color::DarkGray)),
+                Span::styled("Esc", Style::default().fg(Color::Yellow)),
+                Span::styled(":cancel", Style::default().fg(Color::DarkGray)),
+            ]))
+        } else {
+            Paragraph::new(Line::from(vec![
+                Span::styled(" /", Style::default().fg(Color::Yellow)),
+                Span::styled(":search ", Style::default().fg(Color::DarkGray)),
+                Span::styled("j/k", Style::default().fg(Color::Yellow)),
+                Span::styled(":move ", Style::default().fg(Color::DarkGray)),
+                Span::styled("C-d/C-u", Style::default().fg(Color::Yellow)),
+                Span::styled(":scroll ", Style::default().fg(Color::DarkGray)),
+                Span::styled("s", Style::default().fg(Color::Yellow)),
+                Span::styled(":sort ", Style::default().fg(Color::DarkGray)),
+                Span::styled("Enter", Style::default().fg(Color::Yellow)),
+                Span::styled(":add ", Style::default().fg(Color::DarkGray)),
+                Span::styled("o", Style::default().fg(Color::Yellow)),
+                Span::styled(":open ", Style::default().fg(Color::DarkGray)),
+                Span::styled("R", Style::default().fg(Color::Yellow)),
+                Span::styled(":refresh ", Style::default().fg(Color::DarkGray)),
+                Span::styled("q", Style::default().fg(Color::Yellow)),
+                Span::styled(":quit", Style::default().fg(Color::DarkGray)),
+            ]))
+        };
+        f.render_widget(
+            footer.block(Block::default().borders(Borders::ALL)),
+            chunks[2],
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_repo(name: &str, stars: u64) -> GitHubRepo {
+        GitHubRepo {
+            full_name: format!("owner/{}", name),
+            html_url: format!("https://github.com/owner/{}", name),
+            description: Some(format!("{} plugin", name)),
+            stargazers_count: stars,
+            updated_at: "2026-01-01".to_string(),
+            topics: vec![],
+            default_branch: Some("main".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_sort_by_stars() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo("low", 10),
+            make_repo("high", 1000),
+            make_repo("mid", 100),
+        ]);
+        assert_eq!(state.plugins[0].plugin_name(), "high");
+        assert_eq!(state.plugins[1].plugin_name(), "mid");
+        assert_eq!(state.plugins[2].plugin_name(), "low");
+    }
+
+    #[test]
+    fn test_sort_by_name() {
+        let mut state = StoreTuiState::new();
+        state.sort_mode = SortMode::Name;
+        state.set_plugins(vec![make_repo("zebra", 10), make_repo("alpha", 1000)]);
+        assert_eq!(state.plugins[0].plugin_name(), "alpha");
+        assert_eq!(state.plugins[1].plugin_name(), "zebra");
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo("a", 100),
+            make_repo("b", 50),
+            make_repo("c", 10),
+        ]);
+        assert_eq!(state.table_state.selected(), Some(0));
+        state.next();
+        assert_eq!(state.table_state.selected(), Some(1));
+        state.next();
+        assert_eq!(state.table_state.selected(), Some(2));
+        state.next(); // wrap
+        assert_eq!(state.table_state.selected(), Some(0));
+        state.previous(); // wrap back
+        assert_eq!(state.table_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn test_readme_scroll() {
+        let mut state = StoreTuiState::new();
+        state.scroll_readme_down(10);
+        assert_eq!(state.readme_scroll, 10);
+        state.scroll_readme_up(3);
+        assert_eq!(state.readme_scroll, 7);
+        state.scroll_readme_up(100);
+        assert_eq!(state.readme_scroll, 0);
+    }
+}


### PR DESCRIPTION
## Summary
Add `rvpm store` command — a split-pane TUI for discovering and installing Neovim plugins directly from GitHub.

### UI Layout
```
┌─ rvpm store ── 100 plugins  sort:stars ──┐
├────────────────────┬─────────────────────┤
│ ★25.1k telescope   │ # telescope.nvim    │
│ ★ 1.2k file-browse │                     │
│ ★  800 frecency    │ A highly extendable │
│                    │ fuzzy finder...     │
├────────────────────┴─────────────────────┤
│ /:search j/k:move s:sort Enter:add q:quit│
└──────────────────────────────────────────┘
```

### Features
- `/` — Search plugins (GitHub Search API, `topic:neovim-plugin`)
- `j/k` — Navigate, `C-d/C-u` — Scroll README
- `s` — Cycle sort (stars → updated → name)
- `Enter` — Add selected plugin to `config.toml`
- `o` — Open in browser
- `R` — Refresh cache

### Caching
- Search results: 24h TTL (`~/.cache/rvpm/store/`)
- README: 7-day TTL (`~/.cache/rvpm/store/readme/`)

### New dependencies
- `reqwest` — HTTP client for GitHub API and README fetch
- `open` — Cross-platform browser launch

## Test plan
- [x] 169 tests pass (8 new: 4 store core + 4 store TUI)
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Manual: `rvpm store` → search → select → view README → add plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "store" subcommand: browse popular plugins from GitHub.
  * Search mode with keyboard entry, multiple sort options (stars, updated, name).
  * README preview with scroll controls and ability to open repos in your browser.
  * Install plugins directly from the interface.
  * Cache for search/README with a manual cache-clear action and graceful terminal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->