### PR TITLE
fix(tui): force full redraw and hide cursor when re-entering TUI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -850,12 +850,24 @@ async fn run_list(no_tui: bool) -> Result<()> {
         res
     }
 
-    // アクション後に config とステータスを再読み込みしてTUIを復帰するヘルパー
+    // アクション後に config とステータスを再読み込みしてTUIを復帰するヘルパー。
+    // 失敗しても TUI 状態は戻せるように、alt screen への復帰を最初に行う。
     async fn reload_state(
         config_path: &Path,
         cache_root: &Path,
         terminal: &mut ratatui::Terminal<CrosstermBackend<std::io::Stdout>>,
     ) -> Result<(config::Config, TuiState)> {
+        // ── 1. 先に TUI に復帰 ──
+        // show_cursor() を事前に呼んでいるので hide_cursor() で戻す。
+        // clear() は ratatui の内部バッファを無効化して全セル再描画を強制する
+        // (これをしないとサブプロセスが alt screen 外で行った描画のせいで
+        //  差分描画が崩れた画面を残したまま戻る)。
+        enable_raw_mode()?;
+        execute!(std::io::stdout(), EnterAlternateScreen)?;
+        terminal.clear()?;
+        terminal.hide_cursor()?;
+
+        // ── 2. 状態を再構築 ──
         let toml_content = std::fs::read_to_string(config_path)?;
         let config = parse_config(&toml_content)?;
         let statuses = fetch_plugin_statuses(&config, cache_root).await;
@@ -864,9 +876,6 @@ async fn run_list(no_tui: bool) -> Result<()> {
         for (url, status) in statuses {
             tui_state.update_status(&url, status);
         }
-        enable_raw_mode()?;
-        execute!(std::io::stdout(), EnterAlternateScreen)?;
-        terminal.clear()?;
         Ok((config, tui_state))
     }
 
@@ -2796,6 +2805,12 @@ async fn run_store() -> Result<()> {
                         disable_raw_mode()?;
                         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
                         enable_raw_mode()?;
+                        // ratatui の内部バッファは LeaveAlternateScreen 中に
+                        // run_add() 内の sync TUI や println! が行った描画を知らない。
+                        // clear() で全セル再描画を強制し、hide_cursor() で
+                        // 先に show_cursor() した状態を戻す。
+                        terminal.clear()?;
+                        terminal.hide_cursor()?;
                         state.message = Some(format!("Added {}", url));
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -863,7 +863,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
         // (これをしないとサブプロセスが alt screen 外で行った描画のせいで
         //  差分描画が崩れた画面を残したまま戻る)。
         enable_raw_mode()?;
-        execute!(std::io::stdout(), EnterAlternateScreen)?;
+        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
         terminal.clear()?;
         terminal.hide_cursor()?;
 


### PR DESCRIPTION
## Summary

After running a subcommand from inside the list or store TUI (e.g. `S` sync-all in list, Enter-to-add in store), control returns to the main TUI loop. The old re-entry path called `EnterAlternateScreen` + `enable_raw_mode` but left two visible bugs:

1. **Corrupted re-entry frame** — ratatui's internal buffer still thought the previous frame was on-screen, so only cell-level diffs were written. Output from the subcommand (sync's own TUI, editor exit, stray `println!`) produced a garbled first frame. User reported "戻れなかったときがある" (sometimes can't return properly) — the TUI was technically drawn but looked broken so it felt stuck.
2. **Visible cursor** — `terminal.show_cursor()` was called before leaving, but `hide_cursor()` was never paired on return.

Fix both sites (`run_list::reload_state` and `run_store`'s Enter handler) by calling:
- `terminal.clear()` to invalidate ratatui's diff buffer → full redraw
- `terminal.hide_cursor()` to restore the hidden-cursor state

For `run_list::reload_state` I also moved the TUI re-entry **before** the potentially slow `fetch_plugin_statuses()` call, so the user sees the TUI come back immediately instead of staring at the stale post-action screen while statuses load.

## Test plan

- [ ] `rvpm list` → `S` (sync all) → after "Press any key…" prompt, TUI redraws cleanly with no cursor
- [ ] `rvpm list` → `u` on a plugin (update) → same
- [ ] `rvpm list` → `e` (edit) → close editor → TUI returns cleanly
- [ ] `rvpm list` → `d` (delete) → TUI returns cleanly
- [ ] `rvpm store` → select a plugin → Enter (add) → "Press any key…" → store TUI redraws cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)