### PR TITLE
feat(store): local search, installed mark, markdown README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ let _permit = sem.acquire_owned().await.unwrap();
 | `config` | `run_config()` | `config.toml` を `$EDITOR` で直接開く (終了後に generate のみ実行。新規プラグイン追加した場合は `rvpm sync` 明示実行) |
 | `init [--write]` | `run_init()` | Neovim `init.lua` に loader.lua を繋ぐ `dofile(...)` スニペットを案内。`--write` で自動追記 (init.lua がなければ新規作成)。`$NVIM_APPNAME` を尊重 |
 | `list [--no-tui]` | `run_list()` | プラグイン一覧表示。デフォルトは TUI で `[S] sync / [u/U] update / [d] remove / [e] edit / [s] set / [?] help` のアクションキー対応。ナビ: `j/k/g/G/Ctrl-d/u/f/b`、検索: `/n/N`。`--no-tui` で pipe-friendly な plain text 出力 |
-| `store` | `run_store()` | GitHub `neovim-plugin` トピックのプラグインブラウザ TUI。`Tab` でリスト/README フォーカス切替。ナビキーはフォーカスに応じてリスト操作 or README スクロール。`Enter` で追加、`o` でブラウザ、`s` でソート切替、`?` でヘルプ |
+| `store` | `run_store()` | GitHub `neovim-plugin` トピックのプラグインブラウザ TUI (最大 300 件、3 ページ取得)。README は tui-markdown で GFM レンダ。行頭の `✓` でインストール済みを表示し、`Enter` で installed plugin は警告して add をスキップ。`/` ローカルインクリメンタル検索 (name + description + topics) + `n`/`N` でマッチジャンプ。`S` で GitHub API 検索。`Tab` でリスト/README フォーカス切替。`o` でブラウザ、`s` でソート切替、`R` でキャッシュクリア+再取得、`?` でヘルプ |
 
 **廃止コマンド:**
 - `status` → `list --no-tui` に統合 (plain text 出力で機能同等)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -139,6 +158,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -786,6 +814,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2561,6 +2599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,6 +2716,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2758,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2758,6 +2821,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "open"
@@ -2937,10 +3022,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3046,6 +3150,15 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -3752,6 +3865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +4002,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -4051,12 +4197,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4064,6 +4212,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -4281,11 +4439,13 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
 dependencies = [
+ "ansi-to-tui",
  "itertools",
  "pretty_assertions",
  "pulldown-cmark",
  "ratatui-core",
  "rstest",
+ "syntect",
  "tracing",
 ]
 
@@ -5087,6 +5247,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "tui-markdown",
+ "unicode-width",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +843,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +879,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -880,6 +904,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1830,6 +1863,12 @@ dependencies = [
  "gix-traverse",
  "parking_lot",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -2943,6 +2982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,6 +2999,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2969,6 +3027,25 @@ checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.11.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quinn"
@@ -3250,6 +3327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,6 +3387,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3437,6 +3549,7 @@ dependencies = [
  "tokio",
  "toml",
  "toml_edit",
+ "tui-markdown",
  "walkdir",
 ]
 
@@ -4132,7 +4245,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4151,6 +4276,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-markdown"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e766339aabad4528c3fccddf4acf03bc2b7ae6642def41e43c7af1a11f183122"
+dependencies = [
+ "itertools",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui-core",
+ "rstest",
+ "tracing",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +4300,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"
@@ -4942,6 +5087,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,10 @@ toml = "1.1"
 toml_edit = "0.25"
 
 # Markdown rendering (for store TUI README preview).
-# default-features = false to avoid pulling syntect/ansi-to-tui (heavy, MB-scale).
-tui-markdown = { version = "0.3", default-features = false }
+# `highlight-code` brings in syntect + ansi-to-tui (~4 MB of syntax / theme
+# data) but is the only way to make fenced code blocks readable — without it
+# they render as plain prose indistinguishable from text paragraphs.
+tui-markdown = { version = "0.3", features = ["highlight-code"] }
 
 # HTTP client (for store)
 # default-features = false to pin TLS backend to `rustls` (avoid native-tls /

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1.0"
 toml = "1.1"
 toml_edit = "0.25"
 
+# Markdown rendering (for store TUI README preview).
+# default-features = false to avoid pulling syntect/ansi-to-tui (heavy, MB-scale).
+tui-markdown = { version = "0.3", default-features = false }
+
 # HTTP client (for store)
 # default-features = false to pin TLS backend to `rustls` (avoid native-tls /
 # OpenSSL transitively). Re-add the non-TLS pieces of reqwest's default feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ toml_edit = "0.25"
 # data) but is the only way to make fenced code blocks readable — without it
 # they render as plain prose indistinguishable from text paragraphs.
 tui-markdown = { version = "0.3", features = ["highlight-code"] }
+# post-wrap row count の計算用 (store TUI の README scroll clamp)。
+unicode-width = "0.2"
 
 # HTTP client (for store)
 # default-features = false to pin TLS backend to `rustls` (avoid native-tls /

--- a/README.md
+++ b/README.md
@@ -502,9 +502,13 @@ Run `rvpm <command> --help` for flag-level details.
 ### `rvpm store` — plugin discovery TUI
 
 Browse, search, and install plugins from GitHub without leaving the terminal.
-`rvpm store` queries the GitHub Search API for repositories tagged with the
-`neovim-plugin` topic, displays them in a split-pane TUI, and fetches each
-plugin's `README.md` on demand for preview.
+`rvpm store` fetches up to ~300 repositories tagged with the `neovim-plugin`
+topic, displays them in a split-pane TUI with a GitHub-flavored markdown
+preview, and installs the selected plugin into your `config.toml` on `Enter`.
+
+Plugins already listed in `config.toml` are marked with a green `✓` at the
+start of the row; pressing `Enter` on an installed plugin shows a warning
+instead of adding a duplicate.
 
 <details>
 <summary><b>Key bindings</b></summary>
@@ -523,13 +527,18 @@ plugin list and the README preview pane.
 | Key | Action |
 |---|---|
 | `Tab` | Switch focus between list and README |
-| `/` | Search (`topic:neovim-plugin <query>` against GitHub Search API) |
-| `Enter` | Add the selected plugin to `config.toml` |
+| `/` | Local incremental search over `name + description + topics` |
+| `n` / `N` | Jump to next / previous search match |
+| `S` | GitHub API search (`topic:neovim-plugin <query>`, replaces list) |
+| `Enter` | Add the selected plugin to `config.toml` (warns if already installed) |
 | `o` | Open the plugin's GitHub page in your default browser |
 | `s` | Cycle sort mode (`stars` / `updated` / `name`) |
 | `R` | Clear the search cache and re-fetch |
 | `?` | Toggle help popup |
 | `q` / `Esc` | Quit |
+
+**Legend:** `✓` in the leftmost column means the plugin is already in your
+`config.toml`. Topics are shown in the rightmost column (`#lua #ui ...`).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,8 @@ plugin list and the README preview pane.
 | `s` | Cycle sort mode (`stars` / `updated` / `name`) |
 | `R` | Clear the search cache and re-fetch |
 | `?` | Toggle help popup |
-| `q` / `Esc` | Quit |
+| `q` | Quit |
+| `Esc` | Cancel active input (`/` or `S`) when in a search mode; quit otherwise |
 
 **Legend:** `✓` in the leftmost column means the plugin is already in your
 `config.toml`. Topics are shown in the rightmost column (`#lua #ui ...`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -2659,20 +2659,68 @@ fn build_plugin_scripts(
 }
 
 /// `rvpm store` — GitHub からプラグインを検索して追加する TUI。
+/// Plugin URL を GitHub の `owner/repo` 形式 (小文字) に正規化する。
+/// GitHub の `full_name` は大文字小文字非依存なので lowercase で揃える。
+/// - `"owner/repo"` → `Some("owner/repo")`
+/// - `"https://github.com/Owner/Repo(.git)?"` → `Some("owner/repo")`
+/// - `"git@github.com:Owner/Repo.git"` → `Some("owner/repo")`
+/// - GitHub 以外 (gitlab 等) → None
+fn installed_full_name(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches(".git");
+    // SSH 形式: git@github.com:owner/repo
+    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 2 {
+            return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
+        }
+        return None;
+    }
+    // HTTPS/HTTP
+    for prefix in ["https://github.com/", "http://github.com/"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let parts: Vec<&str> = rest.split('/').collect();
+            if parts.len() >= 2 {
+                return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
+            }
+            return None;
+        }
+    }
+    // 別ホストの URL は GitHub ではないので None
+    if trimmed.contains("://") {
+        return None;
+    }
+    // `owner/repo` 形式 (スキーム無し)
+    if trimmed.contains('/') && !trimmed.contains(' ') {
+        let parts: Vec<&str> = trimmed.split('/').collect();
+        if parts.len() == 2 {
+            return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
+        }
+    }
+    None
+}
+
 async fn run_store() -> Result<()> {
     use crate::store_tui::StoreTuiState;
 
-    // cache_root を config から解決 (options.cache_root を尊重)
+    // cache_root を config から解決 (options.cache_root を尊重)。
+    // 同時に config.plugins から installed 集合を構築する。
     let config_path = rvpm_config_path();
-    let cache_root = if config_path.exists() {
+    let (cache_root, installed) = if config_path.exists() {
         let toml_content = std::fs::read_to_string(&config_path)?;
         let config = parse_config(&toml_content)?;
-        resolve_cache_root(config.options.cache_root.as_deref())
+        let cache = resolve_cache_root(config.options.cache_root.as_deref());
+        let set: std::collections::HashSet<String> = config
+            .plugins
+            .iter()
+            .filter_map(|p| installed_full_name(&p.url))
+            .collect();
+        (cache, set)
     } else {
-        resolve_cache_root(None)
+        (resolve_cache_root(None), std::collections::HashSet::new())
     };
 
     let mut state = StoreTuiState::new();
+    state.installed = installed;
 
     // 初期表示: 人気プラグインをバックグラウンドで取得
     let cache_root_bg = cache_root.clone();
@@ -2733,14 +2781,26 @@ async fn run_store() -> Result<()> {
                 continue;
             }
 
+            // `/` ローカルインクリメンタル検索モード
             if state.search_mode {
                 match key.code {
-                    crossterm::event::KeyCode::Esc => {
-                        state.search_mode = false;
-                    }
+                    crossterm::event::KeyCode::Esc => state.search_cancel(),
+                    crossterm::event::KeyCode::Enter => state.search_confirm(),
+                    crossterm::event::KeyCode::Backspace => state.search_backspace(),
+                    crossterm::event::KeyCode::Char(c) => state.search_type(c),
+                    _ => {}
+                }
+                continue;
+            }
+
+            // `S` GitHub API 検索モード (旧 `/` の挙動)
+            if state.api_search_mode {
+                match key.code {
+                    crossterm::event::KeyCode::Esc => state.search_cancel(),
                     crossterm::event::KeyCode::Enter => {
-                        state.search_mode = false;
+                        state.api_search_mode = false;
                         let query = state.search_input.clone();
+                        state.search_input.clear();
                         state.message = Some(format!("Searching '{}'...", query));
                         terminal.draw(|f| state.draw(f))?;
                         let cache_root_bg = cache_root.clone();
@@ -2782,9 +2842,16 @@ async fn run_store() -> Result<()> {
                     state.show_help = !state.show_help;
                 }
                 crossterm::event::KeyCode::Char('/') => {
-                    state.search_mode = true;
-                    state.search_input.clear();
-                    state.message = None;
+                    state.start_search();
+                }
+                crossterm::event::KeyCode::Char('S') => {
+                    state.start_api_search();
+                }
+                crossterm::event::KeyCode::Char('n') => {
+                    state.search_next();
+                }
+                crossterm::event::KeyCode::Char('N') => {
+                    state.search_prev();
                 }
 
                 // ── Navigation: focus-aware ──
@@ -2887,8 +2954,12 @@ async fn run_store() -> Result<()> {
                     }
                 }
                 crossterm::event::KeyCode::Enter => {
-                    // config.toml に追加
-                    if let Some(repo) = state.selected_repo() {
+                    // config.toml に追加 (installed なら警告のみ)
+                    if let Some(repo) = state.selected_repo().cloned() {
+                        if state.is_installed(&repo) {
+                            state.message = Some(format!("already installed: {}", repo.full_name));
+                            continue;
+                        }
                         let url = repo.full_name.clone();
                         let _ = disable_raw_mode();
                         let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
@@ -2898,6 +2969,7 @@ async fn run_store() -> Result<()> {
                         // run_add の最小版: config.toml に追記して sync
                         let result =
                             run_add(url.clone(), None, None, None, None, None, None, None).await;
+                        let added = result.is_ok();
                         match result {
                             Ok(_) => println!("Added {} successfully!", url),
                             Err(e) => eprintln!("Failed to add {}: {}", url, e),
@@ -2924,7 +2996,12 @@ async fn run_store() -> Result<()> {
                         // 先に show_cursor() した状態を戻す。
                         terminal.clear()?;
                         terminal.hide_cursor()?;
-                        state.message = Some(format!("Added {}", url));
+                        if added {
+                            state.mark_installed(&repo);
+                            state.message = Some(format!("Added {}", url));
+                        } else {
+                            state.message = Some(format!("Failed: {}", url));
+                        }
                     }
                 }
                 _ => {}
@@ -2945,6 +3022,51 @@ mod tests {
     use crate::loader::PluginScripts;
     use tempfile::tempdir;
     use toml_edit::DocumentMut;
+
+    #[test]
+    fn test_installed_full_name_owner_repo() {
+        assert_eq!(
+            installed_full_name("folke/snacks.nvim"),
+            Some("folke/snacks.nvim".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installed_full_name_https_url_with_git_suffix() {
+        assert_eq!(
+            installed_full_name("https://github.com/Owner/Repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installed_full_name_https_url_without_git_suffix() {
+        assert_eq!(
+            installed_full_name("https://github.com/nvim-lua/plenary.nvim"),
+            Some("nvim-lua/plenary.nvim".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installed_full_name_ssh_url() {
+        assert_eq!(
+            installed_full_name("git@github.com:Owner/Repo.git"),
+            Some("owner/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installed_full_name_non_github_returns_none() {
+        assert_eq!(installed_full_name("https://gitlab.com/owner/repo"), None);
+    }
+
+    #[test]
+    fn test_installed_full_name_case_normalized() {
+        assert_eq!(
+            installed_full_name("Folke/Snacks.NVIM"),
+            Some("folke/snacks.nvim".to_string())
+        );
+    }
 
     #[test]
     fn test_update_filters_by_query() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2787,6 +2787,10 @@ async fn run_store() -> Result<()> {
                 state.readme_loading = true;
                 state.readme_content = None;
                 state.readme_scroll = 0;
+                // Clear widget だけでは ansi-to-tui の styled span の残骸が
+                // 一部ホスト (zellij 等) で残ることがあるため、選択変更時は
+                // ratatui の内部バッファを明示的に無効化して全セル再描画を強制する。
+                terminal.clear()?;
                 let tx = readme_tx.clone();
                 let cache_root_bg = cache_root.clone();
                 tokio::task::spawn_blocking(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2909,7 +2909,7 @@ async fn run_store() -> Result<()> {
                 crossterm::event::KeyCode::Char('G') | crossterm::event::KeyCode::End => {
                     match state.focus {
                         store_tui::Focus::List => state.go_bottom(),
-                        store_tui::Focus::Readme => state.scroll_readme_down(u16::MAX),
+                        store_tui::Focus::Readme => state.scroll_readme_to_bottom(),
                     }
                 }
                 crossterm::event::KeyCode::Char('d')

--- a/src/main.rs
+++ b/src/main.rs
@@ -2764,8 +2764,15 @@ async fn run_store() -> Result<()> {
     // README を非同期で取得するためのチャネル
     let (readme_tx, mut readme_rx) = tokio::sync::mpsc::channel::<(String, String)>(1);
     let mut last_selected: Option<String> = None;
+    // README pane の scroll が変化したら terminal.clear() して diff を無効化する。
+    // highlight-code の styled span が zellij 等で残骸を残す問題への belt-and-suspenders。
+    let mut last_readme_scroll: u16 = state.readme_scroll;
 
     loop {
+        if state.readme_scroll != last_readme_scroll {
+            terminal.clear()?;
+            last_readme_scroll = state.readme_scroll;
+        }
         terminal.draw(|f| state.draw(f))?;
 
         // README 非同期受信

--- a/src/main.rs
+++ b/src/main.rs
@@ -2666,7 +2666,12 @@ fn build_plugin_scripts(
 /// - `"git@github.com:Owner/Repo.git"` → `Some("owner/repo")`
 /// - GitHub 以外 (gitlab 等) → None
 fn installed_full_name(url: &str) -> Option<String> {
-    let trimmed = url.trim().trim_end_matches(".git");
+    // `.git` と末尾 `/` の順序が揺れるケースを両方受け付ける
+    let trimmed = url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
     // SSH 形式: git@github.com:owner/repo
     if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
         let parts: Vec<&str> = rest.split('/').collect();
@@ -2704,19 +2709,38 @@ async fn run_store() -> Result<()> {
 
     // cache_root を config から解決 (options.cache_root を尊重)。
     // 同時に config.plugins から installed 集合を構築する。
+    // resilience 原則: config.toml が壊れていても store TUI は defaults で開く。
     let config_path = rvpm_config_path();
-    let (cache_root, installed) = if config_path.exists() {
-        let toml_content = std::fs::read_to_string(&config_path)?;
-        let config = parse_config(&toml_content)?;
-        let cache = resolve_cache_root(config.options.cache_root.as_deref());
-        let set: std::collections::HashSet<String> = config
-            .plugins
-            .iter()
-            .filter_map(|p| installed_full_name(&p.url))
-            .collect();
-        (cache, set)
-    } else {
-        (resolve_cache_root(None), std::collections::HashSet::new())
+    let (cache_root, installed) = 'resolve: {
+        if !config_path.exists() {
+            break 'resolve (resolve_cache_root(None), std::collections::HashSet::new());
+        }
+        let toml_content = match std::fs::read_to_string(&config_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("\u{26a0} failed to read {}: {}", config_path.display(), e);
+                break 'resolve (resolve_cache_root(None), std::collections::HashSet::new());
+            }
+        };
+        match parse_config(&toml_content) {
+            Ok(config) => {
+                let cache = resolve_cache_root(config.options.cache_root.as_deref());
+                let set: std::collections::HashSet<String> = config
+                    .plugins
+                    .iter()
+                    .filter_map(|p| installed_full_name(&p.url))
+                    .collect();
+                (cache, set)
+            }
+            Err(e) => {
+                eprintln!(
+                    "\u{26a0} failed to parse {}: {}. Opening store with defaults.",
+                    config_path.display(),
+                    e
+                );
+                (resolve_cache_root(None), std::collections::HashSet::new())
+            }
+        }
     };
 
     let mut state = StoreTuiState::new();
@@ -3065,6 +3089,23 @@ mod tests {
         assert_eq!(
             installed_full_name("Folke/Snacks.NVIM"),
             Some("folke/snacks.nvim".to_string())
+        );
+    }
+
+    #[test]
+    fn test_installed_full_name_trailing_slash() {
+        // `owner/repo/`, `.../repo.git/`, `.../repo/` をすべて許容する
+        assert_eq!(
+            installed_full_name("folke/snacks.nvim/"),
+            Some("folke/snacks.nvim".to_string())
+        );
+        assert_eq!(
+            installed_full_name("https://github.com/Owner/Repo/"),
+            Some("owner/repo".to_string())
+        );
+        assert_eq!(
+            installed_full_name("https://github.com/Owner/Repo.git/"),
+            Some("owner/repo".to_string())
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2820,7 +2820,12 @@ async fn run_store() -> Result<()> {
             // `S` GitHub API 検索モード (旧 `/` の挙動)
             if state.api_search_mode {
                 match key.code {
-                    crossterm::event::KeyCode::Esc => state.search_cancel(),
+                    crossterm::event::KeyCode::Esc => {
+                        // API 入力だけキャンセル。既存の local `/` 検索の
+                        // pattern / matches は保持して n/N を引き続き使えるようにする。
+                        state.api_search_mode = false;
+                        state.search_input.clear();
+                    }
                     crossterm::event::KeyCode::Enter => {
                         state.api_search_mode = false;
                         let query = state.search_input.clone();

--- a/src/store.rs
+++ b/src/store.rs
@@ -87,8 +87,12 @@ fn is_cache_valid(path: &Path, max_age: std::time::Duration) -> bool {
 
 const SEARCH_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(86400); // 24h
 const README_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(604800); // 7 days
+/// 取得する最大ページ数 (100 件/ページ)。unauth rate limit (60 req/h) を食い潰さない
+/// 範囲に抑える。3 ページ = 300 件で体感上十分。
+const MAX_PAGES: u32 = 3;
 
 /// GitHub Search API でプラグインを検索。キャッシュがあればそれを返す。
+/// 複数ページ取得 (最大 `MAX_PAGES` * 100 件) し、合算結果をキャッシュする。
 pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>> {
     // キャッシュチェック
     let cache_path = search_cache_path(cache_root, query);
@@ -110,25 +114,60 @@ pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>>
         .user_agent("rvpm")
         .build()?;
 
-    let resp: SearchResponse = client
-        .get("https://api.github.com/search/repositories")
-        .query(&[
-            ("q", search_query.as_str()),
-            ("sort", "stars"),
-            ("order", "desc"),
-            ("per_page", "100"),
-        ])
-        .send()?
-        .json()?;
+    let mut all_items: Vec<GitHubRepo> = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let page_str = page.to_string();
+        // resilience: ページ途中で失敗しても、既に取得済みの結果は返す
+        let resp = match client
+            .get("https://api.github.com/search/repositories")
+            .query(&[
+                ("q", search_query.as_str()),
+                ("sort", "stars"),
+                ("order", "desc"),
+                ("per_page", "100"),
+                ("page", page_str.as_str()),
+            ])
+            .send()
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if all_items.is_empty() {
+                    return Err(e.into());
+                }
+                eprintln!("\u{26a0} GitHub search page {} failed: {}", page, e);
+                break;
+            }
+        };
+
+        let parsed: SearchResponse = match resp.json() {
+            Ok(p) => p,
+            Err(e) => {
+                if all_items.is_empty() {
+                    return Err(e.into());
+                }
+                eprintln!("\u{26a0} GitHub search page {} parse failed: {}", page, e);
+                break;
+            }
+        };
+
+        if parsed.items.is_empty() {
+            break;
+        }
+        let got_full_page = parsed.items.len() >= 100;
+        all_items.extend(parsed.items);
+        if !got_full_page {
+            break;
+        }
+    }
 
     // キャッシュに保存
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    let json = serde_json::to_string(&resp.items)?;
+    let json = serde_json::to_string(&all_items)?;
     std::fs::write(&cache_path, json).ok();
 
-    Ok(resp.items)
+    Ok(all_items)
 }
 
 /// 人気プラグインのランキングを取得。

--- a/src/store.rs
+++ b/src/store.rs
@@ -115,9 +115,11 @@ pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>>
         .build()?;
 
     let mut all_items: Vec<GitHubRepo> = Vec::new();
+    // ページ境界で失敗した場合、取得済みの部分結果は呼び出し元に返すが、
+    // 不完全なデータは 24h キャッシュに書かない (次回 TUI 復帰時に再試行させる)。
+    let mut cache_complete = true;
     for page in 1..=MAX_PAGES {
         let page_str = page.to_string();
-        // resilience: ページ途中で失敗しても、既に取得済みの結果は返す
         let resp = match client
             .get("https://api.github.com/search/repositories")
             .query(&[
@@ -134,7 +136,8 @@ pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>>
                 if all_items.is_empty() {
                     return Err(e.into());
                 }
-                eprintln!("\u{26a0} GitHub search page {} failed: {}", page, e);
+                // TUI が active かもしれないので eprintln! はしない。
+                cache_complete = false;
                 break;
             }
         };
@@ -145,12 +148,13 @@ pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>>
                 if all_items.is_empty() {
                     return Err(e.into());
                 }
-                eprintln!("\u{26a0} GitHub search page {} parse failed: {}", page, e);
+                cache_complete = false;
                 break;
             }
         };
 
         if parsed.items.is_empty() {
+            // 正常終了 (ページ尽き)
             break;
         }
         let got_full_page = parsed.items.len() >= 100;
@@ -160,12 +164,15 @@ pub fn search_plugins(cache_root: &Path, query: &str) -> Result<Vec<GitHubRepo>>
         }
     }
 
-    // キャッシュに保存
-    if let Some(parent) = cache_path.parent() {
-        std::fs::create_dir_all(parent).ok();
+    // 完全取得できたときだけキャッシュに保存
+    if cache_complete && !all_items.is_empty() {
+        if let Some(parent) = cache_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        if let Ok(json) = serde_json::to_string(&all_items) {
+            std::fs::write(&cache_path, json).ok();
+        }
     }
-    let json = serde_json::to_string(&all_items)?;
-    std::fs::write(&cache_path, json).ok();
 
     Ok(all_items)
 }

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -150,6 +150,29 @@ fn parse_tag_name(tag: &str) -> String {
         .collect()
 }
 
+/// リスト行のセル表示用に問題のある Unicode スカラを落とす。
+///
+/// nerd font の Private Use Area (U+E000-F8FF 等) は `unicode-width` が幅 1 と
+/// 答える一方で、nerd font を積んだ端末は 2 セルで描画するため、テーブル内に
+/// 1 つでも混じると後続の列が累積的にずれてしまう (terminal と ratatui の
+/// 合意が崩れる)。見た目より整列を優先して、該当レンジを抜く。
+fn sanitize_cell_text(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            let code = *c as u32;
+            // BMP PUA
+            !(0xE000..=0xF8FF).contains(&code)
+                // Supplementary PUA-A / PUA-B
+                && !(0xF0000..=0xFFFFD).contains(&code)
+                && !(0x100000..=0x10FFFD).contains(&code)
+                // Variation selectors (FE00-FE0F, E0100-E01EF) — nerd font 絵文字の
+                // 後ろにくっついて幅計算を乱すことがある。
+                && !(0xFE00..=0xFE0F).contains(&code)
+                && !(0xE0100..=0xE01EF).contains(&code)
+        })
+        .collect()
+}
+
 /// `<img ... alt="..." ...>` から `alt` 属性の値を取り出す。
 /// クォート必須、エスケープ非対応。UTF-8 安全 (`=` / クォートは ASCII)。
 fn extract_alt(tag: &str) -> Option<String> {
@@ -593,7 +616,9 @@ impl StoreTuiState {
             .iter()
             .map(|repo| {
                 let desc = repo.description.as_deref().unwrap_or("");
-                let desc_truncated: String = desc.chars().take(40).collect();
+                // PUA / VS 除去してから char 数で truncate。これで terminal 描画幅と
+                // ratatui の見積もり幅が一致し、以降の列が累積ずれしない。
+                let desc_truncated: String = sanitize_cell_text(desc).chars().take(40).collect();
                 let installed_cell = if self.is_installed(repo) {
                     ratatui::widgets::Cell::from(Span::styled(
                         "\u{2713}",
@@ -602,19 +627,21 @@ impl StoreTuiState {
                 } else {
                     ratatui::widgets::Cell::from(" ")
                 };
-                let topics_str: String = repo
-                    .topics
-                    .iter()
-                    .take(3)
-                    .map(|t| format!("#{}", t))
-                    .collect::<Vec<_>>()
-                    .join(" ");
+                let topics_str: String = sanitize_cell_text(
+                    &repo
+                        .topics
+                        .iter()
+                        .take(3)
+                        .map(|t| format!("#{}", t))
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                );
+                let name_str = sanitize_cell_text(repo.plugin_name());
                 Row::new(vec![
                     installed_cell,
                     ratatui::widgets::Cell::from(format!(" \u{2605}{}", repo.stars_display()))
                         .style(Style::default().fg(Color::Yellow)),
-                    ratatui::widgets::Cell::from(repo.plugin_name().to_string())
-                        .style(Style::default().fg(Color::White)),
+                    ratatui::widgets::Cell::from(name_str).style(Style::default().fg(Color::White)),
                     ratatui::widgets::Cell::from(desc_truncated)
                         .style(Style::default().fg(Color::DarkGray)),
                     ratatui::widgets::Cell::from(topics_str)
@@ -1262,6 +1289,34 @@ mod tests {
         // markdown のインラインコード/カスタム要素は残す
         let out = strip_common_html("<mark>note</mark>");
         assert!(out.contains("<mark>"));
+    }
+
+    // ───── sanitize_cell_text ─────
+
+    #[test]
+    fn test_sanitize_strips_nerd_font_pua() {
+        let input = "icon \u{e801} here";
+        assert_eq!(sanitize_cell_text(input), "icon  here");
+    }
+
+    #[test]
+    fn test_sanitize_strips_variation_selectors() {
+        // U+FE0F (emoji presentation selector) — しばしば width 計算を乱す
+        let input = "gear\u{FE0F} icon";
+        assert_eq!(sanitize_cell_text(input), "gear icon");
+    }
+
+    #[test]
+    fn test_sanitize_keeps_ascii() {
+        let input = "A collection of small qol plugins for Neovim";
+        assert_eq!(sanitize_cell_text(input), input);
+    }
+
+    #[test]
+    fn test_sanitize_keeps_japanese_and_standard_emoji() {
+        // 日本語と通常絵文字 (unicode-width が正しく 2 と判定するもの) は残す
+        let input = "プラグイン 🎉 ready";
+        assert_eq!(sanitize_cell_text(input), input);
     }
 
     #[test]

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -566,7 +566,11 @@ impl StoreTuiState {
             .unwrap_or_default();
 
         let cleaned = strip_common_html(&body);
-        self.readme_prepared = format!("{}{}", topics_prefix, cleaned);
+        // README 本文にも nerd font の Private Use Area 文字が混じることがあり、
+        // `unicode-width` は幅 1 と答えるが terminal は 2 セルで描画するため
+        // tui-markdown の Line 折返しが壊れる。リスト側と同じく PUA / VS を除去する。
+        let sanitized = sanitize_cell_text(&cleaned);
+        self.readme_prepared = format!("{}{}", topics_prefix, sanitized);
         // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
         // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
         // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -530,13 +530,12 @@ impl StoreTuiState {
 
         let cleaned = strip_common_html(&body);
         self.readme_prepared = format!("{}{}", topics_prefix, cleaned);
-        // pre-wrap の改行数で近似。wrap 後は増えるが scroll 上限としては十分。
-        self.readme_line_count = self
-            .readme_prepared
-            .lines()
-            .count()
-            .try_into()
-            .unwrap_or(u16::MAX);
+        // tui-markdown が実際に生成する Line 数で clamp する。`\n` を数えると
+        // paragraph 内のソフトラップ (改行はあるがブロック境界ではない) まで
+        // カウントしてしまい、G が実内容より遥かに下へ飛ぶ原因になる。
+        // pulldown-cmark + tui-markdown の block 整形を通した後の行数が正確。
+        let rendered = tui_markdown::from_str(&self.readme_prepared);
+        self.readme_line_count = rendered.lines.len().try_into().unwrap_or(u16::MAX);
         self.readme_prepared_key = Some(key);
     }
 

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -570,11 +570,22 @@ impl StoreTuiState {
         );
         f.render_widget(title, chunks[0]);
 
-        // ── Main: left (list) + right (readme) ──
-        let main_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-            .split(chunks[1]);
+        // ── Main: list + readme ──
+        // 横幅が狭い terminal では side-by-side だと plugin 名が潰れるので、
+        // 一定幅未満のときは縦積み (list: 上 / readme: 下) に切り替える。
+        let total_width = f.area().width;
+        let side_by_side = total_width >= 160;
+        let main_chunks = if side_by_side {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+                .split(chunks[1])
+        } else {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(chunks[1])
+        };
 
         // Left: plugin list
         let rows: Vec<Row> = self
@@ -612,14 +623,24 @@ impl StoreTuiState {
             })
             .collect();
 
+        // plugin name を最優先にするため、name と desc は Min 制約で伸縮、
+        // topics は終端で Length、stars/installed は固定。side_by_side のときは
+        // 横幅が限られるため topics を短めに (18)、vertical 積みのときは余裕あるので広めに (30)。
+        let name_col = Constraint::Min(15);
+        let desc_col = Constraint::Min(20);
+        let topics_col = if side_by_side {
+            Constraint::Length(18)
+        } else {
+            Constraint::Length(30)
+        };
         let table = Table::new(
             rows,
             [
                 Constraint::Length(2),
                 Constraint::Length(8),
-                Constraint::Length(30),
-                Constraint::Min(20),
-                Constraint::Length(24),
+                name_col,
+                desc_col,
+                topics_col,
             ],
         )
         .block(

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -770,7 +770,16 @@ impl StoreTuiState {
         // HTML strip + topics 結合 + post-wrap 行数はキャッシュされるので、
         // draw() ごとのコストは tui_markdown::from_str のパースだけ。
         self.ensure_readme_prepared();
-        let rendered = tui_markdown::from_str(&self.readme_prepared);
+        let mut rendered = tui_markdown::from_str(&self.readme_prepared);
+        // highlight-code 由来の背景色付き Span が scroll 時に一部ホストで
+        // 残骸を残すので、前景色だけ残して背景は既定に戻す。fg による
+        // syntax highlighting は維持されるので可読性は保たれる。
+        for line in &mut rendered.lines {
+            for span in &mut line.spans {
+                span.style.bg = None;
+            }
+            line.style.bg = None;
+        }
 
         let readme_title = self
             .selected_repo()

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -664,6 +664,11 @@ impl StoreTuiState {
             )
             .wrap(Wrap { trim: false })
             .scroll((self.readme_scroll, 0));
+        // Paragraph は inner area の未使用セルを空白で埋めないため、前フレームの
+        // 長い README の残骸が残ることがある (特に zellij のようにターミナルが
+        // セル状態を厳密に保持するホストで顕在化する)。Clear でペイン全体を空白に
+        // してから Paragraph を重ねる。
+        f.render_widget(ratatui::widgets::Clear, main_chunks[1]);
         f.render_widget(readme, main_chunks[1]);
 
         // ── Footer ──

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -178,9 +178,25 @@ fn wrap_tables_as_code_blocks(input: &str) -> String {
     let lines: Vec<&str> = input.lines().collect();
     let mut out = String::new();
     let mut i = 0;
+    // fenced code block の中では table 検出しない (README のコードサンプルが
+    // `| a | b |` を含んでいた場合、二重 wrap で原 fence を壊してしまうため)。
+    // ``` / ~~~ 行を見たら状態を反転させる。
+    let mut in_fence = false;
     while i < lines.len() {
         let line = lines[i];
-        if is_table_row(line) && i + 1 < lines.len() && is_table_separator(lines[i + 1]) {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            out.push_str(line);
+            out.push('\n');
+            i += 1;
+            continue;
+        }
+        if !in_fence
+            && is_table_row(line)
+            && i + 1 < lines.len()
+            && is_table_separator(lines[i + 1])
+        {
             // 連続する table 行を末尾まで収集
             let mut end = i + 2;
             while end < lines.len() && is_table_row(lines[end]) {
@@ -400,6 +416,11 @@ impl StoreTuiState {
                     .cmp(b.plugin_name())
                     .then_with(|| a.full_name.cmp(&b.full_name))
             }),
+        }
+        // sort で plugins の順序が変わると search_matches のインデックスが無効化されるので、
+        // アクティブな local `/` 検索があれば走り直して n/N が破綻しないようにする。
+        if let Some(pat) = self.search_pattern.clone() {
+            self.run_local_search(&pat);
         }
     }
 
@@ -1621,6 +1642,73 @@ outro
         assert!(!out.contains("```"));
         assert!(out.contains("Hello"));
         assert!(out.contains("World"));
+    }
+
+    #[test]
+    fn test_wrap_tables_skips_inside_fenced_code_block() {
+        // README のコードサンプル内に pipe table があっても二重 wrap しない
+        let input = "\
+intro
+
+```markdown
+| col | other |
+| --- | --- |
+| a | b |
+```
+
+outro
+";
+        let out = wrap_tables_as_code_blocks(input);
+        // ``` の数は元と同じ 2 (開始 + 終了) で、新たな fence は足されていない
+        assert_eq!(out.matches("```").count(), 2);
+        assert!(out.contains("```markdown"));
+    }
+
+    #[test]
+    fn test_wrap_tables_still_wraps_tables_outside_fences() {
+        let input = "\
+```lua
+print(1)
+```
+
+| a | b |
+| --- | --- |
+| 1 | 2 |
+";
+        let out = wrap_tables_as_code_blocks(input);
+        // 内側 (lua コード) の ``` と新たに足された ```text / ``` で計 4 個
+        assert_eq!(out.matches("```").count(), 4);
+        assert!(out.contains("```text"));
+    }
+
+    #[test]
+    fn test_sort_rebuilds_search_matches() {
+        // sort 後も search が追従して n/N の飛び先が正しいこと
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("aaa-nvim", 10, None, vec![]),
+            make_repo_full("zzz", 100, None, vec![]),
+            make_repo_full("bbb-nvim", 50, None, vec![]),
+        ]);
+        state.start_search();
+        state.search_type('n');
+        state.search_type('v');
+        state.search_type('i');
+        state.search_type('m');
+        // stars 降順 (デフォルト) で zzz(100), bbb-nvim(50), aaa-nvim(10)
+        // nvim マッチは bbb-nvim(idx 1) と aaa-nvim(idx 2)
+        assert_eq!(state.search_matches, vec![1, 2]);
+        // sort を Name に切り替え → aaa-nvim(0), bbb-nvim(1), zzz(2)
+        state.sort_mode = SortMode::Name;
+        state.sort_plugins();
+        // 再計算後: aaa-nvim(0), bbb-nvim(1)
+        assert_eq!(state.search_matches, vec![0, 1]);
+        // n で次のマッチ (bbb-nvim) に飛ぶ
+        state.search_next();
+        assert_eq!(
+            state.selected_repo().map(|r| r.plugin_name().to_string()),
+            Some("bbb-nvim".to_string())
+        );
     }
 
     #[test]

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -159,97 +159,6 @@ fn parse_tag_name(tag: &str) -> String {
         .collect()
 }
 
-/// Markdown の pipe テーブル (`| a | b |` + `| --- | --- |`) を検出して
-/// 列ごとに max 幅に合わせて space padding を追加する。tui-markdown 0.3 は
-/// テーブルを plain text として流すだけなので、行ごとの cell 長が違うと `|`
-/// 位置がバラつく。pre-pass で揃えておくと少なくとも pane に収まる table は
-/// 整って見える (pane 幅を超える場合は wrap するのでそこは仕方ない)。
-fn realign_markdown_tables(input: &str) -> String {
-    use unicode_width::UnicodeWidthStr;
-
-    let lines: Vec<&str> = input.lines().collect();
-    let mut out = String::new();
-    let mut i = 0;
-    while i < lines.len() {
-        let line = lines[i];
-        if is_table_header(line) && i + 1 < lines.len() && is_table_separator(lines[i + 1]) {
-            // 連続する table 行を収集
-            let mut end = i + 2;
-            while end < lines.len() && is_table_row(lines[end]) {
-                end += 1;
-            }
-            let rows = &lines[i..end];
-            // 各行をセル列に分解 (先頭/末尾の `|` は除く、trim)
-            let parsed: Vec<Vec<&str>> = rows
-                .iter()
-                .map(|l| {
-                    let t = l.trim();
-                    let inner = t.strip_prefix('|').unwrap_or(t);
-                    let inner = inner.strip_suffix('|').unwrap_or(inner);
-                    inner.split('|').map(|c| c.trim()).collect()
-                })
-                .collect();
-            let ncols = parsed.iter().map(|r| r.len()).max().unwrap_or(0);
-            let mut widths = vec![0usize; ncols];
-            // separator 行 (index 1) は width 計算から除外
-            for (row_idx, row) in parsed.iter().enumerate() {
-                if row_idx == 1 {
-                    continue;
-                }
-                for (ci, cell) in row.iter().enumerate() {
-                    widths[ci] = widths[ci].max(UnicodeWidthStr::width(*cell));
-                }
-            }
-            for (row_idx, row) in parsed.iter().enumerate() {
-                out.push('|');
-                for (ci, width) in widths.iter().enumerate() {
-                    out.push(' ');
-                    let cell = row.get(ci).copied().unwrap_or("");
-                    if row_idx == 1 {
-                        out.push_str(&"-".repeat((*width).max(3)));
-                    } else {
-                        out.push_str(cell);
-                        let pad = width.saturating_sub(UnicodeWidthStr::width(cell));
-                        for _ in 0..pad {
-                            out.push(' ');
-                        }
-                    }
-                    out.push(' ');
-                    out.push('|');
-                }
-                out.push('\n');
-            }
-            i = end;
-            continue;
-        }
-        out.push_str(line);
-        out.push('\n');
-        i += 1;
-    }
-    out
-}
-
-fn is_table_row(line: &str) -> bool {
-    let t = line.trim();
-    t.starts_with('|') && t.len() >= 2 && t.contains('|')
-}
-
-fn is_table_header(line: &str) -> bool {
-    is_table_row(line)
-}
-
-fn is_table_separator(line: &str) -> bool {
-    let t = line.trim();
-    if !t.starts_with('|') || !t.ends_with('|') || t.len() < 3 {
-        return false;
-    }
-    let inner = &t[1..t.len() - 1];
-    inner.split('|').all(|cell| {
-        let c = cell.trim();
-        !c.is_empty() && c.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
-    })
-}
-
 /// Paragraph が `Wrap { trim: false }` で描画したときの実行数を推定する。
 /// - 幅が 0 (draw 前) なら Text の Line 数をそのまま返す
 /// - 各 Line の spans 合計 display 幅を `pane_width` で割り切り上げ (空 Line は 1 行)
@@ -661,10 +570,7 @@ impl StoreTuiState {
         // `unicode-width` は幅 1 と答えるが terminal は 2 セルで描画するため
         // tui-markdown の Line 折返しが壊れる。リスト側と同じく PUA / VS を除去する。
         let sanitized = sanitize_cell_text(&cleaned);
-        // pipe テーブルは tui-markdown が plain text として流してしまい行毎に
-        // `|` 位置がバラつくので、事前に列幅を揃えておく。
-        let aligned = realign_markdown_tables(&sanitized);
-        self.readme_prepared = format!("{}{}", topics_prefix, aligned);
+        self.readme_prepared = format!("{}{}", topics_prefix, sanitized);
         // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
         // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
         // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。
@@ -1528,65 +1434,6 @@ mod tests {
     fn test_sanitize_keeps_ascii() {
         let input = "A collection of small qol plugins for Neovim";
         assert_eq!(sanitize_cell_text(input), input);
-    }
-
-    // ───── realign_markdown_tables ─────
-
-    #[test]
-    fn test_realign_table_pads_short_cells() {
-        let input = "\
-| short | name |
-| --- | --- |
-| NoiceCmdlineIcon | desc |
-";
-        let out = realign_markdown_tables(input);
-        // 列ごとに `|` 位置が揃っているか
-        let lines: Vec<&str> = out.lines().collect();
-        let pipe_positions: Vec<Vec<usize>> = lines
-            .iter()
-            .map(|l| {
-                l.char_indices()
-                    .filter(|(_, c)| *c == '|')
-                    .map(|(i, _)| i)
-                    .collect()
-            })
-            .collect();
-        assert_eq!(pipe_positions[0], pipe_positions[2]);
-    }
-
-    #[test]
-    fn test_realign_table_preserves_non_table_lines() {
-        let input = "\
-Hello world
-| a | b |
-| --- | --- |
-| 1 | 2 |
-Goodbye
-";
-        let out = realign_markdown_tables(input);
-        assert!(out.contains("Hello world"));
-        assert!(out.contains("Goodbye"));
-    }
-
-    #[test]
-    fn test_realign_table_handles_empty_cells() {
-        let input = "\
-| a | b | c |
-| --- | --- | --- |
-| x | | z |
-";
-        let out = realign_markdown_tables(input);
-        // 空セルが原因で column 数が狂わないこと
-        assert_eq!(out.lines().count(), 3);
-    }
-
-    #[test]
-    fn test_realign_without_separator_is_noop() {
-        // separator が無い連続行はテーブル扱いしない
-        let input = "| not | a table |\nbecause no separator";
-        let out = realign_markdown_tables(input);
-        assert!(out.contains("| not | a table |"));
-        assert!(out.contains("because no separator"));
     }
 
     #[test]

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -41,6 +41,12 @@ pub struct StoreTuiState {
     /// `readme_prepared` の cache key: (selected full_name, readme_content の長さ, loading)
     /// 内容そのものを保持せず長さだけで比較 (同一内容の読み直しは想定しない)。
     readme_prepared_key: Option<(String, usize, bool)>,
+    /// `readme_prepared` の行数 (改行で区切った pre-wrap の行数)。`G` / `j` で
+    /// スクロールオーバーしないよう clamp に使う。wrap 後はこれより増えうるが
+    /// 下限として十分機能する。
+    pub readme_line_count: u16,
+    /// README pane の表示行数 (`draw()` で毎フレーム更新)。clamp 計算に使う。
+    pub readme_visible_height: u16,
     pub sort_mode: SortMode,
     pub message: Option<String>,
     pub focus: Focus,
@@ -205,6 +211,8 @@ impl StoreTuiState {
             readme_scroll: 0,
             readme_prepared: String::new(),
             readme_prepared_key: None,
+            readme_line_count: 0,
+            readme_visible_height: 0,
             sort_mode: SortMode::Stars,
             message: None,
             focus: Focus::List,
@@ -333,11 +341,26 @@ impl StoreTuiState {
     }
 
     pub fn scroll_readme_down(&mut self, n: u16) {
-        self.readme_scroll = self.readme_scroll.saturating_add(n);
+        let max = self.readme_max_scroll();
+        self.readme_scroll = self.readme_scroll.saturating_add(n).min(max);
     }
 
     pub fn scroll_readme_up(&mut self, n: u16) {
         self.readme_scroll = self.readme_scroll.saturating_sub(n);
+    }
+
+    /// README を最下部までスクロール (`G` / `End` 用)。pre-wrap の行数を基準に
+    /// 最終行あたりが pane 下端に来る位置を設定する。wrap で行数が増えた場合は
+    /// 若干上方に見えるが、空白のみ見える `u16::MAX` 飛びより実用的。
+    pub fn scroll_readme_to_bottom(&mut self) {
+        self.readme_scroll = self.readme_max_scroll();
+    }
+
+    /// 現在の readme 行数と pane 高さから、これ以上下に行くと空白しか見えない
+    /// 限界スクロール位置を返す。行数 ≤ 表示高さなら 0。
+    fn readme_max_scroll(&self) -> u16 {
+        self.readme_line_count
+            .saturating_sub(self.readme_visible_height)
     }
 
     // ───────── ローカル検索 (`/` + n/N) ─────────
@@ -507,6 +530,13 @@ impl StoreTuiState {
 
         let cleaned = strip_common_html(&body);
         self.readme_prepared = format!("{}{}", topics_prefix, cleaned);
+        // pre-wrap の改行数で近似。wrap 後は増えるが scroll 上限としては十分。
+        self.readme_line_count = self
+            .readme_prepared
+            .lines()
+            .count()
+            .try_into()
+            .unwrap_or(u16::MAX);
         self.readme_prepared_key = Some(key);
     }
 
@@ -712,6 +742,9 @@ impl StoreTuiState {
             )
             .wrap(Wrap { trim: false })
             .scroll((self.readme_scroll, 0));
+        // scroll_readme_to_bottom() / scroll_readme_down() が使う pane 内側高さ。
+        // Borders 2 行を差し引く。
+        self.readme_visible_height = main_chunks[1].height.saturating_sub(2);
         // Paragraph は inner area の未使用セルを空白で埋めないため、前フレームの
         // 長い README の残骸が残ることがある (特に zellij のようにターミナルが
         // セル状態を厳密に保持するホストで顕在化する)。Clear でペイン全体を空白に
@@ -950,11 +983,44 @@ mod tests {
     #[test]
     fn test_readme_scroll() {
         let mut state = StoreTuiState::new();
+        // clamp を効かせるために表示範囲を設定 (100 行 README を高さ 20 の pane で)
+        state.readme_line_count = 100;
+        state.readme_visible_height = 20;
         state.scroll_readme_down(10);
         assert_eq!(state.readme_scroll, 10);
         state.scroll_readme_up(3);
         assert_eq!(state.readme_scroll, 7);
         state.scroll_readme_up(100);
+        assert_eq!(state.readme_scroll, 0);
+    }
+
+    #[test]
+    fn test_scroll_readme_down_clamps_to_max() {
+        let mut state = StoreTuiState::new();
+        state.readme_line_count = 50;
+        state.readme_visible_height = 20;
+        // max = 50 - 20 = 30
+        state.scroll_readme_down(u16::MAX);
+        assert_eq!(state.readme_scroll, 30);
+    }
+
+    #[test]
+    fn test_scroll_readme_to_bottom_lands_at_max() {
+        let mut state = StoreTuiState::new();
+        state.readme_line_count = 80;
+        state.readme_visible_height = 25;
+        state.scroll_readme_to_bottom();
+        // max = 80 - 25 = 55
+        assert_eq!(state.readme_scroll, 55);
+    }
+
+    #[test]
+    fn test_scroll_readme_to_bottom_on_short_content_stays_at_top() {
+        let mut state = StoreTuiState::new();
+        // 内容が pane より短いならスクロール不要
+        state.readme_line_count = 10;
+        state.readme_visible_height = 25;
+        state.scroll_readme_to_bottom();
         assert_eq!(state.readme_scroll, 0);
     }
 

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -159,6 +159,99 @@ fn parse_tag_name(tag: &str) -> String {
         .collect()
 }
 
+/// Markdown の pipe テーブルを検出し、列幅を揃えた上で fenced code block として
+/// 囲む。tui-markdown 0.3 はテーブルの TableRow/Cell イベントを 1 Text::Line に
+/// 詰めてしまうため、ヘッダー・separator・本体行が 1 表示行に折り重なって崩れる。
+/// code fence で囲めば tui-markdown は逐行 preserve するので、最低限の
+/// プレーンテキスト表として読めるようになる (外部 renderer 無しで済む)。
+///
+/// 列幅は `unicode-width` ベースで最大幅を取り、各セルを空白で右 padding する。
+/// pane 幅を超えるテーブルは wrap されるが、その場合も「少なくとも改行で切れる」
+/// 動作は保たれる。
+fn wrap_tables_as_code_blocks(input: &str) -> String {
+    use unicode_width::UnicodeWidthStr;
+
+    let lines: Vec<&str> = input.lines().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if is_table_row(line) && i + 1 < lines.len() && is_table_separator(lines[i + 1]) {
+            // 連続する table 行を末尾まで収集
+            let mut end = i + 2;
+            while end < lines.len() && is_table_row(lines[end]) {
+                end += 1;
+            }
+            let rows = &lines[i..end];
+            let parsed: Vec<Vec<&str>> = rows
+                .iter()
+                .map(|l| {
+                    let t = l.trim();
+                    let inner = t.strip_prefix('|').unwrap_or(t);
+                    let inner = inner.strip_suffix('|').unwrap_or(inner);
+                    inner.split('|').map(|c| c.trim()).collect()
+                })
+                .collect();
+            let ncols = parsed.iter().map(|r| r.len()).max().unwrap_or(0);
+            let mut widths = vec![0usize; ncols];
+            for (row_idx, row) in parsed.iter().enumerate() {
+                if row_idx == 1 {
+                    continue;
+                }
+                for (ci, cell) in row.iter().enumerate() {
+                    widths[ci] = widths[ci].max(UnicodeWidthStr::width(*cell));
+                }
+            }
+            // 全体を code fence で囲む。言語は "text" にして syntect の
+            // 言語推定を抑止する。
+            out.push_str("\n```text\n");
+            for (row_idx, row) in parsed.iter().enumerate() {
+                out.push('|');
+                for (ci, width) in widths.iter().enumerate() {
+                    out.push(' ');
+                    let cell = row.get(ci).copied().unwrap_or("");
+                    if row_idx == 1 {
+                        out.push_str(&"-".repeat((*width).max(3)));
+                    } else {
+                        out.push_str(cell);
+                        let pad = width.saturating_sub(UnicodeWidthStr::width(cell));
+                        for _ in 0..pad {
+                            out.push(' ');
+                        }
+                    }
+                    out.push(' ');
+                    out.push('|');
+                }
+                out.push('\n');
+            }
+            out.push_str("```\n");
+            i = end;
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+        i += 1;
+    }
+    out
+}
+
+fn is_table_row(line: &str) -> bool {
+    let t = line.trim();
+    t.starts_with('|') && t.len() >= 2 && t.contains('|')
+}
+
+fn is_table_separator(line: &str) -> bool {
+    let t = line.trim();
+    if !t.starts_with('|') || !t.ends_with('|') || t.len() < 3 {
+        return false;
+    }
+    let inner = &t[1..t.len() - 1];
+    inner.split('|').all(|cell| {
+        let c = cell.trim();
+        !c.is_empty() && c.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+    })
+}
+
 /// Paragraph が `Wrap { trim: false }` で描画したときの実行数を推定する。
 /// - 幅が 0 (draw 前) なら Text の Line 数をそのまま返す
 /// - 各 Line の spans 合計 display 幅を `pane_width` で割り切り上げ (空 Line は 1 行)
@@ -570,7 +663,11 @@ impl StoreTuiState {
         // `unicode-width` は幅 1 と答えるが terminal は 2 セルで描画するため
         // tui-markdown の Line 折返しが壊れる。リスト側と同じく PUA / VS を除去する。
         let sanitized = sanitize_cell_text(&cleaned);
-        self.readme_prepared = format!("{}{}", topics_prefix, sanitized);
+        // tui-markdown 0.3 はテーブルの全セルを 1 Line に詰めてしまい、ヘッダーと
+        // 本体行が重なって読めなくなる。pipe テーブルを検出したら列幅を揃えつつ
+        // code fence でラップして、逐行描画される経路に逃がす。
+        let tabled = wrap_tables_as_code_blocks(&sanitized);
+        self.readme_prepared = format!("{}{}", topics_prefix, tabled);
         // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
         // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
         // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。
@@ -1434,6 +1531,69 @@ mod tests {
     fn test_sanitize_keeps_ascii() {
         let input = "A collection of small qol plugins for Neovim";
         assert_eq!(sanitize_cell_text(input), input);
+    }
+
+    // ───── wrap_tables_as_code_blocks ─────
+
+    #[test]
+    fn test_wrap_tables_puts_fence_around_pipe_table() {
+        let input = "\
+intro
+
+| col | other |
+| --- | --- |
+| a | b |
+
+outro
+";
+        let out = wrap_tables_as_code_blocks(input);
+        assert!(out.contains("```text\n"));
+        assert!(out.contains("\n```\n"));
+        assert!(out.contains("intro"));
+        assert!(out.contains("outro"));
+    }
+
+    #[test]
+    fn test_wrap_tables_aligns_columns_inside_fence() {
+        let input = "\
+| short | name |
+| --- | --- |
+| VeryLongCell | desc |
+";
+        let out = wrap_tables_as_code_blocks(input);
+        // すべての table 行で `|` 位置が揃う
+        let table_lines: Vec<&str> = out.lines().filter(|l| l.starts_with('|')).collect();
+        assert_eq!(table_lines.len(), 3);
+        let first_pipes: Vec<usize> = table_lines[0]
+            .char_indices()
+            .filter(|(_, c)| *c == '|')
+            .map(|(i, _)| i)
+            .collect();
+        for l in &table_lines[1..] {
+            let pipes: Vec<usize> = l
+                .char_indices()
+                .filter(|(_, c)| *c == '|')
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(pipes, first_pipes, "pipe positions differ on `{}`", l);
+        }
+    }
+
+    #[test]
+    fn test_wrap_tables_preserves_non_table_lines() {
+        let input = "Hello\n\nWorld\n";
+        let out = wrap_tables_as_code_blocks(input);
+        assert!(!out.contains("```"));
+        assert!(out.contains("Hello"));
+        assert!(out.contains("World"));
+    }
+
+    #[test]
+    fn test_wrap_tables_without_separator_is_noop() {
+        // separator なし → table ではない → ラップしない
+        let input = "| not | a table |\nbut a line";
+        let out = wrap_tables_as_code_blocks(input);
+        assert!(!out.contains("```"));
     }
 
     #[test]

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -38,15 +38,18 @@ pub struct StoreTuiState {
     /// draw() ごとに strip+format し直さないための前処理済み markdown キャッシュ。
     /// `readme_prepared_key` に紐付き、キーが変わったときだけ作り直す。
     pub readme_prepared: String,
-    /// `readme_prepared` の cache key: (selected full_name, readme_content の長さ, loading)
-    /// 内容そのものを保持せず長さだけで比較 (同一内容の読み直しは想定しない)。
-    readme_prepared_key: Option<(String, usize, bool)>,
-    /// `readme_prepared` の行数 (改行で区切った pre-wrap の行数)。`G` / `j` で
-    /// スクロールオーバーしないよう clamp に使う。wrap 後はこれより増えうるが
-    /// 下限として十分機能する。
+    /// `readme_prepared` の cache key:
+    /// (selected full_name, readme_content 長, loading, visible_width)
+    /// 内容そのものを保持せず長さだけで比較。幅が変わると wrap 後行数が変わるので
+    /// key に含め、resize 時にも再計算する。
+    readme_prepared_key: Option<(String, usize, bool, u16)>,
+    /// README の post-wrap 推定行数。pane 内側幅 (`readme_visible_width`) で
+    /// 文字幅換算して割った近似値。G / scroll 下限の clamp に使う。
     pub readme_line_count: u16,
     /// README pane の表示行数 (`draw()` で毎フレーム更新)。clamp 計算に使う。
     pub readme_visible_height: u16,
+    /// README pane の表示幅 (`draw()` で毎フレーム更新)。post-wrap 計算に使う。
+    pub readme_visible_width: u16,
     pub sort_mode: SortMode,
     pub message: Option<String>,
     pub focus: Focus,
@@ -156,6 +159,33 @@ fn parse_tag_name(tag: &str) -> String {
         .collect()
 }
 
+/// Paragraph が `Wrap { trim: false }` で描画したときの実行数を推定する。
+/// - 幅が 0 (draw 前) なら Text の Line 数をそのまま返す
+/// - 各 Line の spans 合計 display 幅を `pane_width` で割り切り上げ (空 Line は 1 行)
+/// - 合計を u16 にクランプ
+///
+/// word-wrap の影響は無視しているので ±数行の誤差はあるが、`G` の clamp 用途には十分。
+fn estimate_wrapped_rows(text: &ratatui::text::Text<'_>, pane_width: u16) -> u16 {
+    use unicode_width::UnicodeWidthStr;
+    if pane_width == 0 {
+        return text.lines.len().try_into().unwrap_or(u16::MAX);
+    }
+    let w = pane_width as usize;
+    let total: usize = text
+        .lines
+        .iter()
+        .map(|line| {
+            let display: usize = line
+                .spans
+                .iter()
+                .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                .sum();
+            display.max(1).div_ceil(w)
+        })
+        .sum();
+    total.try_into().unwrap_or(u16::MAX)
+}
+
 /// リスト行のセル表示用に問題のある Unicode スカラを落とす。
 ///
 /// nerd font の Private Use Area (U+E000-F8FF 等) は `unicode-width` が幅 1 と
@@ -213,6 +243,7 @@ impl StoreTuiState {
             readme_prepared_key: None,
             readme_line_count: 0,
             readme_visible_height: 0,
+            readme_visible_width: 0,
             sort_mode: SortMode::Stars,
             message: None,
             focus: Focus::List,
@@ -486,15 +517,21 @@ impl StoreTuiState {
     }
 
     /// README 描画用の前処理済み markdown を必要なら再計算する。
-    /// `selected_repo` / `readme_content` / `readme_loading` が変わったときだけ
-    /// HTML strip + topics prefix の組み立てを行い、結果を `readme_prepared` に保持する。
+    /// `selected_repo` / `readme_content` / `readme_loading` / pane 幅 のいずれかが
+    /// 変わったときだけ HTML strip + topics prefix の組み立てと post-wrap 行数の
+    /// 見積もりを行い、結果を `readme_prepared` / `readme_line_count` に保持する。
     fn ensure_readme_prepared(&mut self) {
         let selected_name = self
             .selected_repo()
             .map(|r| r.full_name.clone())
             .unwrap_or_default();
         let content_len = self.readme_content.as_ref().map(|c| c.len()).unwrap_or(0);
-        let key = (selected_name, content_len, self.readme_loading);
+        let key = (
+            selected_name,
+            content_len,
+            self.readme_loading,
+            self.readme_visible_width,
+        );
         if self.readme_prepared_key.as_ref() == Some(&key) {
             return;
         }
@@ -530,16 +567,24 @@ impl StoreTuiState {
 
         let cleaned = strip_common_html(&body);
         self.readme_prepared = format!("{}{}", topics_prefix, cleaned);
-        // tui-markdown が実際に生成する Line 数で clamp する。`\n` を数えると
-        // paragraph 内のソフトラップ (改行はあるがブロック境界ではない) まで
-        // カウントしてしまい、G が実内容より遥かに下へ飛ぶ原因になる。
-        // pulldown-cmark + tui-markdown の block 整形を通した後の行数が正確。
+        // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
+        // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
+        // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。
+        // word-wrap と完全一致はしないが、G のオーバー/アンダーを実用レベルまで
+        // 抑えられる。`\n` カウントは paragraph 内の soft break まで数えすぎ、
+        // tui-markdown Line 数は wrap を無視するため、いずれも単独だとズレる。
         let rendered = tui_markdown::from_str(&self.readme_prepared);
-        self.readme_line_count = rendered.lines.len().try_into().unwrap_or(u16::MAX);
+        self.readme_line_count = estimate_wrapped_rows(&rendered, self.readme_visible_width);
         self.readme_prepared_key = Some(key);
     }
 
     pub fn draw(&mut self, f: &mut Frame) {
+        // 毎フレームまず全セルを空白 + 既定スタイルに戻してから widget を重ねる。
+        // 個別 pane 単位の Clear だと highlight-code (ansi-to-tui) の styled span が
+        // scroll 位置変更時に残骸を残すケースがあるため、フレーム丸ごと洗う。
+        // ratatui の diff 機構により実際の端末出力は変化したセルのみ。
+        f.render_widget(ratatui::widgets::Clear, f.area());
+
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -718,7 +763,11 @@ impl StoreTuiState {
         f.render_stateful_widget(table, main_chunks[0], &mut self.table_state);
 
         // Right: README preview (tui-markdown rendered GFM)
-        // HTML strip + topics 結合はキャッシュ (`readme_prepared`) されるので、
+        // scroll 系のメソッドが使う pane 内側サイズ。borders 分を差し引く。
+        // ensure_readme_prepared は visible_width を cache key に使うのでその前に更新する。
+        self.readme_visible_height = main_chunks[1].height.saturating_sub(2);
+        self.readme_visible_width = main_chunks[1].width.saturating_sub(2);
+        // HTML strip + topics 結合 + post-wrap 行数はキャッシュされるので、
         // draw() ごとのコストは tui_markdown::from_str のパースだけ。
         self.ensure_readme_prepared();
         let rendered = tui_markdown::from_str(&self.readme_prepared);
@@ -741,9 +790,6 @@ impl StoreTuiState {
             )
             .wrap(Wrap { trim: false })
             .scroll((self.readme_scroll, 0));
-        // scroll_readme_to_bottom() / scroll_readme_down() が使う pane 内側高さ。
-        // Borders 2 行を差し引く。
-        self.readme_visible_height = main_chunks[1].height.saturating_sub(2);
         // Paragraph は inner area の未使用セルを空白で埋めないため、前フレームの
         // 長い README の残骸が残ることがある (特に zellij のようにターミナルが
         // セル状態を厳密に保持するホストで顕在化する)。Clear でペイン全体を空白に

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -35,6 +35,12 @@ pub struct StoreTuiState {
     pub readme_content: Option<String>,
     pub readme_loading: bool,
     pub readme_scroll: u16,
+    /// draw() ごとに strip+format し直さないための前処理済み markdown キャッシュ。
+    /// `readme_prepared_key` に紐付き、キーが変わったときだけ作り直す。
+    pub readme_prepared: String,
+    /// `readme_prepared` の cache key: (selected full_name, readme_content の長さ, loading)
+    /// 内容そのものを保持せず長さだけで比較 (同一内容の読み直しは想定しない)。
+    readme_prepared_key: Option<(String, usize, bool)>,
     pub sort_mode: SortMode,
     pub message: Option<String>,
     pub focus: Focus,
@@ -69,108 +75,94 @@ impl SortMode {
 /// GitHub README によくある `<img src="...badge">`, `<a>`, `<p align="center">`,
 /// `<br>`, `<div>` 等の HTML タグを除去して markdown として読みやすくする。
 ///
-/// 完全な HTML パーサではなく、行単位の **存在感が大きい** タグだけを対象にする最小限の処理:
-/// - `<img .../>` や `<img ...>` を alt text で置き換え (alt があれば) or 空文字
-/// - `<a ...>` / `</a>` / `<br ?/?>` / `<div ...>` / `</div>` / `<p ...>` / `</p>` / `<picture>` 類を削除
-/// - `<!-- ... -->` コメントを削除
+/// 単一パスで UTF-8 安全 (ASCII の `<` / `>` 境界でしか切らない)。
+/// - HTML コメント `<!-- ... -->` を削除
+/// - `<img ...>` は `alt` 属性の値に置換、無ければ除去
+/// - `REMOVE_TAGS` に含まれる既知の装飾タグは開き/閉じ両方除去
+/// - それ以外の未知タグは markdown として意味を持ちうるので保持
 fn strip_common_html(input: &str) -> String {
-    let mut s = input.to_string();
+    const REMOVE_TAGS: &[&str] = &[
+        "a", "br", "div", "p", "picture", "source", "sub", "sup", "kbd", "details", "summary",
+        "center", "span", "table", "tr", "td", "th", "tbody", "thead", "ul", "li", "ol",
+    ];
 
-    // HTML コメントを削除
-    while let Some(start) = s.find("<!--") {
-        if let Some(rel_end) = s[start..].find("-->") {
-            s.replace_range(start..start + rel_end + 3, "");
-        } else {
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        // 次の '<' までをそのままコピー ('<' は ASCII なので byte 境界 = char 境界)
+        let Some(lt_rel) = input[i..].find('<') else {
+            out.push_str(&input[i..]);
+            break;
+        };
+        let lt = i + lt_rel;
+        out.push_str(&input[i..lt]);
+
+        // HTML コメント
+        if input[lt..].starts_with("<!--") {
+            if let Some(end_rel) = input[lt + 4..].find("-->") {
+                i = lt + 4 + end_rel + 3;
+                continue;
+            }
+            // 閉じコメント無し → 残りそのまま
+            out.push_str(&input[lt..]);
             break;
         }
-    }
 
-    // <img ...> を alt text or 空文字に置換
-    let mut out = String::with_capacity(s.len());
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'<'
-            && i + 4 <= bytes.len()
-            && &s[i..i + 4].to_lowercase() == "<img"
-            && let Some(rel_end) = s[i..].find('>')
-        {
-            let tag = &s[i..=i + rel_end];
-            let alt = extract_attr(tag, "alt").unwrap_or_default();
-            if !alt.is_empty() {
+        // 対応する '>' を探す (属性値に入った '>' を厳密に扱わない小さな手抜き)
+        let Some(gt_rel) = input[lt..].find('>') else {
+            out.push_str(&input[lt..]);
+            break;
+        };
+        let gt = lt + gt_rel;
+        let tag = &input[lt..=gt];
+
+        // タグ名を抽出 (先頭 '<' / '</' を飛ばし、ASCII alphabetic の連続)
+        let name = parse_tag_name(tag);
+        let lname = name.to_ascii_lowercase();
+
+        if lname == "img" {
+            if let Some(alt) = extract_alt(tag)
+                && !alt.is_empty()
+            {
                 out.push_str(&alt);
             }
-            i += rel_end + 1;
-            continue;
+        } else if REMOVE_TAGS.iter().any(|t| *t == lname) {
+            // 開き/閉じ/self-closing どれでも丸ごと除去
+        } else {
+            // 未知タグは保持
+            out.push_str(tag);
         }
-        out.push(bytes[i] as char);
-        i += 1;
+        i = gt + 1;
     }
-
-    // 既知の **開き/閉じ両方** のタグ名だけを、`<tag ...>` or `</tag>` or `<tag ... />` 形式で削除
-    let tags = [
-        "a", "br", "div", "p", "picture", "source", "sub", "sup", "kbd", "details", "summary",
-        "center", "span", "table", "tr", "td", "th", "tbody", "thead", "ul", "li",
-    ];
-    for tag in tags {
-        let open = format!("<{}", tag);
-        let close = format!("</{}>", tag);
-        out = remove_tag_instances(&out, &open, &close);
-    }
-
     out
 }
 
-/// `<img alt="Hello world" src="...">` から `alt` の値を取り出す。
-/// 非常に緩いパース (属性はクォート必須、エスケープ非対応)。見つからなければ None。
-fn extract_attr(tag: &str, attr: &str) -> Option<String> {
-    let lower = tag.to_lowercase();
-    let pat = format!("{}=", attr);
-    let pos = lower.find(&pat)?;
-    let rest = &tag[pos + pat.len()..];
-    let (delim, start_off) = if let Some(stripped) = rest.strip_prefix('"') {
-        ('"', stripped.as_ptr() as usize - rest.as_ptr() as usize)
-    } else if let Some(stripped) = rest.strip_prefix('\'') {
-        ('\'', stripped.as_ptr() as usize - rest.as_ptr() as usize)
-    } else {
-        return None;
-    };
-    let body = &rest[start_off..];
-    let end = body.find(delim)?;
-    Some(body[..end].to_string())
+/// `<tagname ...>` / `</tagname>` / `<tagname/>` からタグ名を抜き出す。
+/// 見つからなければ空文字列。
+fn parse_tag_name(tag: &str) -> String {
+    let inner = tag
+        .trim_start_matches('<')
+        .trim_start_matches('/')
+        .trim_start_matches('!');
+    inner
+        .chars()
+        .take_while(|c| c.is_ascii_alphabetic())
+        .collect()
 }
 
-/// `<tag ...>` および `</tag>` をすべて削除。
-/// `input.to_lowercase()` で case-insensitive 比較するが、削除は元文字列に対して行う。
-fn remove_tag_instances(input: &str, open_prefix: &str, close: &str) -> String {
-    let mut s = input.to_string();
-    let lower_open = open_prefix.to_lowercase();
-    let lower_close = close.to_lowercase();
-
-    loop {
-        let lower = s.to_lowercase();
-        if let Some(start) = lower.find(&lower_open) {
-            // 次が ' ' / '>' / '/' のいずれかでないと別タグ (e.g., <abbr>)
-            let after = s[start + open_prefix.len()..].chars().next().unwrap_or('>');
-            if !matches!(after, ' ' | '>' | '/' | '\t' | '\n') {
-                // false positive, skip this instance by slicing past it
-                let remainder = &s[start + open_prefix.len()..];
-                // just break to avoid infinite loop; accept leftover
-                let _ = remainder;
-                break;
-            }
-            if let Some(rel_end) = s[start..].find('>') {
-                s.replace_range(start..start + rel_end + 1, "");
-                continue;
-            }
-        }
-        break;
+/// `<img ... alt="..." ...>` から `alt` 属性の値を取り出す。
+/// クォート必須、エスケープ非対応。UTF-8 安全 (`=` / クォートは ASCII)。
+fn extract_alt(tag: &str) -> Option<String> {
+    let lower = tag.to_ascii_lowercase();
+    let pos = lower.find("alt=")?;
+    let rest = &tag[pos + 4..];
+    let delim = rest.chars().next()?;
+    if delim != '"' && delim != '\'' {
+        return None;
     }
-
-    while let Some(start) = s.to_lowercase().find(&lower_close) {
-        s.replace_range(start..start + close.len(), "");
-    }
-    s
+    let after = &rest[delim.len_utf8()..];
+    let end = after.find(delim)?;
+    Some(after[..end].to_string())
 }
 
 impl StoreTuiState {
@@ -188,6 +180,8 @@ impl StoreTuiState {
             readme_content: None,
             readme_loading: false,
             readme_scroll: 0,
+            readme_prepared: String::new(),
+            readme_prepared_key: None,
             sort_mode: SortMode::Stars,
             message: None,
             focus: Focus::List,
@@ -445,6 +439,54 @@ impl StoreTuiState {
         self.installed.insert(repo.full_name.to_lowercase());
     }
 
+    /// README 描画用の前処理済み markdown を必要なら再計算する。
+    /// `selected_repo` / `readme_content` / `readme_loading` が変わったときだけ
+    /// HTML strip + topics prefix の組み立てを行い、結果を `readme_prepared` に保持する。
+    fn ensure_readme_prepared(&mut self) {
+        let selected_name = self
+            .selected_repo()
+            .map(|r| r.full_name.clone())
+            .unwrap_or_default();
+        let content_len = self.readme_content.as_ref().map(|c| c.len()).unwrap_or(0);
+        let key = (selected_name, content_len, self.readme_loading);
+        if self.readme_prepared_key.as_ref() == Some(&key) {
+            return;
+        }
+
+        let body = if self.readme_loading {
+            "_Loading README..._".to_string()
+        } else {
+            self.readme_content.clone().unwrap_or_else(|| {
+                if self.plugins.is_empty() {
+                    "_Press / to search or S to fetch more._".to_string()
+                } else {
+                    "_Loading..._".to_string()
+                }
+            })
+        };
+
+        let topics_prefix = self
+            .selected_repo()
+            .map(|r| {
+                if r.topics.is_empty() {
+                    String::new()
+                } else {
+                    let joined = r
+                        .topics
+                        .iter()
+                        .map(|t| format!("`{}`", t))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!("**Topics:** {}\n\n---\n\n", joined)
+                }
+            })
+            .unwrap_or_default();
+
+        let cleaned = strip_common_html(&body);
+        self.readme_prepared = format!("{}{}", topics_prefix, cleaned);
+        self.readme_prepared_key = Some(key);
+    }
+
     pub fn draw(&mut self, f: &mut Frame) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -599,42 +641,10 @@ impl StoreTuiState {
         f.render_stateful_widget(table, main_chunks[0], &mut self.table_state);
 
         // Right: README preview (tui-markdown rendered GFM)
-        let readme_body = if self.readme_loading {
-            "_Loading README..._".to_string()
-        } else {
-            self.readme_content.clone().unwrap_or_else(|| {
-                if self.plugins.is_empty() {
-                    "_Press / to search or S to fetch more._".to_string()
-                } else {
-                    "_Loading..._".to_string()
-                }
-            })
-        };
-
-        // 選択中 repo の topics を README 先頭に prepend (DarkGray、区切り線付き)
-        let topics_prefix = self
-            .selected_repo()
-            .map(|r| {
-                if r.topics.is_empty() {
-                    String::new()
-                } else {
-                    let joined = r
-                        .topics
-                        .iter()
-                        .map(|t| format!("`{}`", t))
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    format!("**Topics:** {}\n\n---\n\n", joined)
-                }
-            })
-            .unwrap_or_default();
-
-        // バッジや `<div>` 等の HTML タグは pulldown-cmark が HTML block として扱うので
-        // 生テキストが残る。最低限、行頭の `<img ...>` / `<a ...>` / `</a>` / `<br>` 等を
-        // 除去して見た目を整える。
-        let cleaned_body = strip_common_html(&readme_body);
-        let combined = format!("{}{}", topics_prefix, cleaned_body);
-        let rendered = tui_markdown::from_str(&combined);
+        // HTML strip + topics 結合はキャッシュ (`readme_prepared`) されるので、
+        // draw() ごとのコストは tui_markdown::from_str のパースだけ。
+        self.ensure_readme_prepared();
+        let rendered = tui_markdown::from_str(&self.readme_prepared);
 
         let readme_title = self
             .selected_repo()
@@ -1164,5 +1174,76 @@ mod tests {
         assert!(!state.is_installed(&repo));
         state.mark_installed(&repo);
         assert!(state.is_installed(&repo));
+    }
+
+    // ───── strip_common_html UTF-8 safety ─────
+
+    #[test]
+    fn test_strip_html_preserves_japanese_text() {
+        let input = "これは README です。\n<a href=\"...\">リンク</a> の後。";
+        let out = strip_common_html(input);
+        assert!(out.contains("これは README です。"));
+        assert!(out.contains("リンク"));
+        assert!(!out.contains("<a"));
+        assert!(!out.contains("</a>"));
+    }
+
+    #[test]
+    fn test_strip_html_preserves_emoji_around_img() {
+        // <img> のすぐ前後に絵文字・日本語を置いてもバイト位置破綻しない
+        let input = "🎉 hi <img alt=\"X\" src=\"y\"/> あ い";
+        let out = strip_common_html(input);
+        assert!(out.contains("🎉"));
+        assert!(out.contains("X"));
+        assert!(out.contains("あ い"));
+        assert!(!out.contains("<img"));
+    }
+
+    #[test]
+    fn test_strip_html_img_alt_extracted() {
+        let out = strip_common_html("<img src=\"x.png\" alt=\"Build Status\">");
+        assert_eq!(out, "Build Status");
+    }
+
+    #[test]
+    fn test_strip_html_img_no_alt_dropped() {
+        let out = strip_common_html("<img src=\"x.png\">");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_strip_html_abbr_not_false_matched_as_a() {
+        // 以前の実装では <abbr> を <a> として扱って残り全削除していた
+        let input = "<abbr title=\"x\">TLA</abbr> followed by <a>link</a>";
+        let out = strip_common_html(input);
+        assert!(out.contains("<abbr"));
+        assert!(out.contains("TLA"));
+        assert!(out.contains("link"));
+        assert!(!out.contains("<a>"));
+        assert!(!out.contains("</a>"));
+    }
+
+    #[test]
+    fn test_strip_html_comment_removed() {
+        let out = strip_common_html("before <!-- skip me --> after");
+        assert!(out.contains("before"));
+        assert!(out.contains("after"));
+        assert!(!out.contains("skip me"));
+    }
+
+    #[test]
+    fn test_strip_html_unknown_tag_preserved() {
+        // markdown のインラインコード/カスタム要素は残す
+        let out = strip_common_html("<mark>note</mark>");
+        assert!(out.contains("<mark>"));
+    }
+
+    #[test]
+    fn test_strip_html_multibyte_inside_tag() {
+        // 属性値に日本語が入っていても切り損なわない
+        let input = "<img alt=\"ロゴ\" src=\"logo.png\"/> 本文";
+        let out = strip_common_html(input);
+        assert!(out.contains("ロゴ"));
+        assert!(out.contains("本文"));
     }
 }

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -43,6 +43,10 @@ pub struct StoreTuiState {
     /// 内容そのものを保持せず長さだけで比較。幅が変わると wrap 後行数が変わるので
     /// key に含め、resize 時にも再計算する。
     readme_prepared_key: Option<(String, usize, bool, u16)>,
+    /// tui-markdown でパースし、bg 色を剥がし終えた済みの描画用 Text。
+    /// `readme_prepared_key` が変わらない限り再パースしないので、draw() ごとの
+    /// コストは clone の string alloc だけ (再 parse + syntect ハイライトを回避)。
+    pub readme_rendered: Option<ratatui::text::Text<'static>>,
     /// README の post-wrap 推定行数。pane 内側幅 (`readme_visible_width`) で
     /// 文字幅換算して割った近似値。G / scroll 下限の clamp に使う。
     pub readme_line_count: u16,
@@ -252,6 +256,32 @@ fn is_table_separator(line: &str) -> bool {
     })
 }
 
+/// `Text<'_>` を所有権つき Text<'static> に変換する。tui-markdown の結果を
+/// State にキャッシュして再パースを避けるために必要。各 Span の Cow を
+/// Owned (String) 化するので 1 回だけの allocation コストで済む。
+fn text_to_owned(text: ratatui::text::Text<'_>) -> ratatui::text::Text<'static> {
+    use ratatui::text::{Line, Span, Text};
+    let lines: Vec<Line<'static>> = text
+        .lines
+        .into_iter()
+        .map(|line| {
+            let spans: Vec<Span<'static>> = line
+                .spans
+                .into_iter()
+                .map(|span| Span::styled(span.content.into_owned(), span.style))
+                .collect();
+            let mut l = Line::from(spans);
+            l.style = line.style;
+            l.alignment = line.alignment;
+            l
+        })
+        .collect();
+    let mut out = Text::from(lines);
+    out.style = text.style;
+    out.alignment = text.alignment;
+    out
+}
+
 /// Paragraph が `Wrap { trim: false }` で描画したときの実行数を推定する。
 /// - 幅が 0 (draw 前) なら Text の Line 数をそのまま返す
 /// - 各 Line の spans 合計 display 幅を `pane_width` で割り切り上げ (空 Line は 1 行)
@@ -334,6 +364,7 @@ impl StoreTuiState {
             readme_scroll: 0,
             readme_prepared: String::new(),
             readme_prepared_key: None,
+            readme_rendered: None,
             readme_line_count: 0,
             readme_visible_height: 0,
             readme_visible_width: 0,
@@ -668,14 +699,26 @@ impl StoreTuiState {
         // code fence でラップして、逐行描画される経路に逃がす。
         let tabled = wrap_tables_as_code_blocks(&sanitized);
         self.readme_prepared = format!("{}{}", topics_prefix, tabled);
+        // tui-markdown パース + syntect ハイライト + bg strip をここで 1 回だけ
+        // 実行し、結果を Text<'static> にして `readme_rendered` にキャッシュする。
+        // draw() ごとに clone するだけになるので、再パース & 毎フレームの span
+        // 反復コストを回避できる。
+        let mut rendered = tui_markdown::from_str(&self.readme_prepared);
+        // highlight-code 由来の背景色付き Span が scroll 時に一部ホストで
+        // 残骸を残すので、前景色だけ残して背景は既定に戻す。
+        for line in &mut rendered.lines {
+            for span in &mut line.spans {
+                span.style.bg = None;
+            }
+            line.style.bg = None;
+        }
         // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
         // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
         // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。
         // word-wrap と完全一致はしないが、G のオーバー/アンダーを実用レベルまで
-        // 抑えられる。`\n` カウントは paragraph 内の soft break まで数えすぎ、
-        // tui-markdown Line 数は wrap を無視するため、いずれも単独だとズレる。
-        let rendered = tui_markdown::from_str(&self.readme_prepared);
+        // 抑えられる。
         self.readme_line_count = estimate_wrapped_rows(&rendered, self.readme_visible_width);
+        self.readme_rendered = Some(text_to_owned(rendered));
         self.readme_prepared_key = Some(key);
     }
 
@@ -868,19 +911,11 @@ impl StoreTuiState {
         // ensure_readme_prepared は visible_width を cache key に使うのでその前に更新する。
         self.readme_visible_height = main_chunks[1].height.saturating_sub(2);
         self.readme_visible_width = main_chunks[1].width.saturating_sub(2);
-        // HTML strip + topics 結合 + post-wrap 行数はキャッシュされるので、
-        // draw() ごとのコストは tui_markdown::from_str のパースだけ。
+        // HTML strip / topics 結合 / tui-markdown parse / syntect ハイライト /
+        // bg strip / post-wrap 行数 — すべて ensure_readme_prepared でキャッシュ済み。
+        // draw() ごとのコストは cached Text<'static> の clone (String alloc) のみ。
         self.ensure_readme_prepared();
-        let mut rendered = tui_markdown::from_str(&self.readme_prepared);
-        // highlight-code 由来の背景色付き Span が scroll 時に一部ホストで
-        // 残骸を残すので、前景色だけ残して背景は既定に戻す。fg による
-        // syntax highlighting は維持されるので可読性は保たれる。
-        for line in &mut rendered.lines {
-            for span in &mut line.spans {
-                span.style.bg = None;
-            }
-            line.style.bg = None;
-        }
+        let rendered = self.readme_rendered.clone().unwrap_or_default();
 
         let readme_title = self
             .selected_repo()

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -159,6 +159,97 @@ fn parse_tag_name(tag: &str) -> String {
         .collect()
 }
 
+/// Markdown の pipe テーブル (`| a | b |` + `| --- | --- |`) を検出して
+/// 列ごとに max 幅に合わせて space padding を追加する。tui-markdown 0.3 は
+/// テーブルを plain text として流すだけなので、行ごとの cell 長が違うと `|`
+/// 位置がバラつく。pre-pass で揃えておくと少なくとも pane に収まる table は
+/// 整って見える (pane 幅を超える場合は wrap するのでそこは仕方ない)。
+fn realign_markdown_tables(input: &str) -> String {
+    use unicode_width::UnicodeWidthStr;
+
+    let lines: Vec<&str> = input.lines().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if is_table_header(line) && i + 1 < lines.len() && is_table_separator(lines[i + 1]) {
+            // 連続する table 行を収集
+            let mut end = i + 2;
+            while end < lines.len() && is_table_row(lines[end]) {
+                end += 1;
+            }
+            let rows = &lines[i..end];
+            // 各行をセル列に分解 (先頭/末尾の `|` は除く、trim)
+            let parsed: Vec<Vec<&str>> = rows
+                .iter()
+                .map(|l| {
+                    let t = l.trim();
+                    let inner = t.strip_prefix('|').unwrap_or(t);
+                    let inner = inner.strip_suffix('|').unwrap_or(inner);
+                    inner.split('|').map(|c| c.trim()).collect()
+                })
+                .collect();
+            let ncols = parsed.iter().map(|r| r.len()).max().unwrap_or(0);
+            let mut widths = vec![0usize; ncols];
+            // separator 行 (index 1) は width 計算から除外
+            for (row_idx, row) in parsed.iter().enumerate() {
+                if row_idx == 1 {
+                    continue;
+                }
+                for (ci, cell) in row.iter().enumerate() {
+                    widths[ci] = widths[ci].max(UnicodeWidthStr::width(*cell));
+                }
+            }
+            for (row_idx, row) in parsed.iter().enumerate() {
+                out.push('|');
+                for (ci, width) in widths.iter().enumerate() {
+                    out.push(' ');
+                    let cell = row.get(ci).copied().unwrap_or("");
+                    if row_idx == 1 {
+                        out.push_str(&"-".repeat((*width).max(3)));
+                    } else {
+                        out.push_str(cell);
+                        let pad = width.saturating_sub(UnicodeWidthStr::width(cell));
+                        for _ in 0..pad {
+                            out.push(' ');
+                        }
+                    }
+                    out.push(' ');
+                    out.push('|');
+                }
+                out.push('\n');
+            }
+            i = end;
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+        i += 1;
+    }
+    out
+}
+
+fn is_table_row(line: &str) -> bool {
+    let t = line.trim();
+    t.starts_with('|') && t.len() >= 2 && t.contains('|')
+}
+
+fn is_table_header(line: &str) -> bool {
+    is_table_row(line)
+}
+
+fn is_table_separator(line: &str) -> bool {
+    let t = line.trim();
+    if !t.starts_with('|') || !t.ends_with('|') || t.len() < 3 {
+        return false;
+    }
+    let inner = &t[1..t.len() - 1];
+    inner.split('|').all(|cell| {
+        let c = cell.trim();
+        !c.is_empty() && c.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+    })
+}
+
 /// Paragraph が `Wrap { trim: false }` で描画したときの実行数を推定する。
 /// - 幅が 0 (draw 前) なら Text の Line 数をそのまま返す
 /// - 各 Line の spans 合計 display 幅を `pane_width` で割り切り上げ (空 Line は 1 行)
@@ -570,7 +661,10 @@ impl StoreTuiState {
         // `unicode-width` は幅 1 と答えるが terminal は 2 セルで描画するため
         // tui-markdown の Line 折返しが壊れる。リスト側と同じく PUA / VS を除去する。
         let sanitized = sanitize_cell_text(&cleaned);
-        self.readme_prepared = format!("{}{}", topics_prefix, sanitized);
+        // pipe テーブルは tui-markdown が plain text として流してしまい行毎に
+        // `|` 位置がバラつくので、事前に列幅を揃えておく。
+        let aligned = realign_markdown_tables(&sanitized);
+        self.readme_prepared = format!("{}{}", topics_prefix, aligned);
         // ratatui の Paragraph({ wrap: trim=false }) が pane 幅で折り返した後の
         // 実行数を推定する。各 Line の表示幅を unicode-width で測り、
         // pane の内側幅で割って切り上げて合計する近似 (空 Line は 1 行分)。
@@ -1434,6 +1528,65 @@ mod tests {
     fn test_sanitize_keeps_ascii() {
         let input = "A collection of small qol plugins for Neovim";
         assert_eq!(sanitize_cell_text(input), input);
+    }
+
+    // ───── realign_markdown_tables ─────
+
+    #[test]
+    fn test_realign_table_pads_short_cells() {
+        let input = "\
+| short | name |
+| --- | --- |
+| NoiceCmdlineIcon | desc |
+";
+        let out = realign_markdown_tables(input);
+        // 列ごとに `|` 位置が揃っているか
+        let lines: Vec<&str> = out.lines().collect();
+        let pipe_positions: Vec<Vec<usize>> = lines
+            .iter()
+            .map(|l| {
+                l.char_indices()
+                    .filter(|(_, c)| *c == '|')
+                    .map(|(i, _)| i)
+                    .collect()
+            })
+            .collect();
+        assert_eq!(pipe_positions[0], pipe_positions[2]);
+    }
+
+    #[test]
+    fn test_realign_table_preserves_non_table_lines() {
+        let input = "\
+Hello world
+| a | b |
+| --- | --- |
+| 1 | 2 |
+Goodbye
+";
+        let out = realign_markdown_tables(input);
+        assert!(out.contains("Hello world"));
+        assert!(out.contains("Goodbye"));
+    }
+
+    #[test]
+    fn test_realign_table_handles_empty_cells() {
+        let input = "\
+| a | b | c |
+| --- | --- | --- |
+| x | | z |
+";
+        let out = realign_markdown_tables(input);
+        // 空セルが原因で column 数が狂わないこと
+        assert_eq!(out.lines().count(), 3);
+    }
+
+    #[test]
+    fn test_realign_without_separator_is_noop() {
+        // separator が無い連続行はテーブル扱いしない
+        let input = "| not | a table |\nbecause no separator";
+        let out = realign_markdown_tables(input);
+        assert!(out.contains("| not | a table |"));
+        assert!(out.contains("because no separator"));
     }
 
     #[test]

--- a/src/store_tui.rs
+++ b/src/store_tui.rs
@@ -6,6 +6,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Row, Table, TableState, Wrap},
 };
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Focus {
@@ -16,8 +17,21 @@ pub enum Focus {
 pub struct StoreTuiState {
     pub plugins: Vec<GitHubRepo>,
     pub table_state: TableState,
+    /// ローカルインクリメンタル検索の入力モード (`/` キー)
     pub search_mode: bool,
+    /// GitHub API 検索の入力モード (`S` キー) — 旧 `/` の挙動を退避
+    pub api_search_mode: bool,
+    /// search_mode / api_search_mode で共有する入力バッファ
     pub search_input: String,
+    /// 確定済み検索パターン (n/N 用)
+    pub search_pattern: Option<String>,
+    /// 検索にヒットした plugins のインデックス一覧
+    pub search_matches: Vec<usize>,
+    /// search_matches 内の現在位置
+    pub search_cursor: usize,
+    /// インストール済みプラグインの full_name (小文字) 集合。`Enter` 時の
+    /// 重複 add 警告と、リスト行の ✓ マーク表示に使う。
+    pub installed: HashSet<String>,
     pub readme_content: Option<String>,
     pub readme_loading: bool,
     pub readme_scroll: u16,
@@ -52,13 +66,125 @@ impl SortMode {
     }
 }
 
+/// GitHub README によくある `<img src="...badge">`, `<a>`, `<p align="center">`,
+/// `<br>`, `<div>` 等の HTML タグを除去して markdown として読みやすくする。
+///
+/// 完全な HTML パーサではなく、行単位の **存在感が大きい** タグだけを対象にする最小限の処理:
+/// - `<img .../>` や `<img ...>` を alt text で置き換え (alt があれば) or 空文字
+/// - `<a ...>` / `</a>` / `<br ?/?>` / `<div ...>` / `</div>` / `<p ...>` / `</p>` / `<picture>` 類を削除
+/// - `<!-- ... -->` コメントを削除
+fn strip_common_html(input: &str) -> String {
+    let mut s = input.to_string();
+
+    // HTML コメントを削除
+    while let Some(start) = s.find("<!--") {
+        if let Some(rel_end) = s[start..].find("-->") {
+            s.replace_range(start..start + rel_end + 3, "");
+        } else {
+            break;
+        }
+    }
+
+    // <img ...> を alt text or 空文字に置換
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<'
+            && i + 4 <= bytes.len()
+            && &s[i..i + 4].to_lowercase() == "<img"
+            && let Some(rel_end) = s[i..].find('>')
+        {
+            let tag = &s[i..=i + rel_end];
+            let alt = extract_attr(tag, "alt").unwrap_or_default();
+            if !alt.is_empty() {
+                out.push_str(&alt);
+            }
+            i += rel_end + 1;
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    // 既知の **開き/閉じ両方** のタグ名だけを、`<tag ...>` or `</tag>` or `<tag ... />` 形式で削除
+    let tags = [
+        "a", "br", "div", "p", "picture", "source", "sub", "sup", "kbd", "details", "summary",
+        "center", "span", "table", "tr", "td", "th", "tbody", "thead", "ul", "li",
+    ];
+    for tag in tags {
+        let open = format!("<{}", tag);
+        let close = format!("</{}>", tag);
+        out = remove_tag_instances(&out, &open, &close);
+    }
+
+    out
+}
+
+/// `<img alt="Hello world" src="...">` から `alt` の値を取り出す。
+/// 非常に緩いパース (属性はクォート必須、エスケープ非対応)。見つからなければ None。
+fn extract_attr(tag: &str, attr: &str) -> Option<String> {
+    let lower = tag.to_lowercase();
+    let pat = format!("{}=", attr);
+    let pos = lower.find(&pat)?;
+    let rest = &tag[pos + pat.len()..];
+    let (delim, start_off) = if let Some(stripped) = rest.strip_prefix('"') {
+        ('"', stripped.as_ptr() as usize - rest.as_ptr() as usize)
+    } else if let Some(stripped) = rest.strip_prefix('\'') {
+        ('\'', stripped.as_ptr() as usize - rest.as_ptr() as usize)
+    } else {
+        return None;
+    };
+    let body = &rest[start_off..];
+    let end = body.find(delim)?;
+    Some(body[..end].to_string())
+}
+
+/// `<tag ...>` および `</tag>` をすべて削除。
+/// `input.to_lowercase()` で case-insensitive 比較するが、削除は元文字列に対して行う。
+fn remove_tag_instances(input: &str, open_prefix: &str, close: &str) -> String {
+    let mut s = input.to_string();
+    let lower_open = open_prefix.to_lowercase();
+    let lower_close = close.to_lowercase();
+
+    loop {
+        let lower = s.to_lowercase();
+        if let Some(start) = lower.find(&lower_open) {
+            // 次が ' ' / '>' / '/' のいずれかでないと別タグ (e.g., <abbr>)
+            let after = s[start + open_prefix.len()..].chars().next().unwrap_or('>');
+            if !matches!(after, ' ' | '>' | '/' | '\t' | '\n') {
+                // false positive, skip this instance by slicing past it
+                let remainder = &s[start + open_prefix.len()..];
+                // just break to avoid infinite loop; accept leftover
+                let _ = remainder;
+                break;
+            }
+            if let Some(rel_end) = s[start..].find('>') {
+                s.replace_range(start..start + rel_end + 1, "");
+                continue;
+            }
+        }
+        break;
+    }
+
+    while let Some(start) = s.to_lowercase().find(&lower_close) {
+        s.replace_range(start..start + close.len(), "");
+    }
+    s
+}
+
 impl StoreTuiState {
     pub fn new() -> Self {
         Self {
             plugins: Vec::new(),
             table_state: TableState::default(),
             search_mode: false,
+            api_search_mode: false,
             search_input: String::new(),
+            search_pattern: None,
+            search_matches: Vec::new(),
+            search_cursor: 0,
+            installed: HashSet::new(),
             readme_content: None,
             readme_loading: false,
             readme_scroll: 0,
@@ -77,6 +203,10 @@ impl StoreTuiState {
         }
         self.readme_content = None;
         self.readme_scroll = 0;
+        // プラグイン差し替え時は検索結果を無効化 (インデックスが無意味になるため)
+        self.search_pattern = None;
+        self.search_matches.clear();
+        self.search_cursor = 0;
     }
 
     pub fn sort_plugins(&mut self) {
@@ -193,6 +323,128 @@ impl StoreTuiState {
         self.readme_scroll = self.readme_scroll.saturating_sub(n);
     }
 
+    // ───────── ローカル検索 (`/` + n/N) ─────────
+
+    /// `/` モードを開始 (local incremental search)。
+    pub fn start_search(&mut self) {
+        self.search_mode = true;
+        self.api_search_mode = false;
+        self.search_input.clear();
+        self.message = None;
+    }
+
+    /// `S` モードを開始 (GitHub API search)。
+    pub fn start_api_search(&mut self) {
+        self.api_search_mode = true;
+        self.search_mode = false;
+        self.search_input.clear();
+        self.message = None;
+    }
+
+    /// 検索モード (local/API 共通) を Esc でキャンセルし、local 側のハイライトも消す。
+    pub fn search_cancel(&mut self) {
+        self.search_mode = false;
+        self.api_search_mode = false;
+        self.search_input.clear();
+        self.search_pattern = None;
+        self.search_matches.clear();
+        self.search_cursor = 0;
+    }
+
+    /// local 検索モードで Enter を押したときの確定処理。
+    /// search_pattern は保持し続けるので、引き続き n/N で移動できる。
+    pub fn search_confirm(&mut self) {
+        self.search_mode = false;
+    }
+
+    /// local 検索モードで文字を入力 (インクリメンタル)。
+    pub fn search_type(&mut self, c: char) {
+        self.search_input.push(c);
+        self.run_local_search(&self.search_input.clone());
+    }
+
+    /// local 検索モードで Backspace。空になったらハイライトクリア。
+    pub fn search_backspace(&mut self) {
+        self.search_input.pop();
+        if self.search_input.is_empty() {
+            self.search_pattern = None;
+            self.search_matches.clear();
+            self.search_cursor = 0;
+        } else {
+            self.run_local_search(&self.search_input.clone());
+        }
+    }
+
+    /// `plugin_name + description + topics` を対象に大文字小文字無視で部分一致検索。
+    /// 最初のマッチにカーソルを移動。
+    fn run_local_search(&mut self, pattern: &str) {
+        let pat = pattern.to_lowercase();
+        self.search_matches = self
+            .plugins
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| {
+                let name_hit = r.plugin_name().to_lowercase().contains(&pat);
+                let desc_hit = r
+                    .description
+                    .as_deref()
+                    .map(|d| d.to_lowercase().contains(&pat))
+                    .unwrap_or(false);
+                let topic_hit = r.topics.iter().any(|t| t.to_lowercase().contains(&pat));
+                name_hit || desc_hit || topic_hit
+            })
+            .map(|(i, _)| i)
+            .collect();
+        self.search_pattern = Some(pattern.to_string());
+        self.search_cursor = 0;
+        if let Some(&idx) = self.search_matches.first() {
+            self.table_state.select(Some(idx));
+            self.readme_content = None;
+            self.readme_scroll = 0;
+        }
+    }
+
+    /// n — 次のマッチへ (ラップ)。
+    pub fn search_next(&mut self) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        self.search_cursor = (self.search_cursor + 1) % self.search_matches.len();
+        let idx = self.search_matches[self.search_cursor];
+        self.table_state.select(Some(idx));
+        self.readme_content = None;
+        self.readme_scroll = 0;
+    }
+
+    /// N — 前のマッチへ (ラップ)。
+    pub fn search_prev(&mut self) {
+        if self.search_matches.is_empty() {
+            return;
+        }
+        self.search_cursor = if self.search_cursor == 0 {
+            self.search_matches.len() - 1
+        } else {
+            self.search_cursor - 1
+        };
+        let idx = self.search_matches[self.search_cursor];
+        self.table_state.select(Some(idx));
+        self.readme_content = None;
+        self.readme_scroll = 0;
+    }
+
+    // ───────── installed マーク ─────────
+
+    /// 現在選択中の plugin がインストール済みかを判定。
+    /// GitHub の `full_name` は大文字小文字非依存なので lowercase で比較。
+    pub fn is_installed(&self, repo: &GitHubRepo) -> bool {
+        self.installed.contains(&repo.full_name.to_lowercase())
+    }
+
+    /// add 後に呼び出し、以降のリスト描画で ✓ マークが付くようにする。
+    pub fn mark_installed(&mut self, repo: &GitHubRepo) {
+        self.installed.insert(repo.full_name.to_lowercase());
+    }
+
     pub fn draw(&mut self, f: &mut Frame) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -204,8 +456,19 @@ impl StoreTuiState {
             .split(f.area());
 
         // ── Title / Search bar ──
-        let title_content = if self.search_mode {
-            let match_info = format!(" ({} results)", self.plugins.len());
+        let title_content = if self.search_mode || self.api_search_mode {
+            let prompt = if self.api_search_mode { " S " } else { " / " };
+            let match_info = if self.api_search_mode {
+                format!(" (GitHub API, {} cached)", self.plugins.len())
+            } else if self.search_input.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " ({}/{} matches)",
+                    self.search_matches.len(),
+                    self.plugins.len()
+                )
+            };
             Line::from(vec![
                 Span::styled(
                     " rvpm store ",
@@ -215,7 +478,7 @@ impl StoreTuiState {
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    " / ",
+                    prompt,
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -227,6 +490,16 @@ impl StoreTuiState {
         } else {
             let info = if let Some(msg) = &self.message {
                 Span::styled(format!("  {}", msg), Style::default().fg(Color::Green))
+            } else if let Some(pat) = &self.search_pattern {
+                Span::styled(
+                    format!(
+                        "  /{}  {} matches  sort:{}",
+                        pat,
+                        self.search_matches.len(),
+                        self.sort_mode.label()
+                    ),
+                    Style::default().fg(Color::DarkGray),
+                )
             } else {
                 Span::styled(
                     format!(
@@ -268,12 +541,30 @@ impl StoreTuiState {
             .map(|repo| {
                 let desc = repo.description.as_deref().unwrap_or("");
                 let desc_truncated: String = desc.chars().take(40).collect();
+                let installed_cell = if self.is_installed(repo) {
+                    ratatui::widgets::Cell::from(Span::styled(
+                        "\u{2713}",
+                        Style::default().fg(Color::Green),
+                    ))
+                } else {
+                    ratatui::widgets::Cell::from(" ")
+                };
+                let topics_str: String = repo
+                    .topics
+                    .iter()
+                    .take(3)
+                    .map(|t| format!("#{}", t))
+                    .collect::<Vec<_>>()
+                    .join(" ");
                 Row::new(vec![
+                    installed_cell,
                     ratatui::widgets::Cell::from(format!(" \u{2605}{}", repo.stars_display()))
                         .style(Style::default().fg(Color::Yellow)),
                     ratatui::widgets::Cell::from(repo.plugin_name().to_string())
                         .style(Style::default().fg(Color::White)),
                     ratatui::widgets::Cell::from(desc_truncated)
+                        .style(Style::default().fg(Color::DarkGray)),
+                    ratatui::widgets::Cell::from(topics_str)
                         .style(Style::default().fg(Color::DarkGray)),
                 ])
             })
@@ -282,9 +573,11 @@ impl StoreTuiState {
         let table = Table::new(
             rows,
             [
+                Constraint::Length(2),
                 Constraint::Length(8),
                 Constraint::Length(30),
-                Constraint::Min(10),
+                Constraint::Min(20),
+                Constraint::Length(24),
             ],
         )
         .block(
@@ -305,25 +598,50 @@ impl StoreTuiState {
         .highlight_symbol("\u{25b8} ");
         f.render_stateful_widget(table, main_chunks[0], &mut self.table_state);
 
-        // Right: README preview
-        let readme_text = if self.readme_loading {
-            "Loading README...".to_string()
+        // Right: README preview (tui-markdown rendered GFM)
+        let readme_body = if self.readme_loading {
+            "_Loading README..._".to_string()
         } else {
             self.readme_content.clone().unwrap_or_else(|| {
                 if self.plugins.is_empty() {
-                    "Press / to search for plugins".to_string()
+                    "_Press / to search or S to fetch more._".to_string()
                 } else {
-                    "Loading...".to_string()
+                    "_Loading..._".to_string()
                 }
             })
         };
+
+        // 選択中 repo の topics を README 先頭に prepend (DarkGray、区切り線付き)
+        let topics_prefix = self
+            .selected_repo()
+            .map(|r| {
+                if r.topics.is_empty() {
+                    String::new()
+                } else {
+                    let joined = r
+                        .topics
+                        .iter()
+                        .map(|t| format!("`{}`", t))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!("**Topics:** {}\n\n---\n\n", joined)
+                }
+            })
+            .unwrap_or_default();
+
+        // バッジや `<div>` 等の HTML タグは pulldown-cmark が HTML block として扱うので
+        // 生テキストが残る。最低限、行頭の `<img ...>` / `<a ...>` / `</a>` / `<br>` 等を
+        // 除去して見た目を整える。
+        let cleaned_body = strip_common_html(&readme_body);
+        let combined = format!("{}{}", topics_prefix, cleaned_body);
+        let rendered = tui_markdown::from_str(&combined);
 
         let readme_title = self
             .selected_repo()
             .map(|r| format!(" {} ", r.full_name))
             .unwrap_or_else(|| " README ".to_string());
 
-        let readme = Paragraph::new(readme_text)
+        let readme = Paragraph::new(rendered)
             .block(
                 Block::default()
                     .title(readme_title)
@@ -339,10 +657,15 @@ impl StoreTuiState {
         f.render_widget(readme, main_chunks[1]);
 
         // ── Footer ──
-        let footer = if self.search_mode {
+        let footer = if self.search_mode || self.api_search_mode {
+            let confirm_label = if self.api_search_mode {
+                ":api-search "
+            } else {
+                ":confirm "
+            };
             Paragraph::new(Line::from(vec![
                 Span::styled(" Enter", Style::default().fg(Color::Yellow)),
-                Span::styled(":search ", Style::default().fg(Color::DarkGray)),
+                Span::styled(confirm_label, Style::default().fg(Color::DarkGray)),
                 Span::styled("Esc", Style::default().fg(Color::Yellow)),
                 Span::styled(":cancel", Style::default().fg(Color::DarkGray)),
             ]))
@@ -354,6 +677,10 @@ impl StoreTuiState {
             Paragraph::new(Line::from(vec![
                 Span::styled(" /", Style::default().fg(Color::Yellow)),
                 Span::styled(":search ", Style::default().fg(Color::DarkGray)),
+                Span::styled("n/N", Style::default().fg(Color::Yellow)),
+                Span::styled(":next/prev ", Style::default().fg(Color::DarkGray)),
+                Span::styled("S", Style::default().fg(Color::Yellow)),
+                Span::styled(":api-search ", Style::default().fg(Color::DarkGray)),
                 Span::styled("Tab", Style::default().fg(Color::Yellow)),
                 Span::styled(
                     format!(":{} ", focus_label),
@@ -361,8 +688,6 @@ impl StoreTuiState {
                 ),
                 Span::styled("Enter", Style::default().fg(Color::Yellow)),
                 Span::styled(":add ", Style::default().fg(Color::DarkGray)),
-                Span::styled("s", Style::default().fg(Color::Yellow)),
-                Span::styled(":sort ", Style::default().fg(Color::DarkGray)),
                 Span::styled("?", Style::default().fg(Color::Yellow)),
                 Span::styled(":help ", Style::default().fg(Color::DarkGray)),
                 Span::styled("q", Style::default().fg(Color::Yellow)),
@@ -379,8 +704,8 @@ impl StoreTuiState {
             use ratatui::layout::Rect;
             use ratatui::widgets::Clear;
             let area = f.area();
-            let popup_w = 50u16.min(area.width.saturating_sub(4));
-            let popup_h = 18u16.min(area.height.saturating_sub(4));
+            let popup_w = 60u16.min(area.width.saturating_sub(4));
+            let popup_h = 26u16.min(area.height.saturating_sub(4));
             let popup = Rect::new(
                 (area.width.saturating_sub(popup_w)) / 2,
                 (area.height.saturating_sub(popup_h)) / 2,
@@ -418,9 +743,31 @@ impl StoreTuiState {
                         Style::default().fg(Color::White),
                     ),
                 ]),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "  Search",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
                 Line::from(vec![
                     Span::styled("  /           ", Style::default().fg(Color::Yellow)),
-                    Span::styled("Search plugins", Style::default().fg(Color::White)),
+                    Span::styled(
+                        "Local incremental (name + desc + topics)",
+                        Style::default().fg(Color::White),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  n / N       ", Style::default().fg(Color::Yellow)),
+                    Span::styled("Next / prev match", Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  S           ", Style::default().fg(Color::Yellow)),
+                    Span::styled(
+                        "GitHub API search (fetch)",
+                        Style::default().fg(Color::White),
+                    ),
                 ]),
                 Line::from(""),
                 Line::from(vec![Span::styled(
@@ -449,6 +796,21 @@ impl StoreTuiState {
                 Line::from(vec![
                     Span::styled("  q / Esc     ", Style::default().fg(Color::Yellow)),
                     Span::styled("Quit", Style::default().fg(Color::White)),
+                ]),
+                Line::from(""),
+                Line::from(vec![Span::styled(
+                    "  Legend",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("  \u{2713}           ", Style::default().fg(Color::Green)),
+                    Span::styled(
+                        "Already installed in your config",
+                        Style::default().fg(Color::White),
+                    ),
                 ]),
             ];
             f.render_widget(Clear, popup);
@@ -589,5 +951,218 @@ mod tests {
         assert_eq!(state.table_state.selected(), Some(4));
         state.move_up(100);
         assert_eq!(state.table_state.selected(), Some(0));
+    }
+
+    fn make_repo_full(
+        name: &str,
+        stars: u64,
+        description: Option<&str>,
+        topics: Vec<&str>,
+    ) -> GitHubRepo {
+        GitHubRepo {
+            full_name: format!("owner/{}", name),
+            html_url: format!("https://github.com/owner/{}", name),
+            description: description.map(|d| d.to_string()),
+            stargazers_count: stars,
+            updated_at: "2026-01-01".to_string(),
+            topics: topics.iter().map(|t| t.to_string()).collect(),
+            default_branch: Some("main".to_string()),
+        }
+    }
+
+    // ───── local search (/ + n/N) ─────
+
+    #[test]
+    fn test_search_matches_plugin_name() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("telescope", 100, Some("fuzzy"), vec![]),
+            make_repo_full("snacks", 90, Some("misc"), vec![]),
+        ]);
+        state.start_search();
+        state.search_type('t');
+        state.search_type('e');
+        state.search_type('l');
+        assert_eq!(state.search_matches, vec![0]);
+        assert_eq!(state.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn test_search_matches_description() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("telescope", 100, Some("fuzzy finder"), vec![]),
+            make_repo_full("snacks", 90, Some("misc utilities"), vec![]),
+        ]);
+        state.start_search();
+        state.search_type('f');
+        state.search_type('u');
+        state.search_type('z');
+        assert_eq!(state.search_matches, vec![0]);
+    }
+
+    #[test]
+    fn test_search_matches_topic() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("telescope", 100, Some("x"), vec!["lua"]),
+            make_repo_full("snacks", 90, Some("y"), vec!["utility"]),
+        ]);
+        state.start_search();
+        state.search_type('l');
+        state.search_type('u');
+        state.search_type('a');
+        assert_eq!(state.search_matches, vec![0]);
+    }
+
+    #[test]
+    fn test_search_case_insensitive() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("Telescope", 100, Some("Fuzzy"), vec!["Lua"]),
+            make_repo_full("snacks", 90, Some("z"), vec![]),
+        ]);
+        state.start_search();
+        state.search_type('L');
+        state.search_type('u');
+        state.search_type('A');
+        assert_eq!(state.search_matches, vec![0]);
+    }
+
+    #[test]
+    fn test_search_next_wraps() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("aaa-nvim", 300, None, vec![]),
+            make_repo_full("bbb", 200, None, vec![]),
+            make_repo_full("ccc-nvim", 100, None, vec![]),
+        ]);
+        state.start_search();
+        state.search_type('n');
+        state.search_type('v');
+        state.search_type('i');
+        state.search_type('m');
+        // matches are aaa-nvim (idx 0) and ccc-nvim (idx 2)
+        assert_eq!(state.search_matches, vec![0, 2]);
+        assert_eq!(state.table_state.selected(), Some(0));
+        state.search_next();
+        assert_eq!(state.table_state.selected(), Some(2));
+        state.search_next(); // wrap
+        assert_eq!(state.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn test_search_prev_wraps() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("aaa-nvim", 300, None, vec![]),
+            make_repo_full("bbb", 200, None, vec![]),
+            make_repo_full("ccc-nvim", 100, None, vec![]),
+        ]);
+        state.start_search();
+        state.search_type('n');
+        state.search_type('v');
+        state.search_type('i');
+        state.search_type('m');
+        assert_eq!(state.table_state.selected(), Some(0));
+        state.search_prev(); // wrap to last
+        assert_eq!(state.table_state.selected(), Some(2));
+        state.search_prev();
+        assert_eq!(state.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn test_search_backspace_clears_matches_when_empty() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![make_repo_full("telescope", 100, None, vec![])]);
+        state.start_search();
+        state.search_type('t');
+        assert!(!state.search_matches.is_empty());
+        state.search_backspace();
+        assert!(state.search_matches.is_empty());
+        assert!(state.search_pattern.is_none());
+    }
+
+    #[test]
+    fn test_search_cancel_clears_state() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![make_repo_full("telescope", 100, None, vec![])]);
+        state.start_search();
+        state.search_type('t');
+        state.search_cancel();
+        assert!(!state.search_mode);
+        assert!(!state.api_search_mode);
+        assert!(state.search_input.is_empty());
+        assert!(state.search_pattern.is_none());
+        assert!(state.search_matches.is_empty());
+    }
+
+    #[test]
+    fn test_search_confirm_keeps_pattern_for_next() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![
+            make_repo_full("aaa-nvim", 300, None, vec![]),
+            make_repo_full("bbb-nvim", 200, None, vec![]),
+        ]);
+        state.start_search();
+        state.search_type('n');
+        state.search_type('v');
+        state.search_confirm();
+        assert!(!state.search_mode);
+        assert_eq!(state.search_pattern.as_deref(), Some("nv"));
+        // n キーでジャンプできる
+        state.search_next();
+        assert_eq!(state.table_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn test_start_api_search_cancels_local_search() {
+        let mut state = StoreTuiState::new();
+        state.start_search();
+        state.search_type('a');
+        state.start_api_search();
+        assert!(!state.search_mode);
+        assert!(state.api_search_mode);
+        assert!(state.search_input.is_empty());
+    }
+
+    #[test]
+    fn test_set_plugins_clears_search_state() {
+        let mut state = StoreTuiState::new();
+        state.set_plugins(vec![make_repo_full("telescope", 100, None, vec![])]);
+        state.start_search();
+        state.search_type('t');
+        assert!(!state.search_matches.is_empty());
+        // 再取得 (API search で差し替え) シミュレーション
+        state.set_plugins(vec![make_repo_full("other", 50, None, vec![])]);
+        assert!(state.search_matches.is_empty());
+        assert!(state.search_pattern.is_none());
+        assert_eq!(state.search_cursor, 0);
+    }
+
+    // ───── installed mark ─────
+
+    #[test]
+    fn test_is_installed_case_insensitive() {
+        let mut state = StoreTuiState::new();
+        state.installed.insert("folke/snacks.nvim".to_string());
+        let repo = make_repo_full("Snacks.nvim", 100, None, vec![]);
+        // full_name is "owner/Snacks.nvim" — different owner, miss
+        assert!(!state.is_installed(&repo));
+
+        // 完全一致 (大文字混じり) は小文字比較でヒット
+        state.installed.clear();
+        state.installed.insert("owner/snacks.nvim".to_string());
+        let repo2 = make_repo_full("Snacks.NVIM", 100, None, vec![]);
+        assert!(state.is_installed(&repo2));
+    }
+
+    #[test]
+    fn test_mark_installed_adds_to_set() {
+        let mut state = StoreTuiState::new();
+        let repo = make_repo_full("telescope.nvim", 100, None, vec![]);
+        assert!(!state.is_installed(&repo));
+        state.mark_installed(&repo);
+        assert!(state.is_installed(&repo));
     }
 }


### PR DESCRIPTION
## Summary

- `/` now does **local incremental search** over `plugin_name + description + topics`, matching the list TUI convention; `n` / `N` jump between matches.
- **`S` key** preserves the previous GitHub API search (`topic:neovim-plugin <query>`) for fetching beyond the cached result set.
- **Fetch up to three pages (~300 plugins)** from the GitHub Search API with per-page resilience (partial failures keep the already-fetched results).
- Render the README pane through `tui-markdown` (without the heavy `highlight-code` feature), strip common HTML tags (`<img>` becomes its `alt` text; `<a>`/`<div>`/`<br>` etc. are removed) and prepend repo topics as a `Topics: ...` line with a separator.
- **Installed mark**: plugins already present in `config.toml` get a green `✓` in the leftmost column. Pressing `Enter` on an installed plugin shows `already installed: ...` instead of re-adding it.
- **Topics column**: rightmost column shows up to three topics (`#lua #ui ...`) in dark gray.
- Help popup, footer, README.md and CLAUDE.md are updated for the new keys and legend.

## Test plan

- [x] `cargo test` — 202 passed, including new unit tests covering `/` local search, `n`/`N` wrap, `Esc` cancel, installed-case matching, and the `installed_full_name` URL normalization helper.
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] `cargo fmt --all -- --check` is clean.
- [ ] Manual `rvpm store` run:
  - [ ] ~300 plugins on first launch, green `✓` on already-installed ones, topics visible in the rightmost column.
  - [ ] `/lua` incrementally filters; `n` / `N` jump between matches; `Esc` clears; `Enter` keeps the pattern for further `n`/`N`.
  - [ ] `S` prompts for an API query and replaces the list with the result.
  - [ ] `Enter` on an installed plugin shows the warning message; `Enter` on a new plugin adds it and flips the row to `✓` on return.
  - [ ] README pane shows headings/lists/code blocks styled by `tui-markdown`, and badge `<img>` blocks are reduced to readable alt text.
  - [ ] `R` clears the cache and reloads 300 plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local incremental search (`/`) across name/description/topics with `n`/`N` navigation; `S` triggers GitHub API search
  * README preview rendered as GitHub-flavored Markdown with syntax highlighting; installed plugins show a leading ✓
  * Discovery expanded to fetch more results (up to ~300 across pages); `R` refreshes cache; `o`, `s`, `Tab`, `?` keybindings updated

* **Behavior Changes**
  * `Enter` skips already-installed plugins with a warning; `Esc` cancels active input, `q` quits

* **Documentation**
  * Updated store command docs and keybindings

* **Tests**
  * Added tests for search, README handling, URL normalization, and installed-state behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->