### PR TITLE
fix(chezmoi): use --force on apply, add chezmoi support to init --write

### DIFF
--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -122,7 +122,7 @@ pub fn apply(wrote_to: &Path, target: &Path) {
         return;
     }
     let mut cmd = Command::new("chezmoi");
-    cmd.arg("apply").arg(target);
+    cmd.arg("apply").arg("--force").arg(target);
     match cmd.status() {
         Ok(s) if s.success() => {}
         Ok(s) => eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1310,12 +1310,11 @@ async fn run_init(write: bool) -> Result<()> {
     let init_lua_path = nvim_init_lua_path();
 
     if write {
-        let chezmoi_enabled = read_chezmoi_flag(&config_path);
-        let wp = chezmoi::write_path(chezmoi_enabled, &init_lua_path);
-        if let Some(parent) = wp.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        match write_init_lua_snippet(&wp, &snippet)? {
+        // `config` は既にパース済みなので再読込せずそのまま使う。
+        // 親ディレクトリ作成は write_init_lua_snippet が新規作成時に行うので不要。
+        let wp = chezmoi::write_path(config.options.chezmoi, &init_lua_path);
+        let result = write_init_lua_snippet(&wp, &snippet)?;
+        match result {
             WriteInitResult::Created => {
                 println!("\u{2714} Created {} with rvpm loader.", wp.display());
                 println!("  Snippet: {}", snippet);
@@ -1331,7 +1330,12 @@ async fn run_init(write: bool) -> Result<()> {
                 );
             }
         }
-        chezmoi::apply(&wp, &init_lua_path);
+        // 実際に source 側を書き換えたときだけ chezmoi apply する。変更なしの
+        // AlreadyConfigured で apply すると、target 側でユーザーが手で編集した
+        // 差分を上書きしてしまう恐れがある。
+        if result != WriteInitResult::AlreadyConfigured {
+            chezmoi::apply(&wp, &init_lua_path);
+        }
     } else {
         println!("-- Add this to your Neovim init.lua:");
         println!("{}", snippet);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1310,28 +1310,28 @@ async fn run_init(write: bool) -> Result<()> {
     let init_lua_path = nvim_init_lua_path();
 
     if write {
-        match write_init_lua_snippet(&init_lua_path, &snippet)? {
+        let chezmoi_enabled = read_chezmoi_flag(&config_path);
+        let wp = chezmoi::write_path(chezmoi_enabled, &init_lua_path);
+        if let Some(parent) = wp.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        match write_init_lua_snippet(&wp, &snippet)? {
             WriteInitResult::Created => {
-                println!(
-                    "\u{2714} Created {} with rvpm loader.",
-                    init_lua_path.display()
-                );
+                println!("\u{2714} Created {} with rvpm loader.", wp.display());
                 println!("  Snippet: {}", snippet);
             }
             WriteInitResult::Appended => {
-                println!(
-                    "\u{2714} Appended rvpm loader to {}.",
-                    init_lua_path.display()
-                );
+                println!("\u{2714} Appended rvpm loader to {}.", wp.display());
                 println!("  Snippet: {}", snippet);
             }
             WriteInitResult::AlreadyConfigured => {
                 println!(
                     "\u{2714} {} already references rvpm loader. No changes.",
-                    init_lua_path.display()
+                    wp.display()
                 );
             }
         }
+        chezmoi::apply(&wp, &init_lua_path);
     } else {
         println!("-- Add this to your Neovim init.lua:");
         println!("{}", snippet);


### PR DESCRIPTION
## Summary

Two chezmoi hardening fixes:

### 1. `chezmoi apply --force`

`chezmoi apply` can trigger an interactive merge dialog if the user has `merge.command` configured in their chezmoi config and the target file was modified outside chezmoi. Since rvpm just wrote the source file, the apply is authoritative — `--force` ensures no merge/prompt interrupts the flow.

### 2. `rvpm init --write` chezmoi support

`rvpm init --write` appends a `dofile(...)` snippet to Neovim's `init.lua`. This file is commonly chezmoi-managed. Now routes through `chezmoi::write_path` → writes to source → `chezmoi apply --force` to target, matching all other mutation paths.

## Test plan

- [x] `cargo make check` (fmt / clippy / 183 tests) passes
- [ ] Manual: `chezmoi = true` + `merge.command` set → `rvpm add` / `rvpm edit` complete without merge dialog
- [ ] Manual: `rvpm init --write` with chezmoi-managed `~/.config/nvim/init.lua` → snippet appears in both source and target