### PR TITLE
feat(store): align keybindings with list TUI, add Tab focus switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,8 @@ let _permit = sem.acquire_owned().await.unwrap();
 | `set [query] [flags]` | `run_set()` | lazy/merge/on_* などを対話式 or 引数で変更。`on_cmd` 等は comma-separated / JSON array 両対応、`--on-map` は JSON object/array で table 形式もサポート。`[ Open config.toml in $EDITOR ]` sentinel で TOML 直接編集に逃げられる |
 | `config` | `run_config()` | `config.toml` を `$EDITOR` で直接開く (終了後に generate のみ実行。新規プラグイン追加した場合は `rvpm sync` 明示実行) |
 | `init [--write]` | `run_init()` | Neovim `init.lua` に loader.lua を繋ぐ `dofile(...)` スニペットを案内。`--write` で自動追記 (init.lua がなければ新規作成)。`$NVIM_APPNAME` を尊重 |
-| `list [--no-tui]` | `run_list()` | プラグイン一覧表示。デフォルトは TUI で `[S] sync / [u/U] update / [g] generate / [d] remove / [e] edit / [s] set` のアクションキー対応。`--no-tui` で pipe-friendly な plain text 出力 (旧 `status` 相当) |
+| `list [--no-tui]` | `run_list()` | プラグイン一覧表示。デフォルトは TUI で `[S] sync / [u/U] update / [d] remove / [e] edit / [s] set / [?] help` のアクションキー対応。ナビ: `j/k/g/G/Ctrl-d/u/f/b`、検索: `/n/N`。`--no-tui` で pipe-friendly な plain text 出力 |
+| `store` | `run_store()` | GitHub `neovim-plugin` トピックのプラグインブラウザ TUI。`Tab` でリスト/README フォーカス切替。ナビキーはフォーカスに応じてリスト操作 or README スクロール。`Enter` で追加、`o` でブラウザ、`s` でソート切替、`?` でヘルプ |
 
 **廃止コマンド:**
 - `status` → `list --no-tui` に統合 (plain text 出力で機能同等)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sources everything without any runtime glob cost.
   `on_source`, auto-detected `ColorSchemePre`, and `depends`-aware loading
 - **Merge optimization** — `merge = true` plugins share a single rtp entry
 - **Plugin discovery TUI** — `rvpm store` browses the GitHub `neovim-plugin`
-  topic with live README preview and one-keystroke install
+  topic with live README preview; `Tab` switches focus between panes
 - **Resilient** — cyclic dependencies, missing plugins, and config errors
   produce warnings, not crashes
 
@@ -474,6 +474,31 @@ vim.keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>")
 
 Run `rvpm <command> --help` for flag-level details.
 
+### `rvpm list` — plugin manager TUI
+
+<details>
+<summary><b>Key bindings</b></summary>
+
+| Key | Action |
+|---|---|
+| `j` / `k` / `↓` / `↑` | Move selection |
+| `g` / `Home` | Go to top |
+| `G` / `End` | Go to bottom |
+| `Ctrl-d` / `Ctrl-u` | Half page down / up |
+| `Ctrl-f` / `Ctrl-b` | Full page down / up |
+| `/` | Incremental search |
+| `n` / `N` | Next / previous search result |
+| `e` | Edit per-plugin hooks (init / before / after.lua) |
+| `s` | Set plugin options (lazy, merge, on_cmd, …) |
+| `S` | Sync all plugins |
+| `u` | Update selected plugin |
+| `U` | Update all plugins |
+| `d` | Remove selected plugin |
+| `?` | Toggle help popup |
+| `q` / `Esc` | Quit |
+
+</details>
+
 ### `rvpm store` — plugin discovery TUI
 
 Browse, search, and install plugins from GitHub without leaving the terminal.
@@ -481,18 +506,32 @@ Browse, search, and install plugins from GitHub without leaving the terminal.
 `neovim-plugin` topic, displays them in a split-pane TUI, and fetches each
 plugin's `README.md` on demand for preview.
 
-**Key bindings:**
+<details>
+<summary><b>Key bindings</b></summary>
+
+Navigation keys are **focus-aware**: press `Tab` to switch between the
+plugin list and the README preview pane.
+
+| Key | List focused | README focused |
+|---|---|---|
+| `j` / `k` / `↓` / `↑` | Move selection | Scroll line |
+| `g` / `Home` | Go to top | Scroll to top |
+| `G` / `End` | Go to bottom | Scroll to bottom |
+| `Ctrl-d` / `Ctrl-u` | Half page down / up | Half page scroll |
+| `Ctrl-f` / `Ctrl-b` | Full page down / up | Full page scroll |
 
 | Key | Action |
 |---|---|
-| `j` / `k` / `↓` / `↑` | Move selection |
-| `Ctrl-d` / `Ctrl-u` | Scroll README pane |
+| `Tab` | Switch focus between list and README |
 | `/` | Search (`topic:neovim-plugin <query>` against GitHub Search API) |
-| `Enter` | Add the selected plugin to `config.toml` and sync |
+| `Enter` | Add the selected plugin to `config.toml` |
 | `o` | Open the plugin's GitHub page in your default browser |
 | `s` | Cycle sort mode (`stars` / `updated` / `name`) |
 | `R` | Clear the search cache and re-fetch |
+| `?` | Toggle help popup |
 | `q` / `Esc` | Quit |
+
+</details>
 
 **Caching:** search results are cached for 24 hours under
 `{cache_root}/store/`; READMEs are cached for 7 days. Press `R` in the TUI
@@ -577,7 +616,7 @@ rvpm config
 
 # ── List / status ────────────────────────────────────────
 
-# TUI with interactive actions ([S] sync, [u] update, [d] remove, …)
+# TUI with interactive actions ([S] sync, [u] update, [d] remove, [?] help)
 rvpm list
 
 # Plain text for scripting / piping

--- a/src/main.rs
+++ b/src/main.rs
@@ -2771,31 +2771,85 @@ async fn run_store() -> Result<()> {
 
             match key.code {
                 crossterm::event::KeyCode::Char('q') | crossterm::event::KeyCode::Esc => break,
+                crossterm::event::KeyCode::Tab => {
+                    state.toggle_focus();
+                }
+                crossterm::event::KeyCode::Char('?') => {
+                    state.show_help = !state.show_help;
+                }
                 crossterm::event::KeyCode::Char('/') => {
                     state.search_mode = true;
                     state.search_input.clear();
                     state.message = None;
                 }
+
+                // ── Navigation: focus-aware ──
                 crossterm::event::KeyCode::Char('j') | crossterm::event::KeyCode::Down => {
-                    state.next();
+                    match state.focus {
+                        store_tui::Focus::List => state.next(),
+                        store_tui::Focus::Readme => state.scroll_readme_down(1),
+                    }
                 }
                 crossterm::event::KeyCode::Char('k') | crossterm::event::KeyCode::Up => {
-                    state.previous();
+                    match state.focus {
+                        store_tui::Focus::List => state.previous(),
+                        store_tui::Focus::Readme => state.scroll_readme_up(1),
+                    }
+                }
+                crossterm::event::KeyCode::Char('g') | crossterm::event::KeyCode::Home => {
+                    match state.focus {
+                        store_tui::Focus::List => state.go_top(),
+                        store_tui::Focus::Readme => state.readme_scroll = 0,
+                    }
+                }
+                crossterm::event::KeyCode::Char('G') | crossterm::event::KeyCode::End => {
+                    match state.focus {
+                        store_tui::Focus::List => state.go_bottom(),
+                        store_tui::Focus::Readme => state.scroll_readme_down(u16::MAX / 2),
+                    }
                 }
                 crossterm::event::KeyCode::Char('d')
                     if key
                         .modifiers
                         .contains(crossterm::event::KeyModifiers::CONTROL) =>
                 {
-                    state.scroll_readme_down(10);
+                    match state.focus {
+                        store_tui::Focus::List => state.move_down(10),
+                        store_tui::Focus::Readme => state.scroll_readme_down(10),
+                    }
                 }
                 crossterm::event::KeyCode::Char('u')
                     if key
                         .modifiers
                         .contains(crossterm::event::KeyModifiers::CONTROL) =>
                 {
-                    state.scroll_readme_up(10);
+                    match state.focus {
+                        store_tui::Focus::List => state.move_up(10),
+                        store_tui::Focus::Readme => state.scroll_readme_up(10),
+                    }
                 }
+                crossterm::event::KeyCode::Char('f')
+                    if key
+                        .modifiers
+                        .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                {
+                    match state.focus {
+                        store_tui::Focus::List => state.move_down(20),
+                        store_tui::Focus::Readme => state.scroll_readme_down(20),
+                    }
+                }
+                crossterm::event::KeyCode::Char('b')
+                    if key
+                        .modifiers
+                        .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                {
+                    match state.focus {
+                        store_tui::Focus::List => state.move_up(20),
+                        store_tui::Focus::Readme => state.scroll_readme_up(20),
+                    }
+                }
+
+                // ── Actions ──
                 crossterm::event::KeyCode::Char('s') => {
                     state.sort_mode = state.sort_mode.next();
                     state.sort_plugins();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2805,7 +2805,7 @@ async fn run_store() -> Result<()> {
                 crossterm::event::KeyCode::Char('G') | crossterm::event::KeyCode::End => {
                     match state.focus {
                         store_tui::Focus::List => state.go_bottom(),
-                        store_tui::Focus::Readme => state.scroll_readme_down(u16::MAX / 2),
+                        store_tui::Focus::Readme => state.scroll_readme_down(u16::MAX),
                     }
                 }
                 crossterm::event::KeyCode::Char('d')

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -7,6 +7,12 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Row, Table, TableState, Wrap},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Focus {
+    List,
+    Readme,
+}
+
 pub struct StoreTuiState {
     pub plugins: Vec<GitHubRepo>,
     pub table_state: TableState,
@@ -17,6 +23,8 @@ pub struct StoreTuiState {
     pub readme_scroll: u16,
     pub sort_mode: SortMode,
     pub message: Option<String>,
+    pub focus: Focus,
+    pub show_help: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -56,6 +64,8 @@ impl StoreTuiState {
             readme_scroll: 0,
             sort_mode: SortMode::Stars,
             message: None,
+            focus: Focus::List,
+            show_help: false,
         }
     }
 
@@ -127,6 +137,52 @@ impl StoreTuiState {
         self.table_state.select(Some(i));
         self.readme_content = None;
         self.readme_scroll = 0;
+    }
+
+    pub fn go_top(&mut self) {
+        if !self.plugins.is_empty() {
+            self.table_state.select(Some(0));
+            self.readme_content = None;
+            self.readme_scroll = 0;
+        }
+    }
+
+    pub fn go_bottom(&mut self) {
+        if !self.plugins.is_empty() {
+            self.table_state.select(Some(self.plugins.len() - 1));
+            self.readme_content = None;
+            self.readme_scroll = 0;
+        }
+    }
+
+    pub fn move_down(&mut self, n: usize) {
+        if self.plugins.is_empty() {
+            return;
+        }
+        let current = self.table_state.selected().unwrap_or(0);
+        let target = (current + n).min(self.plugins.len() - 1);
+        if target != current {
+            self.table_state.select(Some(target));
+            self.readme_content = None;
+            self.readme_scroll = 0;
+        }
+    }
+
+    pub fn move_up(&mut self, n: usize) {
+        let current = self.table_state.selected().unwrap_or(0);
+        let target = current.saturating_sub(n);
+        if target != current {
+            self.table_state.select(Some(target));
+            self.readme_content = None;
+            self.readme_scroll = 0;
+        }
+    }
+
+    pub fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            Focus::List => Focus::Readme,
+            Focus::Readme => Focus::List,
+        };
     }
 
     pub fn scroll_readme_down(&mut self, n: u16) {
@@ -235,7 +291,11 @@ impl StoreTuiState {
             Block::default()
                 .title(" Plugins ")
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow)),
+                .border_style(Style::default().fg(if self.focus == Focus::List {
+                    Color::Yellow
+                } else {
+                    Color::DarkGray
+                })),
         )
         .row_highlight_style(
             Style::default()
@@ -268,7 +328,11 @@ impl StoreTuiState {
                 Block::default()
                     .title(readme_title)
                     .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::Cyan)),
+                    .border_style(Style::default().fg(if self.focus == Focus::Readme {
+                        Color::Cyan
+                    } else {
+                        Color::DarkGray
+                    })),
             )
             .wrap(Wrap { trim: false })
             .scroll((self.readme_scroll, 0));
@@ -283,21 +347,24 @@ impl StoreTuiState {
                 Span::styled(":cancel", Style::default().fg(Color::DarkGray)),
             ]))
         } else {
+            let focus_label = match self.focus {
+                Focus::List => "readme",
+                Focus::Readme => "list",
+            };
             Paragraph::new(Line::from(vec![
                 Span::styled(" /", Style::default().fg(Color::Yellow)),
                 Span::styled(":search ", Style::default().fg(Color::DarkGray)),
-                Span::styled("j/k", Style::default().fg(Color::Yellow)),
-                Span::styled(":move ", Style::default().fg(Color::DarkGray)),
-                Span::styled("C-d/C-u", Style::default().fg(Color::Yellow)),
-                Span::styled(":scroll ", Style::default().fg(Color::DarkGray)),
-                Span::styled("s", Style::default().fg(Color::Yellow)),
-                Span::styled(":sort ", Style::default().fg(Color::DarkGray)),
+                Span::styled("Tab", Style::default().fg(Color::Yellow)),
+                Span::styled(
+                    format!(":{} ", focus_label),
+                    Style::default().fg(Color::DarkGray),
+                ),
                 Span::styled("Enter", Style::default().fg(Color::Yellow)),
                 Span::styled(":add ", Style::default().fg(Color::DarkGray)),
-                Span::styled("o", Style::default().fg(Color::Yellow)),
-                Span::styled(":open ", Style::default().fg(Color::DarkGray)),
-                Span::styled("R", Style::default().fg(Color::Yellow)),
-                Span::styled(":refresh ", Style::default().fg(Color::DarkGray)),
+                Span::styled("s", Style::default().fg(Color::Yellow)),
+                Span::styled(":sort ", Style::default().fg(Color::DarkGray)),
+                Span::styled("?", Style::default().fg(Color::Yellow)),
+                Span::styled(":help ", Style::default().fg(Color::DarkGray)),
                 Span::styled("q", Style::default().fg(Color::Yellow)),
                 Span::styled(":quit", Style::default().fg(Color::DarkGray)),
             ]))
@@ -306,6 +373,95 @@ impl StoreTuiState {
             footer.block(Block::default().borders(Borders::ALL)),
             chunks[2],
         );
+
+        // ── Help popup overlay ──
+        if self.show_help {
+            use ratatui::layout::Rect;
+            use ratatui::widgets::Clear;
+            let area = f.area();
+            let popup_w = 50u16.min(area.width.saturating_sub(4));
+            let popup_h = 18u16.min(area.height.saturating_sub(4));
+            let popup = Rect::new(
+                (area.width.saturating_sub(popup_w)) / 2,
+                (area.height.saturating_sub(popup_h)) / 2,
+                popup_w,
+                popup_h,
+            );
+            let help_lines = vec![
+                Line::from(vec![Span::styled(
+                    "  Navigation",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("  j / k       ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Move / scroll down / up", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  g / G       ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Go to top / bottom", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  C-d / C-u   ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Half page down / up", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  C-f / C-b   ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Full page down / up", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  Tab         ", Style::default().fg(Color::Yellow)),
+                    Span::styled(
+                        "Switch focus: list / readme",
+                        Style::default().fg(Color::White),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  /           ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Search plugins", Style::default().fg(Color::White)),
+                ]),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "  Actions",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("  Enter       ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Add plugin to config", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  o           ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Open in browser", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  s           ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Cycle sort mode", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  R           ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Refresh (clear cache)", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  q / Esc     ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Quit", Style::default().fg(Color::White)),
+                ]),
+            ];
+            f.render_widget(Clear, popup);
+            f.render_widget(
+                Paragraph::new(help_lines).block(
+                    Block::default()
+                        .title(" Help [?] ")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Yellow)),
+                ),
+                popup,
+            );
+        }
     }
 }
 
@@ -375,5 +531,52 @@ mod tests {
         assert_eq!(state.readme_scroll, 7);
         state.scroll_readme_up(100);
         assert_eq!(state.readme_scroll, 0);
+    }
+
+    #[test]
+    fn test_toggle_focus() {
+        let mut state = StoreTuiState::new();
+        assert_eq!(state.focus, Focus::List);
+        state.toggle_focus();
+        assert_eq!(state.focus, Focus::Readme);
+        state.toggle_focus();
+        assert_eq!(state.focus, Focus::List);
+    }
+
+    #[test]
+    fn test_go_top_and_bottom() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo("a", 100),
+            make_repo("b", 50),
+            make_repo("c", 10),
+        ]);
+        state.next();
+        state.next();
+        assert_eq!(state.table_state.selected(), Some(2));
+        state.go_top();
+        assert_eq!(state.table_state.selected(), Some(0));
+        state.go_bottom();
+        assert_eq!(state.table_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn test_move_down_up() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo("a", 100),
+            make_repo("b", 90),
+            make_repo("c", 80),
+            make_repo("d", 70),
+            make_repo("e", 60),
+        ]);
+        state.move_down(3);
+        assert_eq!(state.table_state.selected(), Some(3));
+        state.move_up(2);
+        assert_eq!(state.table_state.selected(), Some(1));
+        state.move_down(100);
+        assert_eq!(state.table_state.selected(), Some(4));
+        state.move_up(100);
+        assert_eq!(state.table_state.selected(), Some(0));
     }
 }

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -554,10 +554,17 @@ mod tests {
         state.next();
         state.next();
         assert_eq!(state.table_state.selected(), Some(2));
+        // seed readme state to verify it resets
+        state.readme_content = Some("old".to_string());
+        state.readme_scroll = 42;
         state.go_top();
         assert_eq!(state.table_state.selected(), Some(0));
+        assert!(state.readme_content.is_none());
+        assert_eq!(state.readme_scroll, 0);
         state.go_bottom();
         assert_eq!(state.table_state.selected(), Some(2));
+        assert!(state.readme_content.is_none());
+        assert_eq!(state.readme_scroll, 0);
     }
 
     #[test]
@@ -570,8 +577,12 @@ mod tests {
             make_repo("d", 70),
             make_repo("e", 60),
         ]);
+        state.readme_content = Some("test".to_string());
+        state.readme_scroll = 10;
         state.move_down(3);
         assert_eq!(state.table_state.selected(), Some(3));
+        assert!(state.readme_content.is_none());
+        assert_eq!(state.readme_scroll, 0);
         state.move_up(2);
         assert_eq!(state.table_state.selected(), Some(1));
         state.move_down(100);


### PR DESCRIPTION
## Summary

Align store TUI keybindings with the list TUI so users don't have to learn two different schemes.

### Changes

**Focus switching**
- `Tab` toggles focus between the plugin list pane and the readme pane
- Active pane has a highlighted border (Yellow for list, Cyan for readme), inactive is DarkGray
- Footer dynamically shows which pane Tab will switch to

**Focus-aware navigation**
- `j`/`k`, `g`/`G`, `Ctrl-d`/`Ctrl-u`, `Ctrl-f`/`Ctrl-b` now dispatch based on focus:
  - List focused → navigate plugin list (existing behavior + new g/G and Ctrl-f/b)
  - Readme focused → scroll readme preview
- Previously `Ctrl-d`/`Ctrl-u` always scrolled readme regardless of context

**Help popup**
- `?` toggles a help popup matching list TUI's layout (Navigation + Actions sections)

**New store_tui helpers**: `go_top`, `go_bottom`, `move_down`, `move_up`, `toggle_focus` — all unit-tested.

### Keybind parity summary

| Key | list | store (before) | store (after) |
|---|---|---|---|
| g / G | top/bottom | missing | top/bottom (focus-aware) |
| Ctrl-f / Ctrl-b | full page | missing | full page (focus-aware) |
| Ctrl-d / Ctrl-u | half page | readme only | focus-aware |
| Tab | n/a | n/a | toggle list/readme focus |
| ? | help popup | missing | help popup |

## Test plan

- [x] `cargo make check` (fmt / clippy / 183 tests) passes
- [ ] Manual: `rvpm store` → Tab switches focus, border color changes
- [ ] Manual: j/k/g/G/Ctrl-d/u/f/b work on list when list focused, readme when readme focused
- [ ] Manual: ? shows help popup with all keybinds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Focus-aware navigation between plugin list and README panes (Tab to toggle)
  * Help overlay (press ?)
  * Enhanced keyboard navigation (j/k, g/G, Ctrl‑d/Ctrl‑u, Ctrl‑f/Ctrl‑b, /n/N)
  * Enter adds the selected plugin to config (no immediate sync)
  * Visual focus indicators on active pane borders

* **Documentation**
  * Updated README and command docs with new TUI keys and behavior

* **Tests**
  * Added unit tests for navigation and focus behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->