### PR TITLE
docs: stack demo GIFs vertically so they render at full README width

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ sources everything without any runtime glob cost.
 
 ## Demos
 
-| `rvpm init --write` → `add` → `list` | `rvpm store` (plugin browser) |
-|---|---|
-| ![list](vhs/demo.gif) | ![store](vhs/store.gif) |
+**`rvpm init --write` → `add` → `list`**
+
+![list](vhs/demo.gif)
+
+**`rvpm store` — plugin browser**
+
+![store](vhs/store.gif)
 
 GIFs are generated from the `vhs/demo.tape` / `vhs/store.tape` files
 with [vhs](https://github.com/charmbracelet/vhs) — `cd vhs && vhs


### PR DESCRIPTION
## Summary

- The previous two-column table under `## Demos` packed each GIF into half the README column, which made both recordings (900 px and 1200 px source widths) hard to read on GitHub.
- Switch to plain bold labels above each `![...](...)` image so the demos stack vertically and each gets the full column width.

## Test plan

- [x] Rendered preview locally: each GIF now occupies the full column width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Demos section layout from a two-column table format to a stacked layout for improved readability and presentation of demo content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->