### PR TITLE
refactor: drop full sync after edit/set/config, only regenerate loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,12 +259,12 @@ let _permit = sem.acquire_owned().await.unwrap();
 |---------|------|------|
 | `sync [--prune]` | `run_sync()` | clone/pull + merged + loader.lua 生成。`--prune` で未使用プラグインディレクトリも削除。無指定でも未使用があれば末尾で警告表示 |
 | `generate` | `run_generate()` | loader.lua のみ再生成 |
-| `add <repo>` | `run_add()` | TOML 追加 + sync |
+| `add <repo>` | `run_add()` | TOML 追加 + 当該プラグインだけ clone + generate |
 | `update [query]` | `run_update()` | 既存プラグインの pull (clone しない) |
 | `remove [query]` | `run_remove()` | TOML + ディレクトリ削除 + generate |
 | `edit [query] [--init\|--before\|--after] [--global]` | `run_edit()` | per-plugin init/before/after.lua をエディタで編集。フラグ指定でファイル選択をスキップ。`--global` で global hooks (`~/.config/rvpm/before.lua` / `after.lua`) を編集。インタラクティブ選択時は `[ Global hooks ]` sentinel でも同じ動作 |
 | `set [query] [flags]` | `run_set()` | lazy/merge/on_* などを対話式 or 引数で変更。`on_cmd` 等は comma-separated / JSON array 両対応、`--on-map` は JSON object/array で table 形式もサポート。`[ Open config.toml in $EDITOR ]` sentinel で TOML 直接編集に逃げられる |
-| `config` | `run_config()` | `config.toml` を `$EDITOR` で直接開く (終了後に sync 実行) |
+| `config` | `run_config()` | `config.toml` を `$EDITOR` で直接開く (終了後に generate のみ実行。新規プラグイン追加した場合は `rvpm sync` 明示実行) |
 | `init [--write]` | `run_init()` | Neovim `init.lua` に loader.lua を繋ぐ `dofile(...)` スニペットを案内。`--write` で自動追記 (init.lua がなければ新規作成)。`$NVIM_APPNAME` を尊重 |
 | `list [--no-tui]` | `run_list()` | プラグイン一覧表示。デフォルトは TUI で `[S] sync / [u/U] update / [g] generate / [d] remove / [e] edit / [s] set` のアクションキー対応。`--no-tui` で pipe-friendly な plain text 出力 (旧 `status` 相当) |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ async fn main() -> Result<()> {
             global,
         } => {
             if run_edit(query, init, before, after, global).await? {
-                let _ = run_sync(false).await;
+                let _ = run_generate().await;
             }
         }
         Commands::Set {
@@ -282,7 +282,7 @@ async fn main() -> Result<()> {
             )
             .await?
             {
-                let _ = run_sync(false).await;
+                let _ = run_generate().await;
             }
         }
         Commands::Update { query } => {
@@ -296,7 +296,7 @@ async fn main() -> Result<()> {
         }
         Commands::Config => {
             if run_config().await? {
-                let _ = run_sync(false).await;
+                let _ = run_generate().await;
             }
         }
         Commands::Init { write } => {
@@ -318,17 +318,12 @@ use crossterm::{
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
 
-/// cond + merge=true の組み合わせを検出し、merge を無効化する。
-/// 警告メッセージを返す (呼び出し元でまとめて表示)。
-fn warn_and_disable_merge_if_cond(plugin: &mut crate::config::Plugin) -> Option<String> {
+/// cond + merge=true の組み合わせを検出し、silent に merge を無効化する。
+/// (cond が false のとき merged rtp に中身が残ると矛盾するため。警告は
+/// 出さない — 自明に整合させているだけで、ユーザーアクションは不要。)
+fn disable_merge_if_cond(plugin: &mut crate::config::Plugin) {
     if plugin.cond.is_some() && plugin.merge {
         plugin.merge = false;
-        Some(format!(
-            "{}: cond + merge=true -> merge disabled",
-            plugin.display_name()
-        ))
-    } else {
-        None
     }
 }
 
@@ -403,12 +398,8 @@ async fn run_sync(prune: bool) -> Result<()> {
 
     let mut config_data = parse_config(&toml_content)?;
     crate::config::sort_plugins(&mut config_data.plugins)?;
-    // TUI 開始前に cond+merge を処理 (警告は後でまとめて出す)
-    let mut cond_warnings: Vec<String> = Vec::new();
     for plugin in config_data.plugins.iter_mut() {
-        if let Some(w) = warn_and_disable_merge_if_cond(plugin) {
-            cond_warnings.push(w);
-        }
+        disable_merge_if_cond(plugin);
     }
     let config = Arc::new(config_data);
 
@@ -621,13 +612,6 @@ async fn run_sync(prune: bool) -> Result<()> {
             eprintln!("  -> {}", name);
         }
     }
-    if !cond_warnings.is_empty() {
-        eprintln!("\n{} cond/merge warning(s):", cond_warnings.len());
-        for w in &cond_warnings {
-            eprintln!("  \u{26a0} {}", w);
-        }
-    }
-
     println!("Generating loader.lua...");
     let loader_path = resolve_loader_path(&cache_root);
     write_loader_to_path(
@@ -689,11 +673,8 @@ async fn run_generate() -> Result<()> {
         .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
     let mut config = parse_config(&toml_content)?;
     crate::config::sort_plugins(&mut config.plugins)?;
-    // cond + merge=true を正規化 (run_sync と同じ)
     for plugin in config.plugins.iter_mut() {
-        if let Some(w) = warn_and_disable_merge_if_cond(plugin) {
-            eprintln!("Warning: {}", w);
-        }
+        disable_merge_if_cond(plugin);
     }
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
     let merged_dir = resolve_merged_dir(&cache_root);
@@ -1023,7 +1004,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                     if let Some(url) = tui_state.selected_url() {
                         leave_tui(&mut terminal)?;
                         if run_edit(Some(url), false, false, false, false).await? {
-                            let _ = run_sync(false).await;
+                            let _ = run_generate().await;
                         }
                         reload!();
                     }
@@ -1045,7 +1026,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                         )
                         .await?
                         {
-                            let _ = run_sync(false).await;
+                            let _ = run_generate().await;
                         }
                         reload!();
                     }
@@ -1278,9 +1259,7 @@ async fn run_add(
     let merged_dir = resolve_merged_dir(&cache_root);
 
     if let Some(mut plugin) = config_data.plugins.iter().find(|p| p.url == repo).cloned() {
-        if let Some(w) = warn_and_disable_merge_if_cond(&mut plugin) {
-            eprintln!("Warning: {}", w);
-        }
+        disable_merge_if_cond(&mut plugin);
         let dst_path = resolve_plugin_dst(&plugin, &cache_root);
 
         println!("Syncing {}...", plugin.display_name());

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ async fn main() -> Result<()> {
             global,
         } => {
             if run_edit(query, init, before, after, global).await? {
-                let _ = run_generate().await;
+                run_generate().await?;
             }
         }
         Commands::Set {
@@ -282,7 +282,7 @@ async fn main() -> Result<()> {
             )
             .await?
             {
-                let _ = run_generate().await;
+                run_generate().await?;
             }
         }
         Commands::Update { query } => {
@@ -296,7 +296,7 @@ async fn main() -> Result<()> {
         }
         Commands::Config => {
             if run_config().await? {
-                let _ = run_generate().await;
+                run_generate().await?;
             }
         }
         Commands::Init { write } => {
@@ -1004,7 +1004,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                     if let Some(url) = tui_state.selected_url() {
                         leave_tui(&mut terminal)?;
                         if run_edit(Some(url), false, false, false, false).await? {
-                            let _ = run_generate().await;
+                            run_generate().await?;
                         }
                         reload!();
                     }
@@ -1026,7 +1026,7 @@ async fn run_list(no_tui: bool) -> Result<()> {
                         )
                         .await?
                         {
-                            let _ = run_generate().await;
+                            run_generate().await?;
                         }
                         reload!();
                     }


### PR DESCRIPTION
## Summary

For users with 200+ plugins, post-action `run_sync` (git pull across all plugins) was making every interactive tweak slow even when the plugin repos hadn't changed at all. This PR switches those paths to `run_generate` (loader.lua regen + merged/ rebuild, no network).

### Before → After

| Command / action | Before | After |
|---|---|---|
| `rvpm edit` (CLI) | sync | **generate** |
| `rvpm set` (CLI) | sync | **generate** |
| `rvpm config` (CLI) | sync | **generate** |
| TUI `e` | sync | **generate** |
| TUI `s` | sync | **generate** |
| `rvpm sync` (explicit) | sync | sync (unchanged) |
| `rvpm update` / TUI `u` / `U` (explicit) | update | update (unchanged) |
| TUI `S` (explicit) | sync | sync (unchanged) |
| `rvpm add <repo>` | per-plugin clone + generate | per-plugin clone + generate (unchanged) |
| `rvpm remove` | generate | generate (unchanged) |

### Notes

- `run_generate` already rebuilds `merged/` and re-applies lazy→eager promotion, so `rvpm set --merge`, `--lazy` etc still behave correctly without a network round-trip.
- **Edge case**: `rvpm config` users who manually add new `[[plugins]]` entries in the editor must now run `rvpm sync` afterward. Documented in CLAUDE.md.
- Also silences the `cond + merge=true -> merge disabled` warning — rvpm auto-disables merge for correctness; no user action is needed, so the per-plugin warning was just noise. Renamed the helper to `disable_merge_if_cond` and dropped the warning accumulator.

## Test plan

- [x] `cargo make check` (fmt / clippy / 180 tests) passes
- [ ] Manual: `rvpm set <plugin> --lazy true` — returns quickly, merged/ and loader.lua updated correctly
- [ ] Manual: `rvpm edit <plugin>` edit init.lua, exit editor — fast, loader.lua regenerated
- [ ] Manual: TUI `e` / `s` — same
- [ ] Manual: `rvpm sync` still pulls all repos (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * `add <repo>` now performs targeted generation for only the newly added plugin, rather than running a full sync operation.
  * `config` command now runs generation after configuration editing instead of performing a sync operation.
  * New plugins added via `config.toml` now require an explicit `rvpm sync` command to be cloned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->