### PR TITLE
feat!: v3.1 — config_root becomes parent of global hooks (+ README restructure)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,7 +3548,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ rvpm config
 nvim_rc = "~/.config/nvim/rc"
 
 [options]
-# Per-plugin init/before/after.lua directory
-# Default: ~/.config/rvpm/<appname>/plugins
-config_root = "{{ vars.nvim_rc }}/plugins"
+# Root of all rvpm config (config.toml, global hooks, plugins/ subdir)
+# Default: ~/.config/rvpm/<appname>
+# config_root = "{{ vars.nvim_rc }}"
 # Root of all rvpm cache (clones, merged rtp, loader.lua, store cache)
 # Default: ~/.cache/rvpm/<appname>
 # cache_root = "~/dotfiles/nvim/rvpm"
@@ -158,18 +158,26 @@ for fully isolated test configs.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `config_root` | `string` | `~/.config/rvpm/<appname>/plugins` | Root directory for per-plugin `init.lua` / `before.lua` / `after.lua`. Supports `~` and Tera templates. **Recommended: leave unset** |
+| `config_root` | `string` | `~/.config/rvpm/<appname>` | Root for all rvpm config (`config.toml`, global `before.lua` / `after.lua`, and `plugins/<host>/<owner>/<repo>/` per-plugin hooks). Supports `~` and Tera templates. **Recommended: leave unset** |
 | `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** |
 | `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
 
-> **Why both defaults end in `/plugins` is subtle:**
-> `cache_root` is the parent of `plugins/` and `store/`, while `config_root`
-> is the `plugins/` directory itself (i.e. where per-plugin hook dirs live).
-> So on disk the layout lines up symmetrically:
+> **Symmetric layout.** `config_root` and `cache_root` are structurally
+> parallel — each owns a `plugins/` subdirectory at the same depth:
 >
 > ```
-> ~/.config/rvpm/<appname>/plugins/...   ← config_root
-> ~/.cache/rvpm/<appname>/plugins/...    ← cache_root's "plugins/" subdir
+> ~/.config/rvpm/<appname>/                ← config_root
+>     ├── config.toml
+>     ├── before.lua       (global, phase 3)
+>     ├── after.lua        (global, phase 9)
+>     └── plugins/<host>/<owner>/<repo>/   (per-plugin init/before/after.lua)
+>
+> ~/.cache/rvpm/<appname>/                 ← cache_root
+>     ├── plugins/
+>     │   ├── repos/<host>/<owner>/<repo>/  (clones)
+>     │   ├── merged/                       (linked rtp for merge=true)
+>     │   └── loader.lua                    (generated)
+>     └── store/                            (`rvpm store` cache)
 > ```
 
 > **💡 Leave `config_root` and `cache_root` unset** — the defaults are already
@@ -371,18 +379,18 @@ overhead when neither is the initial colorscheme.
 
 ### Hooks
 
-Global hooks (`before.lua` / `after.lua` directly under
-`~/.config/rvpm/<appname>/`) and per-plugin hooks (under
-`{config_root}/<host>/<owner>/<repo>/`) are auto-discovered — no config
-entries needed.
+Global hooks (`before.lua` / `after.lua` directly under `{config_root}/`)
+and per-plugin hooks (under `{config_root}/plugins/<host>/<owner>/<repo>/`)
+are auto-discovered — no config entries needed.
 
 <details>
 <summary><b>Hook file reference</b></summary>
 
 #### Global hooks
 
-Place Lua files directly under `~/.config/rvpm/<appname>/` and rvpm picks
-them up automatically at generate time:
+Place Lua files directly under `{config_root}/` (default:
+`~/.config/rvpm/<appname>/`) and rvpm picks them up automatically at
+generate time:
 
 | File | Phase | When it runs |
 |---|---|---|
@@ -395,8 +403,8 @@ belong to any single plugin.
 
 #### Per-plugin hooks
 
-Drop Lua files under `{config_root}/<host>/<owner>/<repo>/` and rvpm will
-include them in the generated loader:
+Drop Lua files under `{config_root}/plugins/<host>/<owner>/<repo>/` and
+rvpm will include them in the generated loader:
 
 | File | When it runs |
 |---|---|
@@ -615,13 +623,13 @@ Beyond ordering, `depends` also affects **loading**:
 ## Directory layout (defaults)
 
 ```
-~/.config/rvpm/<appname>/
-├── config.toml                              ← main configuration (fixed)
+~/.config/rvpm/<appname>/                    ← config_root
+├── config.toml                              ← main configuration
 ├── before.lua                               ← global before hook (phase 3, auto-detected)
 ├── after.lua                                ← global after hook (phase 9, auto-detected)
-└── plugins/                                 ← config_root
+└── plugins/
     └── <host>/<owner>/<repo>/
-        ├── init.lua
+        ├── init.lua                         ← per-plugin hooks
         ├── before.lua
         └── after.lua
 

--- a/README.md
+++ b/README.md
@@ -19,92 +19,85 @@ sources everything without any runtime glob cost.
 - **Pre-compiled loader** — `rvpm generate` walks plugin directories at CLI
   time and bakes the file list into `loader.lua`; Neovim just sources a
   fixed list of `dofile()` / `source` calls
-- **Merge optimization** — `merge = true` plugins share a single rtp entry
 - **Full lazy-loading** — `on_cmd`, `on_ft`, `on_map`, `on_event`, `on_path`,
   `on_source`, auto-detected `ColorSchemePre`, and `depends`-aware loading
+- **Merge optimization** — `merge = true` plugins share a single rtp entry
+- **Plugin discovery TUI** — `rvpm store` browses the GitHub `neovim-plugin`
+  topic with live README preview and one-keystroke install
 - **Resilient** — cyclic dependencies, missing plugins, and config errors
   produce warnings, not crashes
 
-## Features
+<details>
+<summary><b>More features</b></summary>
 
 - **Fast startup** — 9-phase loader model with `vim.go.loadplugins = false`
   and pre-globbed `plugin/` / `ftdetect/` / `after/plugin/` file lists
-- **Global hooks** — `~/.config/rvpm/before.lua` (phase 3, before all plugin
-  `init.lua`) and `~/.config/rvpm/after.lua` (phase 9, after all lazy trigger
-  registrations); auto-detected at generate time, no config required
-- **Merge optimization** — `merge = true` plugins share a single
-  `vim.opt.rtp:append(...)` entry via junction/symlink
-- **Full lazy triggers** — `on_cmd` / `on_ft` / `on_map` / `on_event` /
-  `on_path` / `on_source` (plugin chain), with `User Xxx` pattern shorthand,
-  bang/range/count/complete aware commands, keymaps with mode + desc, and
-  `<Ignore>`-prefixed replay for safety
+- **Global hooks** — `before.lua` / `after.lua` directly under the config
+  root are auto-detected at generate time; no config entry needed
+- **Lazy trigger fidelity** — `User Xxx` pattern shorthand, bang/range/count/
+  complete-aware commands, keymaps with mode + desc, and `<Ignore>`-prefixed
+  replay for safety; operator-pending mode preserves `v:operator` /
+  `v:count1` / `v:register`
 - **Colorscheme auto-detection** — lazy plugins whose clone contains a
   `colors/*.vim` or `colors/*.lua` file automatically gain a `ColorSchemePre`
-  autocmd handler so `:colorscheme <name>` loads the plugin on demand; no
-  extra config required
-- **Dependency ordering** — topological sort on `depends`, resilient to cycles
-  and missing references
+  autocmd handler so `:colorscheme <name>` loads the plugin on demand
+- **Dependency ordering** — topological sort on `depends`, resilient to
+  cycles and missing references; eager→lazy deps are auto-promoted
 - **Windows first-class** — hardcoded `~/.config` / `~/.cache` layout for
   dotfiles portability, junction instead of symlink to avoid permission
   issues
-- **Interactive TUI** (`rvpm list`) — plugin list with action keys for
-  sync/update/generate/remove/edit/set
+- **Interactive TUI** — `rvpm list` with sync / update / generate / remove /
+  edit / set action keys
 - **CLI-driven set** — `rvpm set foo --on-event '["BufReadPre","User Started"]'`
-  or full JSON object form for on_map with mode/desc
+  or full JSON object form for `on_map` with mode/desc
 - **TOML direct edit escape hatch** — `rvpm config` / `rvpm set` sub-menu to
   jump to the plugin's block in `$EDITOR`
 - **Init.lua integration** — `rvpm init --write` wires the generated loader
   into `~/.config/$NVIM_APPNAME/init.lua` (creates the file if missing)
 
+</details>
+
 ## Installation
 
-### From a pre-built binary
-
-Download the latest archive from the
-[Releases](https://github.com/yukimemi/rvpm/releases) page for your platform:
-
-- **Linux (x86_64)**: `rvpm-x86_64-unknown-linux-gnu.tar.gz`
-- **macOS (Intel)**: `rvpm-x86_64-apple-darwin.tar.gz`
-- **macOS (Apple Silicon)**: `rvpm-aarch64-apple-darwin.tar.gz`
-- **Windows (x86_64)**: `rvpm-x86_64-pc-windows-msvc.zip`
-
-Extract the binary into any directory on your `PATH`.
-
-### From crates.io
-
 ```sh
+# From crates.io
 cargo install rvpm
-```
 
-### From source (latest main)
-
-```sh
+# Or from source (latest main)
 cargo install --git https://github.com/yukimemi/rvpm
 ```
+
+Pre-built binaries are also available on the
+[Releases](https://github.com/yukimemi/rvpm/releases) page for Linux
+(x86_64), macOS (Intel / Apple Silicon), and Windows (x86_64). Extract the
+binary into any directory on your `PATH`.
 
 ## Quick start
 
 ```sh
 # 1. One-time setup (creates both config.toml and init.lua)
 rvpm init --write
-# → ~/.config/rvpm/config.toml  (plugin configuration, auto-created)
-# → ~/.config/nvim/init.lua     (loader wiring, auto-created or appended)
-# Respects $NVIM_APPNAME for custom Neovim configs.
+# → ~/.config/rvpm/<appname>/config.toml  (plugin configuration)
+# → ~/.config/nvim/init.lua               (loader wiring)
+# <appname> = $RVPM_APPNAME → $NVIM_APPNAME → "nvim"
 
 # 2. Add plugins
 rvpm add folke/snacks.nvim
 rvpm add nvim-telescope/telescope.nvim
 
-# 3. Open config.toml to tweak settings (lazy, triggers, etc.)
-rvpm config
+# 3. Browse the GitHub "neovim-plugin" topic and install from the TUI
+rvpm store
 
-# 4. Explore the TUI
+# 4. Manage installed plugins interactively
 rvpm list
+
+# 5. Open config.toml to tweak settings (lazy, triggers, etc.)
+rvpm config
 ```
 
 ## Configuration
 
-`~/.config/rvpm/config.toml`:
+`~/.config/rvpm/<appname>/config.toml`:
 
 ```toml
 [vars]
@@ -113,13 +106,13 @@ nvim_rc = "~/.config/nvim/rc"
 
 [options]
 # Per-plugin init/before/after.lua directory
-# Default: ~/.config/rvpm/plugins
+# Default: ~/.config/rvpm/<appname>/plugins
 config_root = "{{ vars.nvim_rc }}/plugins"
-# Parallel git operations limit (default: 8)
-concurrency = 10
-# Optional: move all rvpm cache (plugins + store) under a custom root.
+# Root of all rvpm cache (clones, merged rtp, loader.lua, store cache)
 # Default: ~/.cache/rvpm/<appname>
 # cache_root = "~/dotfiles/nvim/rvpm"
+# Parallel git operations limit (default: 8)
+concurrency = 10
 
 [[plugins]]
 name  = "snacks"
@@ -127,17 +120,17 @@ url   = "folke/snacks.nvim"
 # No on_* triggers → eager (loaded at startup)
 
 [[plugins]]
-name    = "telescope"
-url     = "nvim-telescope/telescope.nvim"
-depends = ["snacks.nvim"]
+name      = "telescope"
+url       = "nvim-telescope/telescope.nvim"
+depends   = ["snacks.nvim"]
 # on_cmd is set → lazy is auto-inferred as true
-on_cmd  = ["Telescope"]
+on_cmd    = ["Telescope"]
 on_source = ["snacks.nvim"]
 
 [[plugins]]
-url     = "neovim/nvim-lspconfig"
+url      = "neovim/nvim-lspconfig"
 # on_ft / on_event → auto lazy
-on_ft   = ["rust", "toml", "lua"]
+on_ft    = ["rust", "toml", "lua"]
 on_event = ["BufReadPre", "User LazyVimStarted"]
 
 [[plugins]]
@@ -152,37 +145,53 @@ on_map = [
 
 ### `[options]` reference
 
-rvpm reads `config.toml` from `~/.config/rvpm/<appname>/config.toml`, where `<appname>` is determined by:
+rvpm reads `config.toml` from `~/.config/rvpm/<appname>/config.toml`, where
+`<appname>` resolves to:
 
 1. `$RVPM_APPNAME` if set, else
 2. `$NVIM_APPNAME` if set, else
 3. `"nvim"` (default)
 
-This mirrors Neovim's `$NVIM_APPNAME` convention, so running `NVIM_APPNAME=nvim-test nvim` pairs with `NVIM_APPNAME=nvim-test rvpm sync` for fully isolated test configs.
+This mirrors Neovim's `$NVIM_APPNAME` convention, so running
+`NVIM_APPNAME=nvim-test nvim` pairs with `NVIM_APPNAME=nvim-test rvpm sync`
+for fully isolated test configs.
 
-> **💡 Recommendation: leave `config_root` and `cache_root` unset.** The defaults
-> are already `<appname>`-aware. Setting a literal path (e.g.
-> `cache_root = "~/dotfiles/rvpm"`) **breaks appname isolation** — every
-> `$NVIM_APPNAME` variant will share the same cache.
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `config_root` | `string` | `~/.config/rvpm/<appname>/plugins` | Root directory for per-plugin `init.lua` / `before.lua` / `after.lua`. Supports `~` and Tera templates. **Recommended: leave unset** |
+| `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** |
+| `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
+
+> **Why both defaults end in `/plugins` is subtle:**
+> `cache_root` is the parent of `plugins/` and `store/`, while `config_root`
+> is the `plugins/` directory itself (i.e. where per-plugin hook dirs live).
+> So on disk the layout lines up symmetrically:
 >
-> If you need a custom root *and* appname isolation, use Tera templates:
+> ```
+> ~/.config/rvpm/<appname>/plugins/...   ← config_root
+> ~/.cache/rvpm/<appname>/plugins/...    ← cache_root's "plugins/" subdir
+> ```
+
+> **💡 Leave `config_root` and `cache_root` unset** — the defaults are already
+> `<appname>`-aware. Setting a literal path (e.g. `cache_root = "~/dotfiles/rvpm"`)
+> **breaks appname isolation**: every `$NVIM_APPNAME` variant will share the same
+> cache. If you need a custom root *and* appname isolation, use a Tera template:
 > ```toml
 > cache_root = "~/dotfiles/rvpm/{{ env.NVIM_APPNAME }}"
 > ```
 > Prefer `~/` over `{{ env.HOME }}` — `~` is portable (Windows too), while
-> `HOME` is not set on Windows.
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `config_root` | `string` | `~/.config/rvpm/<appname>/plugins` | Root directory for per-plugin `init.lua` / `before.lua` / `after.lua`. Supports `~` and Tera templates. **Recommended: leave unset** to preserve appname isolation |
-| `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
-| `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** to preserve appname isolation |
+> `$HOME` is not set on Windows.
 
 ### Tera templates
 
-The entire `config.toml` is processed by [Tera](https://keats.github.io/tera/) before TOML parsing. You can use `{{ vars.xxx }}`, `{{ env.HOME }}`, `{{ is_windows }}`, `{% if %}` blocks, and more.
+The entire `config.toml` is processed by [Tera](https://keats.github.io/tera/)
+before TOML parsing. You can use `{{ vars.xxx }}`, `{{ env.HOME }}`,
+`{{ is_windows }}`, `{% if %}` blocks, and more.
 
-#### Available context
+<details>
+<summary><b>Available context & examples</b></summary>
+
+#### Context
 
 | Variable | Type | Description |
 |---|---|---|
@@ -213,7 +222,6 @@ Use `{% if %}` to completely exclude plugins from `loader.lua` at generate time:
 [vars]
 use_blink = true
 use_cmp = false
-use_telescope = false
 use_snacks = true
 
 [options]
@@ -231,13 +239,6 @@ url = "hrsh7th/nvim-cmp"
 on_event = "InsertEnter"
 {% endif %}
 
-# ── Fuzzy finder: pick one ───────────────────────
-{% if vars.use_telescope %}
-[[plugins]]
-url = "nvim-telescope/telescope.nvim"
-on_cmd = "Telescope"
-{% endif %}
-
 {% if vars.use_snacks %}
 [[plugins]]
 url = "folke/snacks.nvim"
@@ -247,8 +248,6 @@ url = "folke/snacks.nvim"
 #### Platform-specific plugins
 
 ```toml
-[options]
-
 {% if is_windows %}
 [[plugins]]
 url = "thinca/vim-winenv"
@@ -264,7 +263,12 @@ cond = "{{ is_windows }}"  # runtime cond: included in loader but guarded
 > the plugin in `loader.lua` but wraps it in `if <expr> then ... end` for
 > runtime evaluation.
 
+</details>
+
 ### `[[plugins]]` reference
+
+<details>
+<summary><b>All plugin fields</b></summary>
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -279,9 +283,15 @@ cond = "{{ is_windows }}"  # runtime cond: included in loader but guarded
 | `build` | `string` | none | Shell command to run after clone (not yet implemented) |
 | `dev` | `bool` | `false` | When `true`, `sync` and `update` skip this plugin entirely (no clone/fetch/reset). Use for local development — the plugin stays on the rtp but rvpm won't touch the working tree |
 
+</details>
+
 ### Lazy trigger fields
 
-All trigger fields are optional. When multiple triggers are specified on the same plugin they are OR-ed: **any one** firing loads the plugin.
+All trigger fields are optional. When multiple triggers are specified on the
+same plugin they are OR-ed: **any one** firing loads the plugin.
+
+<details>
+<summary><b>All lazy triggers &amp; on_map formats</b></summary>
 
 | Key | Type | Accepts | Description |
 |---|---|---|---|
@@ -315,11 +325,16 @@ on_map = [
 | `mode` | `string \| string[]` | `"n"` | Vim mode(s) for the keymap (`"n"`, `"x"`, `"i"`, etc.) |
 | `desc` | `string` | none | Description shown in `:map` / which-key **before** the plugin is loaded |
 
+</details>
+
 ### Colorscheme lazy loading
 
 Lazy plugins that ship a `colors/` directory (containing `.vim` or `.lua`
 files) are automatically given a `ColorSchemePre` autocmd handler at generate
 time. No extra config field is required.
+
+<details>
+<summary><b>How it works &amp; example</b></summary>
 
 When Neovim processes `:colorscheme <name>`, it fires `ColorSchemePre` before
 switching the scheme. rvpm intercepts this event, loads the matching lazy
@@ -328,12 +343,10 @@ plugin, and then lets the colorscheme apply normally.
 Eager plugins are unaffected: their `colors/` directory is already on the
 runtimepath and Neovim finds it without any handler.
 
-**Recommendation:** if you have multiple colorscheme plugins installed, mark all
-but your active one as `lazy = true`. rvpm will register the `ColorSchemePre`
-handler for each one so they remain switchable on demand without adding startup
-cost.
-
-**Example:**
+**Recommendation:** if you have multiple colorscheme plugins installed, mark
+all but your active one as `lazy = true`. rvpm will register the
+`ColorSchemePre` handler for each one so they remain switchable on demand
+without adding startup cost.
 
 ```toml
 [[plugins]]
@@ -346,7 +359,7 @@ name = "catppuccin"
 lazy = true  # explicit — ColorSchemePre is auto-registered, not an on_* field
 ```
 
-> Note: colorscheme plugins don't have `on_*` triggers, so `lazy = true` must be
+> Colorscheme plugins don't have `on_*` triggers, so `lazy = true` must be
 > written explicitly. rvpm handles the rest (scanning `colors/` and registering
 > `ColorSchemePre`).
 
@@ -354,32 +367,44 @@ With this config, running `:colorscheme tokyonight` or `:colorscheme catppuccin`
 in Neovim will load the respective plugin just in time, with zero startup
 overhead when neither is the initial colorscheme.
 
-### Global hooks
+</details>
 
-Place Lua files directly under `~/.config/rvpm/` and rvpm picks them up
-automatically at generate time — no configuration entry needed:
+### Hooks
+
+Global hooks (`before.lua` / `after.lua` directly under
+`~/.config/rvpm/<appname>/`) and per-plugin hooks (under
+`{config_root}/<host>/<owner>/<repo>/`) are auto-discovered — no config
+entries needed.
+
+<details>
+<summary><b>Hook file reference</b></summary>
+
+#### Global hooks
+
+Place Lua files directly under `~/.config/rvpm/<appname>/` and rvpm picks
+them up automatically at generate time:
 
 | File | Phase | When it runs |
 |---|---|---|
-| `~/.config/rvpm/before.lua` | 3 | After `load_lazy` helper is defined, before any per-plugin `init.lua` |
-| `~/.config/rvpm/after.lua` | 9 | After all lazy trigger registrations |
+| `before.lua` | 3 | After `load_lazy` helper is defined, before any per-plugin `init.lua` |
+| `after.lua`  | 9 | After all lazy trigger registrations |
 
-These are useful for any setup that must happen before plugins are initialised
-(e.g. setting `vim.g.*` globals) or for post-load orchestration that doesn't
+Useful for setup that must happen before plugins are initialised
+(e.g. setting `vim.g.*` globals) or post-load orchestration that doesn't
 belong to any single plugin.
 
-### Per-plugin hooks
+#### Per-plugin hooks
 
 Drop Lua files under `{config_root}/<host>/<owner>/<repo>/` and rvpm will
 include them in the generated loader:
 
 | File | When it runs |
 |---|---|
-| `init.lua` | Before `runtimepath` is touched (pre-rtp phase) |
+| `init.lua`   | Before `runtimepath` is touched (pre-rtp phase) |
 | `before.lua` | Right after the plugin's rtp is added, before `plugin/*` is sourced |
-| `after.lua` | After `plugin/*` is sourced (safe to call plugin APIs) |
+| `after.lua`  | After `plugin/*` is sourced (safe to call plugin APIs) |
 
-Example: `~/.config/rvpm/plugins/github.com/nvim-telescope/telescope.nvim/after.lua`
+Example: `~/.config/rvpm/nvim/plugins/github.com/nvim-telescope/telescope.nvim/after.lua`
 
 ```lua
 require("telescope").setup({
@@ -387,6 +412,8 @@ require("telescope").setup({
 })
 vim.keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>")
 ```
+
+</details>
 
 ## Commands
 
@@ -397,15 +424,46 @@ vim.keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>")
 | `rvpm add <repo>` | Add a plugin and sync |
 | `rvpm update [query]` | `git pull` installed plugins |
 | `rvpm remove [query]` | Remove a plugin from `config.toml` and delete its directory |
-| `rvpm edit [query] [--init\|--before\|--after] [--global]` | Edit per-plugin Lua config in `$EDITOR`. Flag skips the file picker. `--global` (or selecting `[ Global hooks ]` in the interactive picker) edits `~/.config/rvpm/before.lua` / `after.lua` |
+| `rvpm edit [query] [--init\|--before\|--after] [--global]` | Edit per-plugin Lua config in `$EDITOR`. Flag skips the file picker. `--global` edits the global `before.lua` / `after.lua` |
 | `rvpm set [query] [flags]` | Interactively or non-interactively tweak plugin options (lazy, merge, on\_\*, rev) |
 | `rvpm config` | Open `config.toml` in `$EDITOR` |
 | `rvpm init [--write]` | Print (or write) the `dofile(...)` snippet to wire `loader.lua` into `init.lua` |
 | `rvpm list [--no-tui]` | TUI plugin list with action keys; `--no-tui` for pipe-friendly plain text |
+| `rvpm store` | TUI plugin browser over the GitHub `neovim-plugin` topic; Enter to install, `o` to open in browser |
 
 Run `rvpm <command> --help` for flag-level details.
 
-### Usage examples
+### `rvpm store` — plugin discovery TUI
+
+Browse, search, and install plugins from GitHub without leaving the terminal.
+`rvpm store` queries the GitHub Search API for repositories tagged with the
+`neovim-plugin` topic, displays them in a split-pane TUI, and fetches each
+plugin's `README.md` on demand for preview.
+
+**Key bindings:**
+
+| Key | Action |
+|---|---|
+| `j` / `k` / `↓` / `↑` | Move selection |
+| `Ctrl-d` / `Ctrl-u` | Scroll README pane |
+| `/` | Search (`topic:neovim-plugin <query>` against GitHub Search API) |
+| `Enter` | Add the selected plugin to `config.toml` and sync |
+| `o` | Open the plugin's GitHub page in your default browser |
+| `s` | Cycle sort mode (`stars` / `updated` / `name`) |
+| `R` | Clear the search cache and re-fetch |
+| `q` / `Esc` | Quit |
+
+**Caching:** search results are cached for 24 hours under
+`{cache_root}/store/`; READMEs are cached for 7 days. Press `R` in the TUI
+to force-refresh.
+
+**Network requirement:** store needs network access to reach
+`api.github.com` and `raw.githubusercontent.com`. Other commands
+(`sync` / `update` / `generate` / `list` / ...) work offline once plugins
+are cloned.
+
+<details>
+<summary><b>More command examples</b></summary>
 
 ```sh
 # ── Sync & generate ──────────────────────────────────────
@@ -447,8 +505,8 @@ rvpm edit lspconfig --before
 rvpm edit
 
 # Jump straight to the global before/after hooks
-rvpm edit --global --before    # ~/.config/rvpm/before.lua (phase 3)
-rvpm edit --global --after     # ~/.config/rvpm/after.lua  (phase 9)
+rvpm edit --global --before    # phase 3
+rvpm edit --global --after     # phase 9
 
 # ── Set plugin options ───────────────────────────────────
 
@@ -464,9 +522,6 @@ rvpm set which-key --on-map '{"lhs":"<leader>?","mode":["n","x"],"desc":"Which K
 
 # Pin to a specific tag
 rvpm set telescope --rev "0.1.8"
-
-# Drop into $EDITOR for manual TOML editing from the set menu
-# → pick a plugin → select [ Open config.toml in $EDITOR ]
 
 # ── Config / init ────────────────────────────────────────
 
@@ -489,15 +544,18 @@ rvpm list --no-tui
 rvpm list --no-tui | grep Missing
 ```
 
+</details>
+
 ## Design highlights
 
-### Loader model
+<details>
+<summary><b>Loader model (9 phases)</b></summary>
 
 ```
 Phase 1: vim.go.loadplugins = false         -- disable Neovim's auto-source
 Phase 2: load_lazy helper                   -- runtime loader for lazy plugins
-Phase 3: global before.lua                  -- ~/.config/rvpm/before.lua (if present)
-Phase 4: all init.lua (dependency order)   -- pre-rtp phase
+Phase 3: global before.lua                  -- ~/.config/rvpm/<appname>/before.lua
+Phase 4: all init.lua (dependency order)    -- pre-rtp phase
 Phase 5: rtp:append(merged_dir)             -- once, if any merge=true plugins
 Phase 6: eager plugins in dependency order:
              if not merge: rtp:append(plugin_path)
@@ -507,25 +565,31 @@ Phase 6: eager plugins in dependency order:
              source after/plugin/**
              after.lua
              User autocmd "rvpm_loaded_<name>"
-Phase 7: lazy trigger registrations (on_cmd / on_ft / on_map / etc)
+Phase 7: lazy trigger registrations         -- on_cmd / on_ft / on_map / etc
 Phase 8: ColorSchemePre handlers            -- auto-registered for lazy plugins
                                               --   whose colors/ dir was detected at
                                               --   generate time (no config needed)
-Phase 9: global after.lua                  -- ~/.config/rvpm/after.lua (if present)
+Phase 9: global after.lua                   -- ~/.config/rvpm/<appname>/after.lua
 ```
 
 Because the file lists are baked in at `rvpm generate` time, the loader does
 zero runtime glob work. `rvpm sync` (or `rvpm generate`) is what pays the I/O
 cost; Neovim startup just sources a fixed list of files.
 
-### Merge optimization
+</details>
+
+<details>
+<summary><b>Merge optimization</b></summary>
 
 When `merge = true`, the plugin directory is linked (junction on Windows,
-symlink elsewhere) into `{cache_root}/plugins/merged/`. All `merge = true` plugins share
-a single `vim.opt.rtp:append(merged_dir)` call, keeping `&runtimepath` lean
-even with many eager plugins.
+symlink elsewhere) into `{cache_root}/plugins/merged/`. All `merge = true`
+plugins share a single `vim.opt.rtp:append(merged_dir)` call, keeping
+`&runtimepath` lean even with many eager plugins.
 
-### Dependency ordering
+</details>
+
+<details>
+<summary><b>Dependency ordering &amp; lazy→eager promotion</b></summary>
 
 `depends` fields are topologically sorted. Cycles and missing dependencies
 emit warnings instead of hard-failing (resilience principle). The sort
@@ -533,35 +597,47 @@ ordering is preserved all the way through to the generated `loader.lua`, so
 `before.lua` / `after.lua` hooks run in the correct order relative to
 dependencies.
 
-Beyond ordering, `depends` now also affects **loading**:
+Beyond ordering, `depends` also affects **loading**:
 
-- **Eager plugin → lazy dep**: a pre-pass during `generate_loader` detects this
-  situation and auto-promotes the lazy dependency to eager, printing a note to
-  stderr. This ensures the dep is unconditionally available before the eager
-  plugin sources its files.
+- **Eager plugin → lazy dep**: a pre-pass during `generate_loader` detects
+  this situation and auto-promotes the lazy dependency to eager, printing a
+  note to stderr. This ensures the dep is unconditionally available before
+  the eager plugin sources its files.
 - **Lazy plugin → lazy dep**: the dependency is loaded on-demand. When the
   trigger fires, the generated callback calls `load_lazy` for each lazy dep
-  (in dependency order) before loading the plugin itself. A double-load guard
-  (`if loaded["<name>"] then return end`) prevents redundant sourcing when
-  multiple plugins share the same dep and their triggers fire close together.
+  (in dependency order) before loading the plugin itself. A double-load
+  guard (`if loaded["<name>"] then return end`) prevents redundant sourcing
+  when multiple plugins share the same dep and their triggers fire close
+  together.
+
+</details>
 
 ## Directory layout (defaults)
 
-| Path | Purpose |
-|---|---|
-| `~/.config/rvpm/config.toml` | Main configuration (fixed location) |
-| `~/.config/rvpm/before.lua` | Global before hook — runs at phase 3, before all plugin `init.lua` |
-| `~/.config/rvpm/after.lua` | Global after hook — runs at phase 9, after all lazy trigger registrations |
-| `~/.config/rvpm/plugins/<host>/<owner>/<repo>/` | Per-plugin `init/before/after.lua` (`options.config_root` to override) |
-| `~/.cache/rvpm/repos/<host>/<owner>/<repo>/` | Plugin clones |
-| `~/.cache/rvpm/merged/` | Linked root for `merge = true` plugins |
-| `~/.cache/rvpm/loader.lua` | Generated loader |
+```
+~/.config/rvpm/<appname>/
+├── config.toml                              ← main configuration (fixed)
+├── before.lua                               ← global before hook (phase 3, auto-detected)
+├── after.lua                                ← global after hook (phase 9, auto-detected)
+└── plugins/                                 ← config_root
+    └── <host>/<owner>/<repo>/
+        ├── init.lua
+        ├── before.lua
+        └── after.lua
 
-Windows uses the same `.config` / `.cache` paths under `%USERPROFILE%` — no
-`%APPDATA%` — to keep dotfiles portable between Linux/macOS/WSL/Windows.
+~/.cache/rvpm/<appname>/                     ← cache_root
+├── plugins/
+│   ├── repos/<host>/<owner>/<repo>/         ← plugin clones
+│   ├── merged/                              ← linked root for merge=true plugins
+│   └── loader.lua                           ← generated loader
+└── store/                                   ← `rvpm store` cache (search + README)
+```
 
-`options.cache_root = "..."` moves all of `~/.cache/rvpm/<appname>/` to a
-different root (useful for dotfiles-managed caches).
+Windows uses the same `.config` / `.cache` paths under `%USERPROFILE%` —
+no `%APPDATA%` — to keep dotfiles portable between Linux / macOS / WSL /
+Windows.
+
+`<appname>` resolves to `$RVPM_APPNAME` → `$NVIM_APPNAME` → `"nvim"`.
 
 ## Development
 
@@ -571,9 +647,6 @@ cargo build
 
 # Run the full test suite
 cargo test
-
-# Run a single test
-cargo test test_loader_phase_order_init_rtp_before
 
 # Format check / lint
 cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ sources everything without any runtime glob cost.
 
 - **Fast startup** — 9-phase loader model with `vim.go.loadplugins = false`
   and pre-globbed `plugin/` / `ftdetect/` / `after/plugin/` file lists
-- **Global hooks** — `before.lua` / `after.lua` directly under the config
-  root are auto-detected at generate time; no config entry needed
+- **Global hooks** — `before.lua` / `after.lua` alongside `config.toml`
+  are auto-detected at generate time; no config entry needed
 - **Lazy trigger fidelity** — `User Xxx` pattern shorthand, bang/range/count/
   complete-aware commands, keymaps with mode + desc, and `<Ignore>`-prefixed
   replay for safety; operator-pending mode preserves `v:operator` /
@@ -165,7 +165,7 @@ for fully isolated test configs.
 > **Symmetric layout.** `config_root` and `cache_root` are structurally
 > parallel — each owns a `plugins/` subdirectory at the same depth:
 >
-> ```
+> ```text
 > ~/.config/rvpm/<appname>/                ← config_root
 >     ├── config.toml
 >     ├── before.lua       (global, phase 3)
@@ -179,7 +179,7 @@ for fully isolated test configs.
 >     │   └── loader.lua                    (generated)
 >     └── store/                            (`rvpm store` cache)
 > ```
-
+>
 > **💡 Leave `config_root` and `cache_root` unset** — the defaults are already
 > `<appname>`-aware. Setting a literal path (e.g. `cache_root = "~/dotfiles/rvpm"`)
 > **breaks appname isolation**: every `$NVIM_APPNAME` variant will share the same
@@ -412,7 +412,7 @@ rvpm will include them in the generated loader:
 | `before.lua` | Right after the plugin's rtp is added, before `plugin/*` is sourced |
 | `after.lua`  | After `plugin/*` is sourced (safe to call plugin APIs) |
 
-Example: `~/.config/rvpm/nvim/plugins/github.com/nvim-telescope/telescope.nvim/after.lua`
+Example: `~/.config/rvpm/<appname>/plugins/github.com/nvim-telescope/telescope.nvim/after.lua`
 
 ```lua
 require("telescope").setup({
@@ -463,7 +463,7 @@ plugin's `README.md` on demand for preview.
 
 **Caching:** search results are cached for 24 hours under
 `{cache_root}/store/`; READMEs are cached for 7 days. Press `R` in the TUI
-to force-refresh.
+to force-refresh the search cache (README cache expires on its own TTL).
 
 **Network requirement:** store needs network access to reach
 `api.github.com` and `raw.githubusercontent.com`. Other commands
@@ -559,7 +559,7 @@ rvpm list --no-tui | grep Missing
 <details>
 <summary><b>Loader model (9 phases)</b></summary>
 
-```
+```text
 Phase 1: vim.go.loadplugins = false         -- disable Neovim's auto-source
 Phase 2: load_lazy helper                   -- runtime loader for lazy plugins
 Phase 3: global before.lua                  -- ~/.config/rvpm/<appname>/before.lua
@@ -622,7 +622,7 @@ Beyond ordering, `depends` also affects **loading**:
 
 ## Directory layout (defaults)
 
-```
+```text
 ~/.config/rvpm/<appname>/                    ← config_root
 ├── config.toml                              ← main configuration
 ├── before.lua                               ← global before hook (phase 3, auto-detected)

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,7 +515,7 @@ async fn run_sync(prune: bool) -> Result<()> {
     let config_root = resolve_config_root(config.options.config_root.as_deref());
     for plugin in config.plugins.iter().filter(|p| p.dev) {
         let dst_path = resolve_plugin_dst(plugin, &cache_root);
-        let plugin_config_dir = config_root.join(plugin.canonical_path());
+        let plugin_config_dir = resolve_plugin_config_dir(&config_root, plugin);
         if plugin.merge && !plugin.lazy {
             let _ = merge_plugin(&dst_path, &merged_dir);
         }
@@ -551,7 +551,7 @@ async fn run_sync(prune: bool) -> Result<()> {
                         let _ = merge_plugin(&dst_path, &merged_dir);
                     }
                     let config_root = resolve_config_root(config.options.config_root.as_deref());
-                    let plugin_config_dir = config_root.join(plugin.canonical_path());
+                    let plugin_config_dir = resolve_plugin_config_dir(&config_root, &plugin);
                     let scripts = build_plugin_scripts(&plugin, &dst_path, &plugin_config_dir);
                     plugin_scripts.push(scripts);
                 }
@@ -633,7 +633,7 @@ async fn run_sync(prune: bool) -> Result<()> {
         &merged_dir,
         &plugin_scripts,
         &loader_path,
-        &build_loader_options(),
+        &build_loader_options(&config_root),
     )?;
     println!("Done! -> {}", loader_path.display());
 
@@ -702,7 +702,7 @@ async fn run_generate() -> Result<()> {
     let config_root = resolve_config_root(config.options.config_root.as_deref());
     for plugin in &config.plugins {
         let dst_path = resolve_plugin_dst(plugin, &cache_root);
-        let plugin_config_dir = config_root.join(plugin.canonical_path());
+        let plugin_config_dir = resolve_plugin_config_dir(&config_root, plugin);
         plugin_scripts.push(build_plugin_scripts(plugin, &dst_path, &plugin_config_dir));
     }
 
@@ -727,7 +727,7 @@ async fn run_generate() -> Result<()> {
         &merged_dir,
         &plugin_scripts,
         &loader_path,
-        &build_loader_options(),
+        &build_loader_options(&config_root),
     )?;
     println!("Done! -> {}", loader_path.display());
     print_init_lua_hint_if_missing(&config);
@@ -1335,12 +1335,18 @@ async fn run_edit(
     flag_after: bool,
     flag_global: bool,
 ) -> Result<bool> {
-    // --global: グローバル hooks (~/.config/rvpm/before.lua / after.lua)
+    // --global: グローバル hooks (<config_root>/before.lua / after.lua)
     if flag_global {
-        let config_dir = rvpm_config_path()
-            .parent()
-            .expect("config path has parent")
-            .to_path_buf();
+        // config_root を決めるため config.toml を先読み (存在しなければデフォルト)。
+        let config_path = rvpm_config_path();
+        let config_root = if config_path.exists() {
+            let toml_content = std::fs::read_to_string(&config_path)?;
+            let config = parse_config(&toml_content)?;
+            resolve_config_root(config.options.config_root.as_deref())
+        } else {
+            resolve_config_root(None)
+        };
+        let config_dir = config_root.clone();
         std::fs::create_dir_all(&config_dir)?;
 
         let file_name = if flag_before {
@@ -1379,10 +1385,8 @@ async fn run_edit(
     // 対話モード: plugin 選択肢に [ Global hooks ] sentinel を追加
     // 各プラグインの init/before/after.lua 存在をサークルアイコンで表示
     let config_root = resolve_config_root(config.options.config_root.as_deref());
-    let config_dir = rvpm_config_path()
-        .parent()
-        .expect("config path has parent")
-        .to_path_buf();
+    // global hook のアイコン表示用 (実使用は run_edit --global 経由)
+    let config_dir = config_root.clone();
 
     let plugin = if let Some(q) = query {
         config
@@ -1411,7 +1415,7 @@ async fn run_edit(
         let mut urls: Vec<String> = vec![String::new()]; // sentinel placeholder
 
         for p in config.plugins.iter() {
-            let plugin_config_dir = config_root.join(p.canonical_path());
+            let plugin_config_dir = resolve_plugin_config_dir(&config_root, p);
             let indicators = hook_indicators(&plugin_config_dir);
             let has_any = plugin_config_dir.join("init.lua").exists()
                 || plugin_config_dir.join("before.lua").exists()
@@ -1445,7 +1449,7 @@ async fn run_edit(
 
     println!("\n>> Editing configuration for: {}", plugin.url);
 
-    let plugin_config_dir = config_root.join(plugin.canonical_path());
+    let plugin_config_dir = resolve_plugin_config_dir(&config_root, plugin);
 
     // --init / --before / --after フラグがあれば対話式をスキップ
     let file_name = if flag_init {
@@ -2068,15 +2072,11 @@ fn update_plugin_config(
     Ok(())
 }
 
-/// config.toml の隣にある before.lua / after.lua を検出して LoaderOptions を構築する。
-fn build_loader_options() -> crate::loader::LoaderOptions {
-    let config_dir = rvpm_config_path()
-        .parent()
-        .expect("config path has parent")
-        .to_path_buf();
+/// `<config_root>/before.lua` / `after.lua` を検出して LoaderOptions を構築する。
+fn build_loader_options(config_root: &Path) -> crate::loader::LoaderOptions {
     crate::loader::LoaderOptions {
-        global_before: find_lua(&config_dir, "before.lua"),
-        global_after: find_lua(&config_dir, "after.lua"),
+        global_before: find_lua(config_root, "before.lua"),
+        global_after: find_lua(config_root, "after.lua"),
     }
 }
 
@@ -2112,14 +2112,20 @@ fn resolve_concurrency(config_value: Option<usize>) -> usize {
 //
 // ユーザー側で別のパスにしたければ TOML の options で上書きできる:
 //   - options.cache_root  → 全キャッシュの root (plugins/ と store/ が配下)
-//   - options.config_root → per-plugin init/before/after.lua の置き場
+//   - options.config_root → 全コンフィグの root (config.toml / 全 global hook /
+//                           plugins/ が配下)
+//
+// config_root と cache_root は対称構造:
+//   <config_root>/config.toml
+//   <config_root>/before.lua / after.lua             (global hooks)
+//   <config_root>/plugins/<host>/<owner>/<repo>/     (per-plugin hooks)
+//   <cache_root>/plugins/{repos,merged,loader.lua}   (plugins 本体)
+//   <cache_root>/store/                              (store キャッシュ)
 //
 // $RVPM_APPNAME > $NVIM_APPNAME > "nvim" の順で appname が決まり、
 // デフォルトパスの末尾に appname が入る:
-//   ~/.config/rvpm/<appname>/config.toml
-//   ~/.config/rvpm/<appname>/plugins/
-//   ~/.cache/rvpm/<appname>/plugins/{repos,merged,loader.lua}
-//   ~/.cache/rvpm/<appname>/store/
+//   ~/.config/rvpm/<appname>/
+//   ~/.cache/rvpm/<appname>/
 // ====================================================================
 
 /// `~/.config/rvpm/config.toml` (固定)
@@ -2200,20 +2206,23 @@ fn resolve_cache_root(config_cache_root: Option<&str>) -> PathBuf {
     }
 }
 
-/// per-plugin の init/before/after.lua を置く root を決定する。
+/// config.toml / global hook / per-plugin hook の親 root を決定する。
 /// `options.config_root` が設定されていればそれを tilde 展開して返す。
-/// 未設定なら `~/.config/rvpm/<appname>/plugins` (デフォルト)。
+/// 未設定なら `~/.config/rvpm/<appname>` (デフォルト)。
 fn resolve_config_root(config_root: Option<&str>) -> PathBuf {
     match config_root {
         Some(raw) => expand_tilde(raw),
         None => {
             let home = dirs::home_dir().expect("Could not find home directory");
-            home.join(".config")
-                .join("rvpm")
-                .join(appname())
-                .join("plugins")
+            home.join(".config").join("rvpm").join(appname())
         }
     }
+}
+
+/// 指定プラグインの per-plugin hook ディレクトリ (`<config_root>/plugins/<host>/<owner>/<repo>`)
+/// を返す。
+fn resolve_plugin_config_dir(config_root: &Path, plugin: &config::Plugin) -> PathBuf {
+    config_root.join("plugins").join(plugin.canonical_path())
 }
 
 /// loader.lua のパス。常に `<cache_root>/plugins/loader.lua`。
@@ -2959,25 +2968,46 @@ mod tests {
     fn test_resolve_config_root_uses_default_when_none() {
         let home = dirs::home_dir().unwrap();
         let result = resolve_config_root(None);
-        // appname は env に依存するので親だけ確認
+        // デフォルトは `~/.config/rvpm/<appname>` (plugins は含まない)
         assert!(result.starts_with(home.join(".config").join("rvpm")));
-        assert!(result.ends_with("plugins"));
+        assert!(!result.ends_with("plugins"));
+        // 末尾は appname (env 依存)
+        assert_eq!(
+            result.parent(),
+            Some(home.join(".config").join("rvpm").as_path())
+        );
     }
 
     #[test]
     fn test_resolve_config_root_expands_tilde() {
         let home = dirs::home_dir().unwrap();
         assert_eq!(
-            resolve_config_root(Some("~/dotfiles/nvim/plugins")),
-            home.join("dotfiles").join("nvim").join("plugins")
+            resolve_config_root(Some("~/dotfiles/nvim")),
+            home.join("dotfiles").join("nvim")
         );
     }
 
     #[test]
     fn test_resolve_config_root_accepts_absolute_path() {
         assert_eq!(
-            resolve_config_root(Some("/etc/rvpm/plugins")),
-            PathBuf::from("/etc/rvpm/plugins")
+            resolve_config_root(Some("/etc/rvpm")),
+            PathBuf::from("/etc/rvpm")
+        );
+    }
+
+    #[test]
+    fn test_resolve_plugin_config_dir_joins_plugins_subdir() {
+        let plugin = config::Plugin {
+            url: "folke/snacks.nvim".to_string(),
+            ..Default::default()
+        };
+        let root = PathBuf::from("/tmp/rvpm");
+        let got = resolve_plugin_config_dir(&root, &plugin);
+        assert_eq!(
+            got,
+            PathBuf::from("/tmp/rvpm")
+                .join("plugins")
+                .join(plugin.canonical_path())
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -562,7 +562,8 @@ impl TuiState {
                 let rev = p.rev.as_deref().unwrap_or("-");
 
                 // I B A 列: init/before/after.lua の存在チェック
-                let pcdir = config_root.join(p.canonical_path());
+                // per-plugin hook は <config_root>/plugins/<host>/<owner>/<repo>/
+                let pcdir = config_root.join("plugins").join(p.canonical_path());
                 let hook_i = if pcdir.join("init.lua").exists() {
                     icons.hook_on
                 } else {


### PR DESCRIPTION
## Summary

Two related changes bundled as v3.1:

### 1. `config_root` restructure (breaking)

Previously `config_root` defaulted to `~/.config/rvpm/<appname>/plugins`, which was misleading — it didn't actually contain `config.toml` or the global `before.lua` / `after.lua` hooks (those lived one level up). It was effectively \"per-plugin hooks root,\" not \"config root.\"

Now `config_root` truly owns all config:

```
<config_root>/
  config.toml                               ← main config
  before.lua                                ← global before hook (phase 3)
  after.lua                                 ← global after hook  (phase 9)
  plugins/<host>/<owner>/<repo>/            ← per-plugin hooks
```

Default: `~/.config/rvpm/<appname>/` (without `/plugins`). Per-plugin hooks resolve as `<config_root>/plugins/<canonical_path>` via the new `resolve_plugin_config_dir()` helper. Global hooks (both in `rvpm edit --global` and in the generated `loader.lua`) now honor `config_root` — previously they were hardcoded to `rvpm_config_path().parent()`.

This pairs cleanly with `cache_root` from #25: both roots now own a `plugins/` subdirectory at the same depth, giving a symmetric mental model.

**Migration:** if you previously set `options.config_root = \"~/foo/plugins\"` (pointing directly at per-plugin hook dirs), change it to `options.config_root = \"~/foo\"` and your existing `~/foo/plugins/<host>/<owner>/<repo>/` hook dirs are already in the right place.

### 2. README restructure (user-requested)

- **Add `rvpm store` section** — previously the command was undocumented
- **Reorder `[options]` table** — `config_root` / `cache_root` / `concurrency` (the two roots sit together)
- **Clarify `config_root` ↔ `cache_root` pairing** — new ASCII tree that shows the symmetry
- **Collapse verbose sections behind `<details>`** — \"More features,\" Tera templates deep dive, `[[plugins]]` reference, Lazy trigger fields / `on_map` formats, Colorscheme lazy loading, Hooks reference, Command example dump, Design highlights

## Test plan

- [x] `cargo test` — 172 tests pass (including new `test_resolve_plugin_config_dir_joins_plugins_subdir` and updated `test_resolve_config_root_*`)
- [x] `cargo make check` (fmt + clippy + test) clean
- [ ] Manual: `rvpm sync` picks up `~/.config/rvpm/nvim/before.lua` as a global before hook
- [ ] Manual: `rvpm edit --global --before` opens `<config_root>/before.lua`
- [ ] Manual: per-plugin hooks at `~/.config/rvpm/nvim/plugins/github.com/folke/snacks.nvim/after.lua` are picked up
- [ ] README: `<details>` collapses render properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)