### PR TITLE
feat(chezmoi): auto-sync config mutations to chezmoi source state

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ for fully isolated test configs.
 | `config_root` | `string` | `~/.config/rvpm/<appname>` | Root for all rvpm config (`config.toml`, global `before.lua` / `after.lua`, and `plugins/<host>/<owner>/<repo>/` per-plugin hooks). Supports `~` and Tera templates. **Recommended: leave unset** |
 | `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** |
 | `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
-| `chezmoi` | `boolean` | `false` | When `true`, rvpm automatically runs `chezmoi re-add` (or `chezmoi add` for new files whose ancestor is already managed) after mutating `config.toml`, global hooks, or per-plugin hooks. Silently skipped if `chezmoi` is not in `PATH`. See [chezmoi integration](#chezmoi-integration) |
+| `chezmoi` | `boolean` | `false` | When `true`, rvpm automatically runs `chezmoi re-add` (or `chezmoi add` for new files whose ancestor is already managed) after mutating `config.toml`, global hooks, or per-plugin hooks. Warns if `chezmoi` is not in `PATH`. See [chezmoi integration](#chezmoi-integration) |
 
 > **Symmetric layout.** `config_root` and `cache_root` are structurally
 > parallel — each owns a `plugins/` subdirectory at the same depth:
@@ -214,9 +214,12 @@ config), rvpm:
   created per-plugin hook files under `plugins/<host>/<owner>/<repo>/`).
 
 Files whose ancestors are not managed by chezmoi are left alone, so this is
-safe to enable even if only part of your rvpm tree lives in chezmoi. If
-`chezmoi` isn't installed or the invocation fails, rvpm prints a single
-warning line and continues — your rvpm operation still succeeds.
+safe to enable even if only part of your rvpm tree lives in chezmoi.
+
+If `options.chezmoi = true` but the `chezmoi` binary isn't in `PATH`, rvpm
+prints a warning on every mutation (since you explicitly opted in — the
+loud feedback nudges you to either install chezmoi or set
+`chezmoi = false`). The primary rvpm operation still succeeds.
 
 Detection uses `chezmoi source-path <path>` (exit 0 = managed).
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ nvim_rc = "~/.config/nvim/rc"
 # cache_root = "~/dotfiles/nvim/rvpm"
 # Parallel git operations limit (default: 8)
 concurrency = 10
+# Auto-sync config.toml / global hooks / per-plugin hooks back to chezmoi
+# source state after mutations (default: false). Requires `chezmoi` in PATH.
+# chezmoi = true
 
 [[plugins]]
 name  = "snacks"
@@ -161,6 +164,7 @@ for fully isolated test configs.
 | `config_root` | `string` | `~/.config/rvpm/<appname>` | Root for all rvpm config (`config.toml`, global `before.lua` / `after.lua`, and `plugins/<host>/<owner>/<repo>/` per-plugin hooks). Supports `~` and Tera templates. **Recommended: leave unset** |
 | `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** |
 | `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
+| `chezmoi` | `boolean` | `false` | When `true`, rvpm automatically runs `chezmoi re-add` (or `chezmoi add` for new files whose ancestor is already managed) after mutating `config.toml`, global hooks, or per-plugin hooks. Silently skipped if `chezmoi` is not in `PATH`. See [chezmoi integration](#chezmoi-integration) |
 
 > **Symmetric layout.** `config_root` and `cache_root` are structurally
 > parallel — each owns a `plugins/` subdirectory at the same depth:
@@ -189,6 +193,32 @@ for fully isolated test configs.
 > ```
 > Prefer `~/` over `{{ env.HOME }}` — `~` is portable (Windows too), while
 > `$HOME` is not set on Windows.
+
+### chezmoi integration
+
+If you manage your dotfiles with [chezmoi](https://www.chezmoi.io/) and want
+rvpm's config changes to land in the chezmoi source state automatically, set:
+
+```toml
+[options]
+chezmoi = true
+```
+
+With this enabled, after every mutation (`rvpm add` / `set` / `remove` /
+`edit` / `config`, plus TUI `S`/`u`/`U`/`e`/`s`/`d` actions that touch
+config), rvpm:
+
+- runs `chezmoi re-add <path>` when the target file is already chezmoi-managed, and
+- runs `chezmoi add <path>` when the file is newly created by rvpm and its
+  nearest existing ancestor directory is chezmoi-managed (typical for newly
+  created per-plugin hook files under `plugins/<host>/<owner>/<repo>/`).
+
+Files whose ancestors are not managed by chezmoi are left alone, so this is
+safe to enable even if only part of your rvpm tree lives in chezmoi. If
+`chezmoi` isn't installed or the invocation fails, rvpm prints a single
+warning line and continues — your rvpm operation still succeeds.
+
+Detection uses `chezmoi source-path <path>` (exit 0 = managed).
 
 ### Tera templates
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ chezmoi = true
 ```
 
 With this enabled, after every mutation (`rvpm add` / `set` / `remove` /
-`edit` / `config`, plus TUI `S`/`u`/`U`/`e`/`s`/`d` actions that touch
-config), rvpm:
+`edit` / `config`, plus TUI actions `e` / `s` / `d` that edit hooks,
+plugin options, or remove plugins), rvpm:
 
 - runs `chezmoi re-add <path>` when the target file is already chezmoi-managed, and
 - runs `chezmoi add <path>` when the file is newly created by rvpm and its

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -1,0 +1,201 @@
+//! chezmoi 連携ヘルパー。
+//!
+//! `options.chezmoi = true` のとき、rvpm が `config.toml` や per-plugin hook を
+//! 書き換えた後にこのモジュールの `sync()` を呼ぶと、chezmoi の source 側へ
+//! `chezmoi re-add` (既存 managed) / `chezmoi add` (新規ファイル、祖先 managed)
+//! で自動同期する。
+//!
+//! `chezmoi` コマンドが見つからない / 非 0 終了した場合は stderr に 1 行 warn を
+//! 出して処理は継続する (resilience 原則)。
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// chezmoi コマンドに何をさせるかを決めた結果。`sync()` の内部ロジックを
+/// 副作用 (Command 実行) から分離するための enum。テスト容易性のため公開。
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyncAction {
+    /// 何もしない (feature OFF、rvpm 外のパス、managed 祖先なし等)。
+    Noop,
+    /// 既存 managed ファイルの再同期: `chezmoi re-add <path>`
+    ReAdd(PathBuf),
+    /// 新規ファイルの初回登録: `chezmoi add <path>`
+    Add(PathBuf),
+}
+
+/// `path` に対して行うべき chezmoi 操作を決定する。Command は実行しない。
+///
+/// - `enabled` が false → `Noop`
+/// - `path` が既に存在し、かつ chezmoi managed → `ReAdd`
+/// - `path` が存在せず、最初に存在する祖先が chezmoi managed → `Add`
+/// - それ以外 → `Noop`
+///
+/// `managed_probe` は「指定パスが chezmoi managed か」を返すクロージャ。
+/// 本番は `chezmoi source-path <p>` の exit code を見るが、テストでは
+/// 任意の判定関数を差し込める。
+pub fn decide_action<F>(enabled: bool, path: &Path, mut managed_probe: F) -> SyncAction
+where
+    F: FnMut(&Path) -> bool,
+{
+    if !enabled {
+        return SyncAction::Noop;
+    }
+    if path.exists() {
+        if managed_probe(path) {
+            SyncAction::ReAdd(path.to_path_buf())
+        } else {
+            SyncAction::Noop
+        }
+    } else {
+        match first_existing_ancestor(path) {
+            Some(anc) if managed_probe(&anc) => SyncAction::Add(path.to_path_buf()),
+            _ => SyncAction::Noop,
+        }
+    }
+}
+
+/// 指定パスから root に向かって遡り、最初に **存在する** ディレクトリを返す。
+/// 新規ファイル作成時、どこまで遡れば既存の親があるかを調べるのに使う。
+pub fn first_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = Some(path);
+    while let Some(p) = current {
+        if p.exists() {
+            return Some(p.to_path_buf());
+        }
+        current = p.parent();
+    }
+    None
+}
+
+/// `chezmoi source-path <p>` を実行して exit 0 なら managed。
+/// `chezmoi` が見つからない場合も false を返す。
+fn is_managed_via_chezmoi(p: &Path) -> bool {
+    Command::new("chezmoi")
+        .arg("source-path")
+        .arg(p)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// `options.chezmoi = true` のときに rvpm の mutate 系コマンドから呼ばれる
+/// エントリポイント。`path` に対する必要な chezmoi 操作を判定し実行する。
+/// 失敗しても rvpm 本体の処理は止めない (stderr に warn 1 行だけ出して継続)。
+pub fn sync(enabled: bool, path: &Path) {
+    let action = decide_action(enabled, path, is_managed_via_chezmoi);
+    match action {
+        SyncAction::Noop => {}
+        SyncAction::ReAdd(p) => run_chezmoi(&["re-add"], &p),
+        SyncAction::Add(p) => run_chezmoi(&["add"], &p),
+    }
+}
+
+fn run_chezmoi(args: &[&str], path: &Path) {
+    let mut cmd = Command::new("chezmoi");
+    cmd.args(args).arg(path);
+    match cmd.status() {
+        Ok(s) if s.success() => {}
+        Ok(s) => eprintln!(
+            "\u{26a0} chezmoi {} {} failed (exit {})",
+            args.join(" "),
+            path.display(),
+            s.code().unwrap_or(-1),
+        ),
+        Err(e) => eprintln!(
+            "\u{26a0} chezmoi {} {} could not be spawned: {}",
+            args.join(" "),
+            path.display(),
+            e,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_first_existing_ancestor_returns_self_when_path_exists() {
+        let tmp = tempdir().unwrap();
+        let got = first_existing_ancestor(tmp.path()).unwrap();
+        assert_eq!(got, tmp.path());
+    }
+
+    #[test]
+    fn test_first_existing_ancestor_walks_up_through_missing_dirs() {
+        let tmp = tempdir().unwrap();
+        let nested = tmp.path().join("a").join("b").join("c").join("init.lua");
+        // `nested` も `a/b/c/` も存在しない。tmp.path() は存在する。
+        let got = first_existing_ancestor(&nested).unwrap();
+        assert_eq!(got, tmp.path());
+    }
+
+    #[test]
+    fn test_first_existing_ancestor_stops_at_first_existing_intermediate() {
+        let tmp = tempdir().unwrap();
+        let mid = tmp.path().join("plugins");
+        std::fs::create_dir_all(&mid).unwrap();
+        let nested = mid
+            .join("github.com")
+            .join("foo")
+            .join("bar")
+            .join("init.lua");
+        let got = first_existing_ancestor(&nested).unwrap();
+        assert_eq!(got, mid);
+    }
+
+    #[test]
+    fn test_decide_action_disabled_is_noop() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("config.toml");
+        std::fs::write(&file, "").unwrap();
+        // 仮に managed_probe が常に true でも、enabled=false なら Noop。
+        let got = decide_action(false, &file, |_| true);
+        assert_eq!(got, SyncAction::Noop);
+    }
+
+    #[test]
+    fn test_decide_action_existing_managed_is_re_add() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("config.toml");
+        std::fs::write(&file, "").unwrap();
+        let got = decide_action(true, &file, |p| p == file);
+        assert_eq!(got, SyncAction::ReAdd(file));
+    }
+
+    #[test]
+    fn test_decide_action_existing_not_managed_is_noop() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("config.toml");
+        std::fs::write(&file, "").unwrap();
+        let got = decide_action(true, &file, |_| false);
+        assert_eq!(got, SyncAction::Noop);
+    }
+
+    #[test]
+    fn test_decide_action_new_file_ancestor_managed_is_add() {
+        let tmp = tempdir().unwrap();
+        let plugins = tmp.path().join("plugins");
+        std::fs::create_dir_all(&plugins).unwrap();
+        let new_file = plugins
+            .join("github.com")
+            .join("foo")
+            .join("bar")
+            .join("init.lua");
+        // plugins/ だけを managed として扱う。祖先遡りが効いているはず。
+        let plugins_clone = plugins.clone();
+        let got = decide_action(true, &new_file, move |p| p == plugins_clone);
+        assert_eq!(got, SyncAction::Add(new_file));
+    }
+
+    #[test]
+    fn test_decide_action_new_file_ancestor_not_managed_is_noop() {
+        let tmp = tempdir().unwrap();
+        let plugins = tmp.path().join("plugins");
+        std::fs::create_dir_all(&plugins).unwrap();
+        let new_file = plugins.join("foo").join("init.lua");
+        let got = decide_action(true, &new_file, |_| false);
+        assert_eq!(got, SyncAction::Noop);
+    }
+}

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -26,55 +26,64 @@ pub enum SyncAction {
 /// `path` に対して行うべき chezmoi 操作を決定する。Command は実行しない。
 ///
 /// - `enabled` が false → `Noop`
-/// - `path` が既に存在し、かつ chezmoi managed → `ReAdd`
-/// - `path` が存在せず、最初に存在する祖先が chezmoi managed → `Add`
+/// - `existed_before = true` (rvpm が mutate する前から存在していたファイル)
+///   かつ `path` が chezmoi managed → `ReAdd`、managed じゃない → `Noop`
+/// - `existed_before = false` (rvpm が新規作成した。$EDITOR 終了後だと既に
+///   ディスク上には存在する点に注意) かつ祖先が chezmoi managed → `Add`
 /// - それ以外 → `Noop`
 ///
-/// `managed_probe` は「指定パスが chezmoi managed か」を返すクロージャ。
-/// 本番は `chezmoi source-path <p>` の exit code を見るが、テストでは
-/// 任意の判定関数を差し込める。
-pub fn decide_action<F>(enabled: bool, path: &Path, mut managed_probe: F) -> SyncAction
+/// `existed_before` 引数が必要なのは: `rvpm edit` 等で新規 hook を作ると
+/// $EDITOR を抜けた時点で `path.exists() == true` になっており、ファイル
+/// 自身は chezmoi にまだ登録されていないので `ReAdd` パスが選ばれて
+/// `Noop` に落ち、本来必要な `Add` が一度も発火しない。そのため呼び出し側
+/// が mutate 前の存在状態を捕捉して渡す必要がある。
+pub fn decide_action<F>(
+    enabled: bool,
+    existed_before: bool,
+    path: &Path,
+    mut managed_probe: F,
+) -> SyncAction
 where
     F: FnMut(&Path) -> bool,
 {
     if !enabled {
         return SyncAction::Noop;
     }
-    if path.exists() {
+    if existed_before {
         if managed_probe(path) {
             SyncAction::ReAdd(path.to_path_buf())
         } else {
             SyncAction::Noop
         }
     } else {
-        match first_existing_ancestor(path) {
-            Some(anc) if managed_probe(&anc) => SyncAction::Add(path.to_path_buf()),
-            _ => SyncAction::Noop,
+        // 祖先を root 方向へ順に見て、最初に managed なディレクトリが
+        // 見つかれば Add。直親が rvpm によって mkdir されたばかりで
+        // まだ chezmoi 管理下に無い場合でも、その上 (例えば plugins/)
+        // が managed なら `chezmoi add` すれば chezmoi が中間ディレクトリ
+        // ごと source に放り込んでくれる。
+        let mut current = path.parent();
+        while let Some(p) = current {
+            if p.exists() && managed_probe(p) {
+                return SyncAction::Add(path.to_path_buf());
+            }
+            current = p.parent();
         }
+        SyncAction::Noop
     }
-}
-
-/// 指定パスから root に向かって遡り、最初に **存在する** ディレクトリを返す。
-/// 新規ファイル作成時、どこまで遡れば既存の親があるかを調べるのに使う。
-pub fn first_existing_ancestor(path: &Path) -> Option<PathBuf> {
-    let mut current = Some(path);
-    while let Some(p) = current {
-        if p.exists() {
-            return Some(p.to_path_buf());
-        }
-        current = p.parent();
-    }
-    None
 }
 
 /// `chezmoi source-path <p>` を実行して exit 0 なら managed。
+/// exit 非 0 は chezmoi が「not managed」と言った場合 (想定内) なので false。
+/// 起動自体の IO エラー (PATH 通っていたのに spawn 失敗など) は stderr に
+/// warn を出して false を返す (managed と推定するのは危険なので保守的に)。
 fn is_managed_via_chezmoi(p: &Path) -> bool {
-    Command::new("chezmoi")
-        .arg("source-path")
-        .arg(p)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    match Command::new("chezmoi").arg("source-path").arg(p).output() {
+        Ok(o) => o.status.success(),
+        Err(e) => {
+            eprintln!("\u{26a0} chezmoi source-path {} failed: {}", p.display(), e,);
+            false
+        }
+    }
 }
 
 /// `chezmoi` 実行可能ファイルが PATH に存在するか。`--version` で軽く叩いて判定。
@@ -94,7 +103,10 @@ fn is_chezmoi_available() -> bool {
 /// 明示的に ON にしている以上不整合なので毎回 warn を出す (設定ミスを放置
 /// しない方が親切)。鬱陶しければ `options.chezmoi = false` に戻すか、
 /// `chezmoi` を入れるかを選んでもらう。
-pub fn sync(enabled: bool, path: &Path) {
+///
+/// `existed_before` は mutate/edit を行う **前** の `path.exists()` の値。
+/// 新規作成か既存更新かの区別に必要 (詳細は [`decide_action`] 参照)。
+pub fn sync(enabled: bool, existed_before: bool, path: &Path) {
     if !enabled {
         return;
     }
@@ -106,7 +118,7 @@ pub fn sync(enabled: bool, path: &Path) {
         );
         return;
     }
-    let action = decide_action(true, path, is_managed_via_chezmoi);
+    let action = decide_action(true, existed_before, path, is_managed_via_chezmoi);
     match action {
         SyncAction::Noop => {}
         SyncAction::ReAdd(p) => run_chezmoi(&["re-add"], &p),
@@ -140,42 +152,12 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn test_first_existing_ancestor_returns_self_when_path_exists() {
-        let tmp = tempdir().unwrap();
-        let got = first_existing_ancestor(tmp.path()).unwrap();
-        assert_eq!(got, tmp.path());
-    }
-
-    #[test]
-    fn test_first_existing_ancestor_walks_up_through_missing_dirs() {
-        let tmp = tempdir().unwrap();
-        let nested = tmp.path().join("a").join("b").join("c").join("init.lua");
-        // `nested` も `a/b/c/` も存在しない。tmp.path() は存在する。
-        let got = first_existing_ancestor(&nested).unwrap();
-        assert_eq!(got, tmp.path());
-    }
-
-    #[test]
-    fn test_first_existing_ancestor_stops_at_first_existing_intermediate() {
-        let tmp = tempdir().unwrap();
-        let mid = tmp.path().join("plugins");
-        std::fs::create_dir_all(&mid).unwrap();
-        let nested = mid
-            .join("github.com")
-            .join("foo")
-            .join("bar")
-            .join("init.lua");
-        let got = first_existing_ancestor(&nested).unwrap();
-        assert_eq!(got, mid);
-    }
-
-    #[test]
     fn test_decide_action_disabled_is_noop() {
         let tmp = tempdir().unwrap();
         let file = tmp.path().join("config.toml");
         std::fs::write(&file, "").unwrap();
         // 仮に managed_probe が常に true でも、enabled=false なら Noop。
-        let got = decide_action(false, &file, |_| true);
+        let got = decide_action(false, true, &file, |_| true);
         assert_eq!(got, SyncAction::Noop);
     }
 
@@ -184,7 +166,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let file = tmp.path().join("config.toml");
         std::fs::write(&file, "").unwrap();
-        let got = decide_action(true, &file, |p| p == file);
+        let got = decide_action(true, true, &file, |p| p == file);
         assert_eq!(got, SyncAction::ReAdd(file));
     }
 
@@ -193,7 +175,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let file = tmp.path().join("config.toml");
         std::fs::write(&file, "").unwrap();
-        let got = decide_action(true, &file, |_| false);
+        let got = decide_action(true, true, &file, |_| false);
         assert_eq!(got, SyncAction::Noop);
     }
 
@@ -209,7 +191,7 @@ mod tests {
             .join("init.lua");
         // plugins/ だけを managed として扱う。祖先遡りが効いているはず。
         let plugins_clone = plugins.clone();
-        let got = decide_action(true, &new_file, move |p| p == plugins_clone);
+        let got = decide_action(true, false, &new_file, move |p| p == plugins_clone);
         assert_eq!(got, SyncAction::Add(new_file));
     }
 
@@ -219,7 +201,26 @@ mod tests {
         let plugins = tmp.path().join("plugins");
         std::fs::create_dir_all(&plugins).unwrap();
         let new_file = plugins.join("foo").join("init.lua");
-        let got = decide_action(true, &new_file, |_| false);
+        let got = decide_action(true, false, &new_file, |_| false);
         assert_eq!(got, SyncAction::Noop);
+    }
+
+    /// `rvpm edit` で新規 hook を作成すると $EDITOR 終了時点で path は既に
+    /// 存在する。呼び出し側が existed_before=false を渡しさえすれば Add に
+    /// 行く (そうしないと ReAdd 判定で chezmoi source-path が false を返し
+    /// Noop に落ちてしまい、Add が一度も発火しない)。
+    #[test]
+    fn test_decide_action_file_exists_but_was_just_created_is_add() {
+        let tmp = tempdir().unwrap();
+        let plugins = tmp.path().join("plugins");
+        std::fs::create_dir_all(&plugins).unwrap();
+        let new_file = plugins.join("bar").join("init.lua");
+        std::fs::create_dir_all(new_file.parent().unwrap()).unwrap();
+        std::fs::write(&new_file, "-- new hook").unwrap();
+        // ファイル自体は存在するが existed_before=false (rvpm が作った) と伝えると
+        // 祖先 plugins/ が managed なら Add になる。
+        let plugins_clone = plugins.clone();
+        let got = decide_action(true, false, &new_file, move |p| p == plugins_clone);
+        assert_eq!(got, SyncAction::Add(new_file));
     }
 }

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -68,7 +68,6 @@ pub fn first_existing_ancestor(path: &Path) -> Option<PathBuf> {
 }
 
 /// `chezmoi source-path <p>` を実行して exit 0 なら managed。
-/// `chezmoi` が見つからない場合も false を返す。
 fn is_managed_via_chezmoi(p: &Path) -> bool {
     Command::new("chezmoi")
         .arg("source-path")
@@ -78,11 +77,36 @@ fn is_managed_via_chezmoi(p: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// `chezmoi` 実行可能ファイルが PATH に存在するか。`--version` で軽く叩いて判定。
+fn is_chezmoi_available() -> bool {
+    Command::new("chezmoi")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// `options.chezmoi = true` のときに rvpm の mutate 系コマンドから呼ばれる
 /// エントリポイント。`path` に対する必要な chezmoi 操作を判定し実行する。
 /// 失敗しても rvpm 本体の処理は止めない (stderr に warn 1 行だけ出して継続)。
+///
+/// `enabled = true` なのに `chezmoi` バイナリが PATH に無い場合は、ユーザーが
+/// 明示的に ON にしている以上不整合なので毎回 warn を出す (設定ミスを放置
+/// しない方が親切)。鬱陶しければ `options.chezmoi = false` に戻すか、
+/// `chezmoi` を入れるかを選んでもらう。
 pub fn sync(enabled: bool, path: &Path) {
-    let action = decide_action(enabled, path, is_managed_via_chezmoi);
+    if !enabled {
+        return;
+    }
+    if !is_chezmoi_available() {
+        eprintln!(
+            "\u{26a0} options.chezmoi = true but `chezmoi` is not in PATH. \
+             Skipping sync for {} (install chezmoi or set chezmoi = false).",
+            path.display(),
+        );
+        return;
+    }
+    let action = decide_action(true, path, is_managed_via_chezmoi);
     match action {
         SyncAction::Noop => {}
         SyncAction::ReAdd(p) => run_chezmoi(&["re-add"], &p),

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,12 @@ pub struct Options {
     /// TUI アイコンスタイル: "nerd" (default), "unicode", "ascii"
     #[serde(default)]
     pub icons: IconStyle,
+    /// chezmoi 連携を有効にするか。`true` なら rvpm が `config.toml` や
+    /// per-plugin hook を書き換えた後に `chezmoi re-add` / `chezmoi add` を
+    /// 自動実行して source 側へ同期する。`chezmoi` コマンドが無い環境では
+    /// 静かにスキップ。デフォルト `false`。
+    #[serde(default)]
+    pub chezmoi: bool,
 }
 
 /// Keymap 仕様. TOML では文字列 (`"<leader>f"`) またはテーブル
@@ -477,6 +483,31 @@ url = "owner/repo"
 "#;
         let config = parse_config(toml).unwrap();
         assert_eq!(config.options.cache_root, None);
+    }
+
+    #[test]
+    fn test_parse_config_chezmoi_defaults_to_false() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(!config.options.chezmoi);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_chezmoi_true() {
+        let toml = r#"
+[options]
+chezmoi = true
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(config.options.chezmoi);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1265,10 +1265,10 @@ async fn run_add(
     let toml_content = doc.to_string();
     std::fs::write(&config_path, &toml_content)?;
     println!("Added plugin to config: {}", repo);
+    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
     let config_data = parse_config(&toml_content)?;
-    chezmoi::sync(config_data.options.chezmoi, &config_path);
     let cache_root = resolve_cache_root(config_data.options.cache_root.as_deref());
     let merged_dir = resolve_merged_dir(&cache_root);
 
@@ -1310,11 +1310,7 @@ async fn run_config() -> Result<bool> {
     ensure_config_exists(&config_path)?;
     println!("Opening {}", config_path.display());
     open_editor_at_line(&config_path, 1)?;
-    if let Ok(toml_content) = std::fs::read_to_string(&config_path)
-        && let Ok(cfg) = parse_config(&toml_content)
-    {
-        chezmoi::sync(cfg.options.chezmoi, &config_path);
-    }
+    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
     Ok(true)
 }
 
@@ -1409,12 +1405,7 @@ async fn run_edit(
         println!("\n>> Editing global hook: {}", target.display());
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
         std::process::Command::new(editor).arg(&target).status()?;
-        if config_path.exists()
-            && let Ok(toml_content) = std::fs::read_to_string(&config_path)
-            && let Ok(cfg) = parse_config(&toml_content)
-        {
-            chezmoi::sync(cfg.options.chezmoi, &target);
-        }
+        chezmoi::sync(read_chezmoi_flag(&config_path), &target);
         return Ok(true);
     }
 
@@ -1521,7 +1512,7 @@ async fn run_edit(
     std::process::Command::new(editor)
         .arg(&target_file)
         .status()?;
-    chezmoi::sync(config.options.chezmoi, &target_file);
+    chezmoi::sync(read_chezmoi_flag(&config_path), &target_file);
     Ok(true)
 }
 
@@ -1803,12 +1794,9 @@ async fn run_set(
     }
 
     if modified {
-        let new_toml = doc.to_string();
-        std::fs::write(&config_path, &new_toml)?;
+        std::fs::write(&config_path, doc.to_string())?;
         println!("Updated config for: {}", selected_repo_url);
-        if let Ok(cfg) = parse_config(&new_toml) {
-            chezmoi::sync(cfg.options.chezmoi, &config_path);
-        }
+        chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
         return Ok(true);
     }
     Ok(false)
@@ -1884,12 +1872,9 @@ async fn run_remove(query: Option<String>) -> Result<()> {
 
     let mut doc = toml_content.parse::<DocumentMut>()?;
     remove_plugin_from_toml(&mut doc, &selected_url)?;
-    let new_toml = doc.to_string();
-    std::fs::write(&config_path, &new_toml)?;
+    std::fs::write(&config_path, doc.to_string())?;
     println!("Removed '{}' from config.", selected_url);
-    if let Ok(cfg) = parse_config(&new_toml) {
-        chezmoi::sync(cfg.options.chezmoi, &config_path);
-    }
+    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
     let plugin = config
@@ -2208,6 +2193,24 @@ fn rvpm_config_path() -> PathBuf {
         .join("rvpm")
         .join(appname())
         .join("config.toml")
+}
+
+/// `config.toml` から `options.chezmoi` フラグだけを軽量に読み出す。
+/// `parse_config` は Tera 展開 + topological sort を行う重量級処理なので、
+/// mutate 系コマンドがフラグ 1 つを見るためだけに呼ぶのは無駄。
+/// toml_edit で該当キーだけ直接参照する。
+/// ファイルが存在しない / パースできない / キーが無い場合は `false`。
+fn read_chezmoi_flag(config_path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(config_path) else {
+        return false;
+    };
+    let Ok(doc) = content.parse::<DocumentMut>() else {
+        return false;
+    };
+    doc.get("options")
+        .and_then(|o| o.get("chezmoi"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
 
 /// config.toml が存在しなければ最小テンプレートで新規作成する。

--- a/src/main.rs
+++ b/src/main.rs
@@ -1215,6 +1215,7 @@ async fn run_add(
     rev: Option<String>,
 ) -> Result<()> {
     let config_path = rvpm_config_path();
+    let config_existed_before = config_path.exists();
     ensure_config_exists(&config_path)?;
     let toml_content = std::fs::read_to_string(&config_path)?;
     let mut doc = toml_content.parse::<DocumentMut>()?;
@@ -1265,7 +1266,11 @@ async fn run_add(
     let toml_content = doc.to_string();
     std::fs::write(&config_path, &toml_content)?;
     println!("Added plugin to config: {}", repo);
-    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
+    chezmoi::sync(
+        read_chezmoi_flag(&config_path),
+        config_existed_before,
+        &config_path,
+    );
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
     let config_data = parse_config(&toml_content)?;
@@ -1307,10 +1312,15 @@ use dialoguer::{FuzzySelect, Select};
 /// 常に `Ok(true)` を返すので呼び出し側で sync を走らせる前提。
 async fn run_config() -> Result<bool> {
     let config_path = rvpm_config_path();
+    let existed_before = config_path.exists();
     ensure_config_exists(&config_path)?;
     println!("Opening {}", config_path.display());
     open_editor_at_line(&config_path, 1)?;
-    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
+    chezmoi::sync(
+        read_chezmoi_flag(&config_path),
+        existed_before,
+        &config_path,
+    );
     Ok(true)
 }
 
@@ -1402,10 +1412,11 @@ async fn run_edit(
         };
 
         let target = config_dir.join(file_name);
+        let existed_before = target.exists();
         println!("\n>> Editing global hook: {}", target.display());
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
         std::process::Command::new(editor).arg(&target).status()?;
-        chezmoi::sync(read_chezmoi_flag(&config_path), &target);
+        chezmoi::sync(read_chezmoi_flag(&config_path), existed_before, &target);
         return Ok(true);
     }
 
@@ -1508,11 +1519,16 @@ async fn run_edit(
     };
     std::fs::create_dir_all(&plugin_config_dir)?;
     let target_file = plugin_config_dir.join(file_name);
+    let existed_before = target_file.exists();
     let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
     std::process::Command::new(editor)
         .arg(&target_file)
         .status()?;
-    chezmoi::sync(read_chezmoi_flag(&config_path), &target_file);
+    chezmoi::sync(
+        read_chezmoi_flag(&config_path),
+        existed_before,
+        &target_file,
+    );
     Ok(true)
 }
 
@@ -1649,6 +1665,7 @@ async fn run_set(
                         // 対応 editor なら plugin の url 行にジャンプ
                         let line = find_plugin_line_in_toml(&toml_content, &selected_repo_url);
                         open_editor_at_line(&config_path, line)?;
+                        chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
                         // ユーザーが何を編集したか分からないので常に変更ありと見なす
                         return Ok(true);
                     }
@@ -1737,6 +1754,7 @@ async fn run_set(
                                 let line =
                                     find_plugin_line_in_toml(&toml_content, &selected_repo_url);
                                 open_editor_at_line(&config_path, line)?;
+                                chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
                                 return Ok(true);
                             }
                             _ => return Ok(false),
@@ -1796,7 +1814,7 @@ async fn run_set(
     if modified {
         std::fs::write(&config_path, doc.to_string())?;
         println!("Updated config for: {}", selected_repo_url);
-        chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
+        chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
         return Ok(true);
     }
     Ok(false)
@@ -1874,7 +1892,7 @@ async fn run_remove(query: Option<String>) -> Result<()> {
     remove_plugin_from_toml(&mut doc, &selected_url)?;
     std::fs::write(&config_path, doc.to_string())?;
     println!("Removed '{}' from config.", selected_url);
-    chezmoi::sync(read_chezmoi_flag(&config_path), &config_path);
+    chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
     let plugin = config

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod chezmoi;
 mod config;
 mod git;
 mod link;
@@ -1267,6 +1268,7 @@ async fn run_add(
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
     let config_data = parse_config(&toml_content)?;
+    chezmoi::sync(config_data.options.chezmoi, &config_path);
     let cache_root = resolve_cache_root(config_data.options.cache_root.as_deref());
     let merged_dir = resolve_merged_dir(&cache_root);
 
@@ -1308,6 +1310,11 @@ async fn run_config() -> Result<bool> {
     ensure_config_exists(&config_path)?;
     println!("Opening {}", config_path.display());
     open_editor_at_line(&config_path, 1)?;
+    if let Ok(toml_content) = std::fs::read_to_string(&config_path)
+        && let Ok(cfg) = parse_config(&toml_content)
+    {
+        chezmoi::sync(cfg.options.chezmoi, &config_path);
+    }
     Ok(true)
 }
 
@@ -1402,6 +1409,12 @@ async fn run_edit(
         println!("\n>> Editing global hook: {}", target.display());
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
         std::process::Command::new(editor).arg(&target).status()?;
+        if config_path.exists()
+            && let Ok(toml_content) = std::fs::read_to_string(&config_path)
+            && let Ok(cfg) = parse_config(&toml_content)
+        {
+            chezmoi::sync(cfg.options.chezmoi, &target);
+        }
         return Ok(true);
     }
 
@@ -1506,8 +1519,9 @@ async fn run_edit(
     let target_file = plugin_config_dir.join(file_name);
     let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
     std::process::Command::new(editor)
-        .arg(target_file)
+        .arg(&target_file)
         .status()?;
+    chezmoi::sync(config.options.chezmoi, &target_file);
     Ok(true)
 }
 
@@ -1789,8 +1803,12 @@ async fn run_set(
     }
 
     if modified {
-        std::fs::write(&config_path, doc.to_string())?;
+        let new_toml = doc.to_string();
+        std::fs::write(&config_path, &new_toml)?;
         println!("Updated config for: {}", selected_repo_url);
+        if let Ok(cfg) = parse_config(&new_toml) {
+            chezmoi::sync(cfg.options.chezmoi, &config_path);
+        }
         return Ok(true);
     }
     Ok(false)
@@ -1866,8 +1884,12 @@ async fn run_remove(query: Option<String>) -> Result<()> {
 
     let mut doc = toml_content.parse::<DocumentMut>()?;
     remove_plugin_from_toml(&mut doc, &selected_url)?;
-    std::fs::write(&config_path, doc.to_string())?;
+    let new_toml = doc.to_string();
+    std::fs::write(&config_path, &new_toml)?;
     println!("Removed '{}' from config.", selected_url);
+    if let Ok(cfg) = parse_config(&new_toml) {
+        chezmoi::sync(cfg.options.chezmoi, &config_path);
+    }
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
     let plugin = config


### PR DESCRIPTION
## Summary

Opt-in chezmoi integration. When `options.chezmoi = true`, rvpm automatically runs `chezmoi re-add` / `chezmoi add` after any command that mutates config files, so dotfile users don't have to manually re-sync.

### What it does

After `rvpm add` / `set` / `remove` / `config` / `edit` (including TUI actions):

- **Existing chezmoi-managed file mutated** → `chezmoi re-add <path>`
- **New file created, nearest existing ancestor is managed** → `chezmoi add <path>` (covers newly created per-plugin hook files under `plugins/<host>/<owner>/<repo>/` where the immediate parent dir is created on the fly)
- **Otherwise** → no-op

Detection uses `chezmoi source-path <path>` (exit 0 = managed). If `chezmoi` isn't installed or the call fails, rvpm prints one warning line and continues — the primary rvpm operation still succeeds (resilience).

### Design notes

The sync logic is split for testability:

- `decide_action(enabled, path, managed_probe)` — pure, returns a `SyncAction` enum (`Noop` / `ReAdd` / `Add`). Fully unit-tested across all 5 branches.
- `first_existing_ancestor(path)` — pure ancestor walk, unit-tested.
- `sync(enabled, path)` — thin shell-out that composes the above with real `chezmoi` invocations.

Default is `false`; feature is entirely opt-in.

## Test plan

- [x] `cargo make check` (fmt / clippy / 182 tests) passes
- [ ] Manual: with `chezmoi = true` and `~/.config/rvpm/` managed by chezmoi
  - [ ] `rvpm add foo/bar` → `chezmoi re-add` runs on config.toml
  - [ ] `rvpm edit <plugin>` creates new `init.lua` → `chezmoi add` runs
  - [ ] `rvpm config` after editor exit → `chezmoi re-add` runs
- [ ] Manual: with `chezmoi = true` but `chezmoi` not in PATH → warning shown, rvpm succeeds
- [ ] Manual: with `chezmoi = false` → no chezmoi invocation at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional chezmoi integration that automatically synchronizes configuration and hook files with chezmoi when enabled. Managed files are updated, and new files within managed directories are automatically added.

* **Documentation**
  * Added detailed chezmoi integration documentation describing feature behavior and configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->