### PR TITLE
refactor(chezmoi)!: write to source directly instead of re-add/add

### DIFF
--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -1,92 +1,89 @@
 //! chezmoi 連携ヘルパー。
 //!
-//! `options.chezmoi = true` のとき、rvpm が `config.toml` や per-plugin hook を
-//! 書き換えた後にこのモジュールの `sync()` を呼ぶと、chezmoi の source 側へ
-//! `chezmoi re-add` (既存 managed) / `chezmoi add` (新規ファイル、祖先 managed)
-//! で自動同期する。
+//! `options.chezmoi = true` のとき、rvpm は config.toml や per-plugin hook を
+//! **chezmoi source 側に直接書き込み**、`chezmoi apply` で target へ反映する。
+//! これにより chezmoi の「source が truth」原則に沿った連携が実現できる。
 //!
-//! `chezmoi` コマンドが見つからない / 非 0 終了した場合は stderr に 1 行 warn を
-//! 出して処理は継続する (resilience 原則)。
+//! 前提: chezmoi = true のとき、管理対象ファイルは **plain file** であること。
+//! `.tmpl` (chezmoi テンプレート) は非対応。rvpm 自身が Tera テンプレートを
+//! 持っているため chezmoi のテンプレート機能は不要。
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// chezmoi コマンドに何をさせるかを決めた結果。`sync()` の内部ロジックを
-/// 副作用 (Command 実行) から分離するための enum。テスト容易性のため公開。
-#[derive(Debug, PartialEq, Eq)]
-pub enum SyncAction {
-    /// 何もしない (feature OFF、rvpm 外のパス、managed 祖先なし等)。
-    Noop,
-    /// 既存 managed ファイルの再同期: `chezmoi re-add <path>`
-    ReAdd(PathBuf),
-    /// 新規ファイルの初回登録: `chezmoi add <path>`
-    Add(PathBuf),
+/// target パスに対応する chezmoi source パスを解決する (pure function)。
+///
+/// 1. `source_path_probe(target)` が Some を返せばそのまま使う
+/// 2. 返さなければ (新規ファイル等) 祖先を遡り、最初に managed な祖先から
+///    相対パスを計算して source 側のフルパスを構築する
+/// 3. source パスが `.tmpl` で終わる場合は None (テンプレート非対応)
+///
+/// `source_path_probe` は「`chezmoi source-path <p>` の結果」を返すクロージャ。
+/// テストでは mock を差し込む。
+pub fn resolve_source_path<F>(target: &Path, mut source_path_probe: F) -> Option<PathBuf>
+where
+    F: FnMut(&Path) -> Option<PathBuf>,
+{
+    // target 自体が managed なケース (既存ファイル)
+    if let Some(sp) = source_path_probe(target) {
+        if is_tmpl(&sp) {
+            eprintln!(
+                "\u{26a0} {} is a chezmoi template (.tmpl). \
+                 chezmoi=true requires plain files — use rvpm's Tera templates instead.",
+                target.display(),
+            );
+            return None;
+        }
+        return Some(sp);
+    }
+    // 新規ファイル: 祖先を遡って managed な ancestor を見つけ、相対パスで join
+    let mut ancestor = target.parent();
+    while let Some(a) = ancestor {
+        if let Some(source_ancestor) = source_path_probe(a) {
+            if is_tmpl(&source_ancestor) {
+                return None;
+            }
+            let relative = target.strip_prefix(a).ok()?;
+            return Some(source_ancestor.join(relative));
+        }
+        ancestor = a.parent();
+    }
+    None
 }
 
-/// `path` に対して行うべき chezmoi 操作を決定する。Command は実行しない。
-///
-/// - `enabled` が false → `Noop`
-/// - `existed_before = true` (rvpm が mutate する前から存在していたファイル)
-///   かつ `path` が chezmoi managed → `ReAdd`、managed じゃない → `Noop`
-/// - `existed_before = false` (rvpm が新規作成した。$EDITOR 終了後だと既に
-///   ディスク上には存在する点に注意) かつ祖先が chezmoi managed → `Add`
-/// - それ以外 → `Noop`
-///
-/// `existed_before` 引数が必要なのは: `rvpm edit` 等で新規 hook を作ると
-/// $EDITOR を抜けた時点で `path.exists() == true` になっており、ファイル
-/// 自身は chezmoi にまだ登録されていないので `ReAdd` パスが選ばれて
-/// `Noop` に落ち、本来必要な `Add` が一度も発火しない。そのため呼び出し側
-/// が mutate 前の存在状態を捕捉して渡す必要がある。
-pub fn decide_action<F>(
-    enabled: bool,
-    existed_before: bool,
-    path: &Path,
-    mut managed_probe: F,
-) -> SyncAction
-where
-    F: FnMut(&Path) -> bool,
-{
-    if !enabled {
-        return SyncAction::Noop;
-    }
-    if existed_before {
-        if managed_probe(path) {
-            SyncAction::ReAdd(path.to_path_buf())
+fn is_tmpl(p: &Path) -> bool {
+    p.to_string_lossy().ends_with(".tmpl")
+}
+
+/// `chezmoi source-path <target>` を実行し、managed なら source パスを返す。
+fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
+    let output = match Command::new("chezmoi")
+        .arg("source-path")
+        .arg(target)
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!(
+                "\u{26a0} chezmoi source-path {} failed: {}",
+                target.display(),
+                e,
+            );
+            return None;
+        }
+    };
+    if output.status.success() {
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if s.is_empty() {
+            None
         } else {
-            SyncAction::Noop
+            Some(PathBuf::from(s))
         }
     } else {
-        // 祖先を root 方向へ順に見て、最初に managed なディレクトリが
-        // 見つかれば Add。直親が rvpm によって mkdir されたばかりで
-        // まだ chezmoi 管理下に無い場合でも、その上 (例えば plugins/)
-        // が managed なら `chezmoi add` すれば chezmoi が中間ディレクトリ
-        // ごと source に放り込んでくれる。
-        let mut current = path.parent();
-        while let Some(p) = current {
-            if p.exists() && managed_probe(p) {
-                return SyncAction::Add(path.to_path_buf());
-            }
-            current = p.parent();
-        }
-        SyncAction::Noop
+        None
     }
 }
 
-/// `chezmoi source-path <p>` を実行して exit 0 なら managed。
-/// exit 非 0 は chezmoi が「not managed」と言った場合 (想定内) なので false。
-/// 起動自体の IO エラー (PATH 通っていたのに spawn 失敗など) は stderr に
-/// warn を出して false を返す (managed と推定するのは危険なので保守的に)。
-fn is_managed_via_chezmoi(p: &Path) -> bool {
-    match Command::new("chezmoi").arg("source-path").arg(p).output() {
-        Ok(o) => o.status.success(),
-        Err(e) => {
-            eprintln!("\u{26a0} chezmoi source-path {} failed: {}", p.display(), e,);
-            false
-        }
-    }
-}
-
-/// `chezmoi` 実行可能ファイルが PATH に存在するか。`--version` で軽く叩いて判定。
 fn is_chezmoi_available() -> bool {
     Command::new("chezmoi")
         .arg("--version")
@@ -95,132 +92,117 @@ fn is_chezmoi_available() -> bool {
         .unwrap_or(false)
 }
 
-/// `options.chezmoi = true` のときに rvpm の mutate 系コマンドから呼ばれる
-/// エントリポイント。`path` に対する必要な chezmoi 操作を判定し実行する。
-/// 失敗しても rvpm 本体の処理は止めない (stderr に warn 1 行だけ出して継続)。
-///
-/// `enabled = true` なのに `chezmoi` バイナリが PATH に無い場合は、ユーザーが
-/// 明示的に ON にしている以上不整合なので毎回 warn を出す (設定ミスを放置
-/// しない方が親切)。鬱陶しければ `options.chezmoi = false` に戻すか、
-/// `chezmoi` を入れるかを選んでもらう。
-///
-/// `existed_before` は mutate/edit を行う **前** の `path.exists()` の値。
-/// 新規作成か既存更新かの区別に必要 (詳細は [`decide_action`] 参照)。
-pub fn sync(enabled: bool, existed_before: bool, path: &Path) {
+/// rvpm が書き込むべきパスを返す。chezmoi 有効かつ managed なら source 側、
+/// そうでなければ target そのまま。
+pub fn write_path(enabled: bool, target: &Path) -> PathBuf {
     if !enabled {
-        return;
+        return target.to_path_buf();
     }
     if !is_chezmoi_available() {
         eprintln!(
             "\u{26a0} options.chezmoi = true but `chezmoi` is not in PATH. \
-             Skipping sync for {} (install chezmoi or set chezmoi = false).",
-            path.display(),
+             Writing to target directly (install chezmoi or set chezmoi = false).",
         );
-        return;
+        return target.to_path_buf();
     }
-    let action = decide_action(true, existed_before, path, is_managed_via_chezmoi);
-    match action {
-        SyncAction::Noop => {}
-        SyncAction::ReAdd(p) => run_chezmoi(&["re-add"], &p),
-        SyncAction::Add(p) => run_chezmoi(&["add"], &p),
-    }
+    resolve_source_path(target, chezmoi_source_path).unwrap_or_else(|| target.to_path_buf())
 }
 
-fn run_chezmoi(args: &[&str], path: &Path) {
+/// source に書いた後、`chezmoi apply <target>` で target へ反映する。
+pub fn apply(enabled: bool, target: &Path) {
+    if !enabled {
+        return;
+    }
+    if !is_chezmoi_available() {
+        return;
+    }
+    // target が managed じゃなければ apply は不要 (write_path が target を返した場合)
+    if chezmoi_source_path(target).is_none() {
+        // 祖先が managed なら新規ファイルとして apply が必要
+        let has_managed_ancestor = target
+            .ancestors()
+            .skip(1)
+            .any(|a| chezmoi_source_path(a).is_some());
+        if !has_managed_ancestor {
+            return;
+        }
+    }
     let mut cmd = Command::new("chezmoi");
-    cmd.args(args).arg(path);
+    cmd.arg("apply").arg(target);
     match cmd.status() {
         Ok(s) if s.success() => {}
         Ok(s) => eprintln!(
-            "\u{26a0} chezmoi {} {} failed (exit {})",
-            args.join(" "),
-            path.display(),
+            "\u{26a0} chezmoi apply {} failed (exit {})",
+            target.display(),
             s.code().unwrap_or(-1),
         ),
-        Err(e) => eprintln!(
-            "\u{26a0} chezmoi {} {} could not be spawned: {}",
-            args.join(" "),
-            path.display(),
-            e,
-        ),
+        Err(e) => eprintln!("\u{26a0} chezmoi apply {} failed: {}", target.display(), e,),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use std::collections::HashMap;
 
-    #[test]
-    fn test_decide_action_disabled_is_noop() {
-        let tmp = tempdir().unwrap();
-        let file = tmp.path().join("config.toml");
-        std::fs::write(&file, "").unwrap();
-        // 仮に managed_probe が常に true でも、enabled=false なら Noop。
-        let got = decide_action(false, true, &file, |_| true);
-        assert_eq!(got, SyncAction::Noop);
+    fn mock_probe(managed: HashMap<PathBuf, PathBuf>) -> impl FnMut(&Path) -> Option<PathBuf> {
+        move |p| managed.get(p).cloned()
     }
 
     #[test]
-    fn test_decide_action_existing_managed_is_re_add() {
-        let tmp = tempdir().unwrap();
-        let file = tmp.path().join("config.toml");
-        std::fs::write(&file, "").unwrap();
-        let got = decide_action(true, true, &file, |p| p == file);
-        assert_eq!(got, SyncAction::ReAdd(file));
+    fn test_resolve_existing_managed_file() {
+        let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
+        let source =
+            PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/config.toml");
+        let managed = HashMap::from([(target.clone(), source.clone())]);
+        let got = resolve_source_path(&target, mock_probe(managed));
+        assert_eq!(got, Some(source));
     }
 
     #[test]
-    fn test_decide_action_existing_not_managed_is_noop() {
-        let tmp = tempdir().unwrap();
-        let file = tmp.path().join("config.toml");
-        std::fs::write(&file, "").unwrap();
-        let got = decide_action(true, true, &file, |_| false);
-        assert_eq!(got, SyncAction::Noop);
+    fn test_resolve_new_file_via_managed_ancestor() {
+        let ancestor_target = PathBuf::from("/home/user/.config/rvpm/nvim/plugins");
+        let ancestor_source =
+            PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/plugins");
+        let target = ancestor_target.join("github.com/foo/bar/init.lua");
+        let managed = HashMap::from([(ancestor_target, ancestor_source.clone())]);
+        let got = resolve_source_path(&target, mock_probe(managed));
+        assert_eq!(
+            got,
+            Some(ancestor_source.join("github.com/foo/bar/init.lua"))
+        );
     }
 
     #[test]
-    fn test_decide_action_new_file_ancestor_managed_is_add() {
-        let tmp = tempdir().unwrap();
-        let plugins = tmp.path().join("plugins");
-        std::fs::create_dir_all(&plugins).unwrap();
-        let new_file = plugins
-            .join("github.com")
-            .join("foo")
-            .join("bar")
-            .join("init.lua");
-        // plugins/ だけを managed として扱う。祖先遡りが効いているはず。
-        let plugins_clone = plugins.clone();
-        let got = decide_action(true, false, &new_file, move |p| p == plugins_clone);
-        assert_eq!(got, SyncAction::Add(new_file));
+    fn test_resolve_tmpl_returns_none() {
+        let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
+        let source =
+            PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/config.toml.tmpl");
+        let managed = HashMap::from([(target.clone(), source)]);
+        let got = resolve_source_path(&target, mock_probe(managed));
+        assert_eq!(got, None);
     }
 
     #[test]
-    fn test_decide_action_new_file_ancestor_not_managed_is_noop() {
-        let tmp = tempdir().unwrap();
-        let plugins = tmp.path().join("plugins");
-        std::fs::create_dir_all(&plugins).unwrap();
-        let new_file = plugins.join("foo").join("init.lua");
-        let got = decide_action(true, false, &new_file, |_| false);
-        assert_eq!(got, SyncAction::Noop);
+    fn test_resolve_not_managed_returns_none() {
+        let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
+        let managed = HashMap::new();
+        let got = resolve_source_path(&target, mock_probe(managed));
+        assert_eq!(got, None);
     }
 
-    /// `rvpm edit` で新規 hook を作成すると $EDITOR 終了時点で path は既に
-    /// 存在する。呼び出し側が existed_before=false を渡しさえすれば Add に
-    /// 行く (そうしないと ReAdd 判定で chezmoi source-path が false を返し
-    /// Noop に落ちてしまい、Add が一度も発火しない)。
     #[test]
-    fn test_decide_action_file_exists_but_was_just_created_is_add() {
-        let tmp = tempdir().unwrap();
-        let plugins = tmp.path().join("plugins");
-        std::fs::create_dir_all(&plugins).unwrap();
-        let new_file = plugins.join("bar").join("init.lua");
-        std::fs::create_dir_all(new_file.parent().unwrap()).unwrap();
-        std::fs::write(&new_file, "-- new hook").unwrap();
-        // ファイル自体は存在するが existed_before=false (rvpm が作った) と伝えると
-        // 祖先 plugins/ が managed なら Add になる。
-        let plugins_clone = plugins.clone();
-        let got = decide_action(true, false, &new_file, move |p| p == plugins_clone);
-        assert_eq!(got, SyncAction::Add(new_file));
+    fn test_resolve_new_file_no_managed_ancestor_returns_none() {
+        let target = PathBuf::from("/home/user/.config/rvpm/nvim/plugins/foo/init.lua");
+        let managed = HashMap::new();
+        let got = resolve_source_path(&target, mock_probe(managed));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_write_path_disabled_returns_target() {
+        let target = Path::new("/some/target");
+        let got = write_path(false, target);
+        assert_eq!(got, target);
     }
 }

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -41,6 +41,11 @@ where
     while let Some(a) = ancestor {
         if let Some(source_ancestor) = source_path_probe(a) {
             if is_tmpl(&source_ancestor) {
+                eprintln!(
+                    "\u{26a0} ancestor {} resolves to a chezmoi template (.tmpl). \
+                     chezmoi=true requires plain files — use rvpm's Tera templates instead.",
+                    a.display(),
+                );
                 return None;
             }
             let relative = target.strip_prefix(a).ok()?;
@@ -93,7 +98,8 @@ fn is_chezmoi_available() -> bool {
 }
 
 /// rvpm が書き込むべきパスを返す。chezmoi 有効かつ managed なら source 側、
-/// そうでなければ target そのまま。
+/// そうでなければ target そのまま。返り値が target と異なれば source に書いた
+/// ことを意味するので、呼び出し側は `apply()` を呼んで target へ反映する。
 pub fn write_path(enabled: bool, target: &Path) -> PathBuf {
     if !enabled {
         return target.to_path_buf();
@@ -109,23 +115,11 @@ pub fn write_path(enabled: bool, target: &Path) -> PathBuf {
 }
 
 /// source に書いた後、`chezmoi apply <target>` で target へ反映する。
-pub fn apply(enabled: bool, target: &Path) {
-    if !enabled {
+/// `wrote_to` は実際に書き込んだパス (`write_path` の返り値)。target と
+/// 異なる場合のみ apply が必要 (同一なら直接 target に書いたので不要)。
+pub fn apply(wrote_to: &Path, target: &Path) {
+    if wrote_to == target {
         return;
-    }
-    if !is_chezmoi_available() {
-        return;
-    }
-    // target が managed じゃなければ apply は不要 (write_path が target を返した場合)
-    if chezmoi_source_path(target).is_none() {
-        // 祖先が managed なら新規ファイルとして apply が必要
-        let has_managed_ancestor = target
-            .ancestors()
-            .skip(1)
-            .any(|a| chezmoi_source_path(a).is_some());
-        if !has_managed_ancestor {
-            return;
-        }
     }
     let mut cmd = Command::new("chezmoi");
     cmd.arg("apply").arg(target);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1247,7 +1247,7 @@ async fn run_add(
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
     let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
     std::fs::write(&wp, &toml_content)?;
-    chezmoi::apply(chezmoi_enabled, &config_path);
+    chezmoi::apply(&wp, &config_path);
     println!("Added plugin to config: {}", repo);
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
@@ -1293,7 +1293,7 @@ async fn run_config() -> Result<bool> {
     let edit_target = chezmoi::write_path(chezmoi_enabled, &config_path);
     println!("Opening {}", edit_target.display());
     open_editor_at_line(&edit_target, 1)?;
-    chezmoi::apply(chezmoi_enabled, &config_path);
+    chezmoi::apply(&edit_target, &config_path);
     Ok(true)
 }
 
@@ -1388,14 +1388,14 @@ async fn run_edit(
         let chezmoi_enabled = read_chezmoi_flag(&config_path);
         let edit_target = chezmoi::write_path(chezmoi_enabled, &target);
         if let Some(parent) = edit_target.parent() {
-            std::fs::create_dir_all(parent).ok();
+            std::fs::create_dir_all(parent)?;
         }
         println!("\n>> Editing global hook: {}", edit_target.display());
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
         std::process::Command::new(editor)
             .arg(&edit_target)
             .status()?;
-        chezmoi::apply(chezmoi_enabled, &target);
+        chezmoi::apply(&edit_target, &target);
         return Ok(true);
     }
 
@@ -1506,7 +1506,7 @@ async fn run_edit(
     std::process::Command::new(editor)
         .arg(&edit_target)
         .status()?;
-    chezmoi::apply(chezmoi_enabled, &target_file);
+    chezmoi::apply(&edit_target, &target_file);
     Ok(true)
 }
 
@@ -1645,7 +1645,7 @@ async fn run_set(
                         let cz = read_chezmoi_flag(&config_path);
                         let ep = chezmoi::write_path(cz, &config_path);
                         open_editor_at_line(&ep, line)?;
-                        chezmoi::apply(cz, &config_path);
+                        chezmoi::apply(&ep, &config_path);
                         // ユーザーが何を編集したか分からないので常に変更ありと見なす
                         return Ok(true);
                     }
@@ -1736,7 +1736,7 @@ async fn run_set(
                                 let cz = read_chezmoi_flag(&config_path);
                                 let ep = chezmoi::write_path(cz, &config_path);
                                 open_editor_at_line(&ep, line)?;
-                                chezmoi::apply(cz, &config_path);
+                                chezmoi::apply(&ep, &config_path);
                                 return Ok(true);
                             }
                             _ => return Ok(false),
@@ -1797,7 +1797,7 @@ async fn run_set(
         let chezmoi_enabled = read_chezmoi_flag(&config_path);
         let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
         std::fs::write(&wp, doc.to_string())?;
-        chezmoi::apply(chezmoi_enabled, &config_path);
+        chezmoi::apply(&wp, &config_path);
         println!("Updated config for: {}", selected_repo_url);
         return Ok(true);
     }
@@ -1877,7 +1877,7 @@ async fn run_remove(query: Option<String>) -> Result<()> {
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
     let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
     std::fs::write(&wp, doc.to_string())?;
-    chezmoi::apply(chezmoi_enabled, &config_path);
+    chezmoi::apply(&wp, &config_path);
     println!("Removed '{}' from config.", selected_url);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2480,12 +2480,10 @@ fn read_input_with_esc(prompt: &str, initial: &str) -> Result<Option<String>> {
                     print!("{}", c);
                     std::io::stdout().flush()?;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        print!("\x08 \x08");
-                        std::io::stdout().flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    print!("\x08 \x08");
+                    std::io::stdout().flush()?;
                 }
                 _ => {}
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1196,7 +1196,6 @@ async fn run_add(
     rev: Option<String>,
 ) -> Result<()> {
     let config_path = rvpm_config_path();
-    let config_existed_before = config_path.exists();
     ensure_config_exists(&config_path)?;
     let toml_content = std::fs::read_to_string(&config_path)?;
     let mut doc = toml_content.parse::<DocumentMut>()?;
@@ -1245,13 +1244,11 @@ async fn run_add(
     }
 
     let toml_content = doc.to_string();
-    std::fs::write(&config_path, &toml_content)?;
+    let chezmoi_enabled = read_chezmoi_flag(&config_path);
+    let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+    std::fs::write(&wp, &toml_content)?;
+    chezmoi::apply(chezmoi_enabled, &config_path);
     println!("Added plugin to config: {}", repo);
-    chezmoi::sync(
-        read_chezmoi_flag(&config_path),
-        config_existed_before,
-        &config_path,
-    );
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
     let config_data = parse_config(&toml_content)?;
@@ -1291,15 +1288,12 @@ use dialoguer::{FuzzySelect, Select};
 /// 常に `Ok(true)` を返すので呼び出し側で sync を走らせる前提。
 async fn run_config() -> Result<bool> {
     let config_path = rvpm_config_path();
-    let existed_before = config_path.exists();
     ensure_config_exists(&config_path)?;
-    println!("Opening {}", config_path.display());
-    open_editor_at_line(&config_path, 1)?;
-    chezmoi::sync(
-        read_chezmoi_flag(&config_path),
-        existed_before,
-        &config_path,
-    );
+    let chezmoi_enabled = read_chezmoi_flag(&config_path);
+    let edit_target = chezmoi::write_path(chezmoi_enabled, &config_path);
+    println!("Opening {}", edit_target.display());
+    open_editor_at_line(&edit_target, 1)?;
+    chezmoi::apply(chezmoi_enabled, &config_path);
     Ok(true)
 }
 
@@ -1391,11 +1385,17 @@ async fn run_edit(
         };
 
         let target = config_dir.join(file_name);
-        let existed_before = target.exists();
-        println!("\n>> Editing global hook: {}", target.display());
+        let chezmoi_enabled = read_chezmoi_flag(&config_path);
+        let edit_target = chezmoi::write_path(chezmoi_enabled, &target);
+        if let Some(parent) = edit_target.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        println!("\n>> Editing global hook: {}", edit_target.display());
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
-        std::process::Command::new(editor).arg(&target).status()?;
-        chezmoi::sync(read_chezmoi_flag(&config_path), existed_before, &target);
+        std::process::Command::new(editor)
+            .arg(&edit_target)
+            .status()?;
+        chezmoi::apply(chezmoi_enabled, &target);
         return Ok(true);
     }
 
@@ -1496,18 +1496,17 @@ async fn run_edit(
             None => return Ok(false),
         }
     };
-    std::fs::create_dir_all(&plugin_config_dir)?;
     let target_file = plugin_config_dir.join(file_name);
-    let existed_before = target_file.exists();
+    let chezmoi_enabled = read_chezmoi_flag(&config_path);
+    let edit_target = chezmoi::write_path(chezmoi_enabled, &target_file);
+    if let Some(parent) = edit_target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let editor = std::env::var("EDITOR").unwrap_or_else(|_| "nvim".to_string());
     std::process::Command::new(editor)
-        .arg(&target_file)
+        .arg(&edit_target)
         .status()?;
-    chezmoi::sync(
-        read_chezmoi_flag(&config_path),
-        existed_before,
-        &target_file,
-    );
+    chezmoi::apply(chezmoi_enabled, &target_file);
     Ok(true)
 }
 
@@ -1643,8 +1642,10 @@ async fn run_set(
                     s if s == EDITOR_SENTINEL => {
                         // 対応 editor なら plugin の url 行にジャンプ
                         let line = find_plugin_line_in_toml(&toml_content, &selected_repo_url);
-                        open_editor_at_line(&config_path, line)?;
-                        chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
+                        let cz = read_chezmoi_flag(&config_path);
+                        let ep = chezmoi::write_path(cz, &config_path);
+                        open_editor_at_line(&ep, line)?;
+                        chezmoi::apply(cz, &config_path);
                         // ユーザーが何を編集したか分からないので常に変更ありと見なす
                         return Ok(true);
                     }
@@ -1732,8 +1733,10 @@ async fn run_set(
                             Some(1) => {
                                 let line =
                                     find_plugin_line_in_toml(&toml_content, &selected_repo_url);
-                                open_editor_at_line(&config_path, line)?;
-                                chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
+                                let cz = read_chezmoi_flag(&config_path);
+                                let ep = chezmoi::write_path(cz, &config_path);
+                                open_editor_at_line(&ep, line)?;
+                                chezmoi::apply(cz, &config_path);
                                 return Ok(true);
                             }
                             _ => return Ok(false),
@@ -1791,9 +1794,11 @@ async fn run_set(
     }
 
     if modified {
-        std::fs::write(&config_path, doc.to_string())?;
+        let chezmoi_enabled = read_chezmoi_flag(&config_path);
+        let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+        std::fs::write(&wp, doc.to_string())?;
+        chezmoi::apply(chezmoi_enabled, &config_path);
         println!("Updated config for: {}", selected_repo_url);
-        chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
         return Ok(true);
     }
     Ok(false)
@@ -1869,9 +1874,11 @@ async fn run_remove(query: Option<String>) -> Result<()> {
 
     let mut doc = toml_content.parse::<DocumentMut>()?;
     remove_plugin_from_toml(&mut doc, &selected_url)?;
-    std::fs::write(&config_path, doc.to_string())?;
+    let chezmoi_enabled = read_chezmoi_flag(&config_path);
+    let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+    std::fs::write(&wp, doc.to_string())?;
+    chezmoi::apply(chezmoi_enabled, &config_path);
     println!("Removed '{}' from config.", selected_url);
-    chezmoi::sync(read_chezmoi_flag(&config_path), true, &config_path);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
     let plugin = config

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -73,7 +73,7 @@ impl StoreTuiState {
         match self.sort_mode {
             SortMode::Stars => self
                 .plugins
-                .sort_by(|a, b| b.stargazers_count.cmp(&a.stargazers_count)),
+                .sort_by_key(|p| std::cmp::Reverse(p.stargazers_count)),
             SortMode::Updated => self.plugins.sort_by(|a, b| b.updated_at.cmp(&a.updated_at)),
             SortMode::Name => self.plugins.sort_by(|a, b| {
                 a.plugin_name()


### PR DESCRIPTION
## Summary

Complete rewrite of the chezmoi integration. The previous approach (write to target → `chezmoi re-add`/`chezmoi add`) fought chezmoi's "source is truth" model. Users who normally edit chezmoi source files directly would see their changes overwritten on the next `chezmoi apply`.

### New approach

When `options.chezmoi = true`, rvpm now:

1. Resolves the chezmoi source path via `chezmoi source-path <target>`
2. Writes/edits the **source file directly**
3. Runs `chezmoi apply <target>` to push source → target

For new files (e.g. per-plugin hooks created by `rvpm edit`), walks up ancestors to find the nearest managed directory's source path, computes the relative path, and creates the file directly in source. No `chezmoi add` needed.

### .tmpl guard

`chezmoi = true` requires plain files in chezmoi source — `.tmpl` is explicitly unsupported. Since rvpm has its own Tera template engine, chezmoi templates are redundant. If a `.tmpl` source is detected, rvpm warns and falls back to writing to target directly.

### API change

```
// Old (removed)
chezmoi::sync(enabled, existed_before, path)

// New
let wp = chezmoi::write_path(enabled, target);  // source or target
std::fs::write(&wp, content)?;                   // write there
chezmoi::apply(enabled, target);                  // push to target
```

### Files changed

- `src/chezmoi.rs` — full rewrite: `resolve_source_path` (pure, testable), `write_path`, `apply`. Dropped `SyncAction` / `decide_action` / `sync` / `re-add` / `add`.
- `src/main.rs` — all 8 call sites updated to new API pattern.
- 6 unit tests for `resolve_source_path` (existing managed, new via ancestor, .tmpl guard, not managed, disabled).

## Test plan

- [x] `cargo make check` (fmt / clippy / 180 tests) passes
- [ ] Manual: with `chezmoi = true`, `rvpm add foo/bar` → source file created, `chezmoi diff` clean after
- [ ] Manual: `rvpm edit <plugin>` → opens source file, after exit target updated via apply
- [ ] Manual: `rvpm config` → opens chezmoi source config.toml
- [ ] Manual: .tmpl file detected → warning, writes to target as fallback
- [ ] Manual: `chezmoi = false` → no chezmoi interaction at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured dotfile synchronization logic; decoupled path resolution from sync operations.
  * Changed config write workflow to resolve paths first, then apply changes separately.
  * Removed file existence pre-tracking from synchronization flow.

* **New Features**
  * Template files (.tmpl) now detected and prevented from source-path resolution with warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->