### PR TITLE
feat: standalone `rvpm clean` command and `options.auto_clean`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,9 @@ nvim_rc = "~/.config/nvim/rc"
 config_root = "{{ vars.nvim_rc }}/plugins"
 # 並列数上限 (デフォルト 8、GitHub rate limit 回避のため控えめ)
 concurrency = 10
+# config.toml から外したプラグインディレクトリを sync / generate 完了時に
+# 自動削除 (デフォルト false)。毎回 `sync --prune` を指定する代わり。
+# auto_clean = true
 # rvpm のデータ置き場 root を上書き (未指定なら ~/.cache/rvpm)
 # repos / merged / loader.lua 全部ここ配下にまとまる
 # base_dir = "~/.cache/nvim/rvpm"
@@ -270,6 +273,7 @@ let _permit = sem.acquire_owned().await.unwrap();
 |---------|------|------|
 | `sync [--prune]` | `run_sync()` | clone/pull + merged + loader.lua 生成。`--prune` で未使用プラグインディレクトリも削除。無指定でも未使用があれば末尾で警告表示 |
 | `generate` | `run_generate()` | loader.lua のみ再生成 |
+| `clean` | `run_clean()` | config.toml から外したプラグインの `{cache_root}/plugins/repos/<host>/<owner>/<repo>/` を削除。git 操作なしで `sync --prune` より高速 (200+ プラグインでの所要時間対策)。共有ヘルパー `prune_unused_repos()` を `sync --prune` と共用 |
 | `add <repo>` | `run_add()` | TOML 追加 + 当該プラグインだけ clone + generate |
 | `update [query]` | `run_update()` | 既存プラグインの pull (clone しない) |
 | `remove [query]` | `run_remove()` | TOML + ディレクトリ削除 + generate |
@@ -282,7 +286,6 @@ let _permit = sem.acquire_owned().await.unwrap();
 
 **廃止コマンド:**
 - `status` → `list --no-tui` に統合 (plain text 出力で機能同等)
-- `clean` → `sync --prune` に統合。未使用 dir がある状態で `sync` を走らせると末尾に警告が出るので発見しやすい
 
 ### ディレクトリレイアウト (デフォルト)
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ concurrency = 10
 # Requires `chezmoi` in PATH. See "chezmoi integration" below.
 # chezmoi = true
 
+# Auto-prune plugin dirs no longer referenced by config.toml on every
+# `sync` and `generate`. Default: false. Same effect as always passing
+# `sync --prune`. Standalone `rvpm clean` remains available.
+# auto_clean = true
+
 # Optional: run READMEs in the store TUI through an external renderer
 # (mdcat / glow / bat). See "External README renderer" below.
 # [options.store]
@@ -178,6 +183,7 @@ for where files land).
 | `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for all rvpm cache (`plugins/repos/`, `plugins/merged/`, `plugins/loader.lua`, `store/`). **Recommended: leave unset** |
 | `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
 | `chezmoi` | `boolean` | `false` | When `true`, rvpm writes mutations (`config.toml`, global hooks, per-plugin hooks) directly to the chezmoi **source** file (resolved via `chezmoi source-path`) and then runs `chezmoi apply --force` to materialise the change in the target. Falls back to writing the target directly if `chezmoi` is missing. Plain files only — `.tmpl` sources are rejected (rvpm has its own Tera engine). See [chezmoi integration](#chezmoi-integration) |
+| `auto_clean` | `boolean` | `false` | When `true`, `rvpm sync` and `rvpm generate` automatically delete plugin directories under `plugins/repos/` that are no longer referenced by `config.toml`. Equivalent to always passing `--prune` to `sync`. The standalone `rvpm clean` command is still available for one-off cleanups |
 
 > **💡 Leave `config_root` / `cache_root` unset.** The defaults are already
 > `<appname>`-aware. Setting a literal path (e.g. `cache_root =
@@ -472,6 +478,7 @@ vim.keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>")
 |---|---|
 | `rvpm sync [--prune]` | Clone/pull plugins and regenerate `loader.lua`. `--prune` deletes unused plugin directories |
 | `rvpm generate` | Regenerate `loader.lua` only (skip git operations) |
+| `rvpm clean` | Delete plugin directories no longer referenced by `config.toml` (no git, faster than `sync --prune` on 200+ plugins) |
 | `rvpm add <repo>` | Add a plugin and sync |
 | `rvpm update [query]` | `git pull` installed plugins |
 | `rvpm remove [query]` | Remove a plugin from `config.toml` and delete its directory |

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,11 @@ pub struct Options {
     /// 静かにスキップ。デフォルト `false`。
     #[serde(default)]
     pub chezmoi: bool,
+    /// `true` なら `sync` / `generate` 完了時に自動で `rvpm clean` 相当の処理
+    /// (config.toml に無いプラグインディレクトリの削除) を実行する。
+    /// `sync --prune` を毎回明示しなくてよくなる。デフォルト `false`。
+    #[serde(default)]
+    pub auto_clean: bool,
     /// `rvpm store` の README preview 用オプション。
     #[serde(default)]
     pub store: StoreOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,14 @@ enum Commands {
     /// TOML triggers — skips the clone/pull phase entirely.
     Generate,
 
+    /// Delete plugin directories no longer referenced by config.toml
+    ///
+    /// Walks `{cache_root}/plugins/repos/` and removes every clone whose
+    /// plugin is no longer in `config.toml`. Does not run git operations,
+    /// so it is much faster than `sync --prune` on large configs
+    /// (hundreds of plugins).
+    Clean,
+
     /// Add a plugin and sync
     ///
     /// Accepts the same trigger flags as `set` to configure the plugin
@@ -242,6 +250,9 @@ async fn main() -> Result<()> {
         }
         Commands::Generate => {
             run_generate().await?;
+        }
+        Commands::Clean => {
+            run_clean().await?;
         }
         Commands::Add {
             repo,
@@ -623,48 +634,65 @@ async fn run_sync(prune: bool) -> Result<()> {
     )?;
     println!("Done! -> {}", loader_path.display());
 
-    // 未使用 plugin ディレクトリの処理: --prune なら削除、それ以外なら警告表示
+    // 未使用 plugin ディレクトリの処理:
+    //  - `--prune` フラグまたは `options.auto_clean = true` で自動削除
+    //  - それ以外なら警告のみ (rvpm clean で後処理できる旨を案内)
     let repos_dir = resolve_repos_dir(&cache_root);
     if repos_dir.exists() {
         let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
         if !unused.is_empty() {
-            if prune {
-                println!();
-                println!(
-                    "Pruning {} unused plugin {}:",
-                    unused.len(),
-                    if unused.len() == 1 {
-                        "directory"
-                    } else {
-                        "directories"
-                    }
-                );
-                for path in &unused {
-                    println!("  - {}", path.display());
-                    if let Err(e) = std::fs::remove_dir_all(path) {
-                        eprintln!("    \u{26a0} failed: {}", e);
-                    }
-                }
+            if prune || config.options.auto_clean {
+                prune_unused_repos(&unused);
             } else {
                 println!();
                 println!(
                     "\u{26a0} Found {} unused plugin {}:",
                     unused.len(),
-                    if unused.len() == 1 {
-                        "directory"
-                    } else {
-                        "directories"
-                    }
+                    plural("directory", "directories", unused.len()),
                 );
                 for path in &unused {
                     println!("    {}", path.display());
                 }
-                println!("  Run `rvpm sync --prune` to delete them.");
+                println!(
+                    "  Run `rvpm clean` (fast, no git) or `rvpm sync --prune` to delete them,\n  \
+                     or set `auto_clean = true` under `[options]` to do it automatically."
+                );
             }
         }
     }
 
     print_init_lua_hint_if_missing(&config);
+    Ok(())
+}
+
+/// `rvpm clean` — git 操作なしで、config.toml に無いプラグインディレクトリだけを削除する。
+/// プラグイン数が多い環境で `sync --prune` が重いケースの受け皿。
+async fn run_clean() -> Result<()> {
+    let config_path = rvpm_config_path();
+    let toml_content = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
+    let config = parse_config(&toml_content)?;
+
+    let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
+    let repos_dir = resolve_repos_dir(&cache_root);
+    if !repos_dir.exists() {
+        println!(
+            "No repos directory at {} — nothing to clean.",
+            repos_dir.display()
+        );
+        return Ok(());
+    }
+
+    let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
+    if unused.is_empty() {
+        println!(
+            "No unused plugin directories under {}.",
+            repos_dir.display()
+        );
+        return Ok(());
+    }
+
+    prune_unused_repos(&unused);
     Ok(())
 }
 
@@ -713,6 +741,19 @@ async fn run_generate() -> Result<()> {
         &build_loader_options(&config_root),
     )?;
     println!("Done! -> {}", loader_path.display());
+
+    // `options.auto_clean = true` なら config から外されたプラグインディレクトリも
+    // 自動削除 (git 操作は行わないので generate 自体のコストは増えない)。
+    if config.options.auto_clean {
+        let repos_dir = resolve_repos_dir(&cache_root);
+        if repos_dir.exists() {
+            let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
+            if !unused.is_empty() {
+                prune_unused_repos(&unused);
+            }
+        }
+    }
+
     print_init_lua_hint_if_missing(&config);
     Ok(())
 }
@@ -1807,6 +1848,28 @@ async fn run_set(
         return Ok(true);
     }
     Ok(false)
+}
+
+/// 英語の単数/複数形切替。表示メッセージで使う小さなヘルパー。
+fn plural<'a>(singular: &'a str, plural: &'a str, n: usize) -> &'a str {
+    if n == 1 { singular } else { plural }
+}
+
+/// 未使用 repo ディレクトリを削除する共通処理。`sync --prune` と `clean` 両方から呼ばれる。
+/// 削除失敗は eprintln で警告のみ出し、処理を続ける (resilience 原則)。
+fn prune_unused_repos(unused: &[PathBuf]) {
+    println!();
+    println!(
+        "Pruning {} unused plugin {}:",
+        unused.len(),
+        plural("directory", "directories", unused.len()),
+    );
+    for path in unused {
+        println!("  - {}", path.display());
+        if let Err(e) = std::fs::remove_dir_all(path) {
+            eprintln!("    \u{26a0} failed: {}", e);
+        }
+    }
 }
 
 fn find_unused_repos(config: &config::Config, repos_dir: &Path) -> Result<Vec<PathBuf>> {
@@ -4016,5 +4079,59 @@ lazy = false"#;
         let unused = find_unused_repos(&config, &repos_dir).unwrap();
         assert_eq!(unused.len(), 1);
         assert!(unused[0].to_string_lossy().contains("unused"));
+    }
+
+    #[test]
+    fn test_prune_unused_repos_removes_listed_dirs() {
+        let root = tempdir().unwrap();
+        let a = root.path().join("a/.git");
+        let b = root.path().join("b/.git");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        let targets = vec![
+            a.parent().unwrap().to_path_buf(),
+            b.parent().unwrap().to_path_buf(),
+        ];
+        prune_unused_repos(&targets);
+        assert!(!targets[0].exists());
+        assert!(!targets[1].exists());
+    }
+
+    #[test]
+    fn test_prune_unused_repos_empty_slice_noop() {
+        // 空でもクラッシュしないこと
+        prune_unused_repos(&[]);
+    }
+
+    #[test]
+    fn test_plural_helper() {
+        assert_eq!(plural("dir", "dirs", 0), "dirs");
+        assert_eq!(plural("dir", "dirs", 1), "dir");
+        assert_eq!(plural("dir", "dirs", 2), "dirs");
+    }
+
+    #[test]
+    fn test_parse_config_auto_clean_defaults_to_false() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = crate::config::parse_config(toml).unwrap();
+        assert!(!config.options.auto_clean);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_auto_clean_true() {
+        let toml = r#"
+[options]
+auto_clean = true
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = crate::config::parse_config(toml).unwrap();
+        assert!(config.options.auto_clean);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1855,7 +1855,7 @@ fn maybe_prune_unused_repos(
     if !repos_dir.exists() {
         return (0, Vec::new());
     }
-    let unused = find_unused_repos(config, &repos_dir).unwrap_or_default();
+    let unused = find_unused_repos(config, cache_root, &repos_dir).unwrap_or_default();
     if unused.is_empty() {
         return (0, Vec::new());
     }
@@ -1885,11 +1885,30 @@ fn prune_unused_repos(unused: &[PathBuf]) {
     }
 }
 
-fn find_unused_repos(config: &config::Config, repos_dir: &Path) -> Result<Vec<PathBuf>> {
+/// `{cache_root}/plugins/repos/` 配下で、config.toml に載っていないプラグイン
+/// ディレクトリを列挙する (削除候補)。
+///
+/// 判定ルール:
+/// - 使用中セットには `resolve_plugin_dst()` の結果 (= `plugin.dst` があれば
+///   それ、無ければ canonical_path ベースの既定) のうち `repos_dir` 配下の
+///   ものだけを入れる。`dst` を別ツリーに逃がしてる plugin は対象外になる。
+/// - `.git` を持つ候補ディレクトリを検出し、**使用中パス自身またはその
+///   子孫であれば保護する** (= プラグイン本体の clone の中に置かれた
+///   submodule の `.git` を誤削除しない)。
+fn find_unused_repos(
+    config: &config::Config,
+    cache_root: &Path,
+    repos_dir: &Path,
+) -> Result<Vec<PathBuf>> {
     let mut unused = Vec::new();
-    let mut used_paths = std::collections::HashSet::new();
+    let mut used_paths: Vec<PathBuf> = Vec::new();
     for plugin in &config.plugins {
-        used_paths.insert(repos_dir.join(plugin.canonical_path()));
+        let dst = resolve_plugin_dst(plugin, cache_root);
+        // custom dst がツリー外 (`~/dev/...` 等) の場合は repos_dir のスキャン
+        // 対象外なので used 判定にも不要。
+        if dst.starts_with(repos_dir) {
+            used_paths.push(dst);
+        }
     }
     for entry in walkdir::WalkDir::new(repos_dir)
         .into_iter()
@@ -1898,7 +1917,9 @@ fn find_unused_repos(config: &config::Config, repos_dir: &Path) -> Result<Vec<Pa
     {
         let git_dir = entry.path();
         if let Some(repo_root) = git_dir.parent()
-            && !used_paths.contains(repo_root)
+            && !used_paths
+                .iter()
+                .any(|used| repo_root == used || repo_root.starts_with(used))
         {
             unused.push(repo_root.to_path_buf());
         }
@@ -4075,7 +4096,8 @@ lazy = false"#;
     #[test]
     fn test_find_unused_repos() {
         let root = tempdir().unwrap();
-        let repos_dir = root.path().join("repos");
+        // `cache_root` を root にして、標準の {cache_root}/plugins/repos/ 下に配置する
+        let repos_dir = root.path().join("plugins/repos");
         std::fs::create_dir_all(&repos_dir).unwrap();
         let used_dir = repos_dir.join("github.com/used/plugin");
         let unused_dir = repos_dir.join("github.com/unused/plugin");
@@ -4089,9 +4111,63 @@ lazy = false"#;
                 ..Default::default()
             }],
         };
-        let unused = find_unused_repos(&config, &repos_dir).unwrap();
+        let unused = find_unused_repos(&config, root.path(), &repos_dir).unwrap();
         assert_eq!(unused.len(), 1);
         assert!(unused[0].to_string_lossy().contains("unused"));
+    }
+
+    #[test]
+    fn test_find_unused_repos_respects_custom_dst_inside_repos_dir() {
+        // `plugin.dst` で canonical_path と違う場所に clone してる場合でも、
+        // その場所は "used" として保護されること。
+        let root = tempdir().unwrap();
+        let repos_dir = root.path().join("plugins/repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let custom = repos_dir.join("custom-slot/my-plugin");
+        std::fs::create_dir_all(custom.join(".git")).unwrap();
+        let config = Config {
+            vars: None,
+            options: Options::default(),
+            plugins: vec![Plugin {
+                url: "owner/my-plugin".to_string(),
+                dst: Some(custom.to_string_lossy().to_string()),
+                ..Default::default()
+            }],
+        };
+        let unused = find_unused_repos(&config, root.path(), &repos_dir).unwrap();
+        assert!(
+            unused.is_empty(),
+            "custom dst must be protected, got {:?}",
+            unused
+        );
+    }
+
+    #[test]
+    fn test_find_unused_repos_preserves_nested_git_inside_used_plugin() {
+        // 設定済みプラグインのクローン配下にある submodule 等の `.git` は
+        // 削除候補にしないこと (repo_root が used プラグインの子孫なら保護)。
+        let root = tempdir().unwrap();
+        let repos_dir = root.path().join("plugins/repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let plugin_dir = repos_dir.join("github.com/used/plugin");
+        std::fs::create_dir_all(plugin_dir.join(".git")).unwrap();
+        // submodule
+        let submodule = plugin_dir.join("deps/sub");
+        std::fs::create_dir_all(submodule.join(".git")).unwrap();
+        let config = Config {
+            vars: None,
+            options: Options::default(),
+            plugins: vec![Plugin {
+                url: "used/plugin".to_string(),
+                ..Default::default()
+            }],
+        };
+        let unused = find_unused_repos(&config, root.path(), &repos_dir).unwrap();
+        assert!(
+            unused.is_empty(),
+            "submodule .git must not be considered unused, got {:?}",
+            unused
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,7 @@ async fn main() -> Result<()> {
             run_generate().await?;
         }
         Commands::Clean => {
-            run_clean().await?;
+            run_clean()?;
         }
         Commands::Add {
             repo,
@@ -637,28 +637,22 @@ async fn run_sync(prune: bool) -> Result<()> {
     // 未使用 plugin ディレクトリの処理:
     //  - `--prune` フラグまたは `options.auto_clean = true` で自動削除
     //  - それ以外なら警告のみ (rvpm clean で後処理できる旨を案内)
-    let repos_dir = resolve_repos_dir(&cache_root);
-    if repos_dir.exists() {
-        let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
-        if !unused.is_empty() {
-            if prune || config.options.auto_clean {
-                prune_unused_repos(&unused);
-            } else {
-                println!();
-                println!(
-                    "\u{26a0} Found {} unused plugin {}:",
-                    unused.len(),
-                    plural("directory", "directories", unused.len()),
-                );
-                for path in &unused {
-                    println!("    {}", path.display());
-                }
-                println!(
-                    "  Run `rvpm clean` (fast, no git) or `rvpm sync --prune` to delete them,\n  \
-                     or set `auto_clean = true` under `[options]` to do it automatically."
-                );
-            }
+    let force = prune || config.options.auto_clean;
+    let (count, unused) = maybe_prune_unused_repos(&config, &cache_root, force);
+    if !force && count > 0 {
+        println!();
+        println!(
+            "\u{26a0} Found {} unused plugin {}:",
+            count,
+            plural("directory", "directories", count),
+        );
+        for path in &unused {
+            println!("    {}", path.display());
         }
+        println!(
+            "  Run `rvpm clean` (fast, no git) or `rvpm sync --prune` to delete them,\n  \
+             or set `auto_clean = true` under `[options]` to do it automatically."
+        );
     }
 
     print_init_lua_hint_if_missing(&config);
@@ -667,7 +661,8 @@ async fn run_sync(prune: bool) -> Result<()> {
 
 /// `rvpm clean` — git 操作なしで、config.toml に無いプラグインディレクトリだけを削除する。
 /// プラグイン数が多い環境で `sync --prune` が重いケースの受け皿。
-async fn run_clean() -> Result<()> {
+/// 非同期処理は無いので `async` は付けない (clippy::unused_async 回避)。
+fn run_clean() -> Result<()> {
     let config_path = rvpm_config_path();
     let toml_content = std::fs::read_to_string(&config_path)
         .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
@@ -683,16 +678,14 @@ async fn run_clean() -> Result<()> {
         return Ok(());
     }
 
-    let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
-    if unused.is_empty() {
+    // force=true で即削除。空なら helper は (0, []) を返すので別メッセージを出す。
+    let (count, _leftover) = maybe_prune_unused_repos(&config, &cache_root, true);
+    if count == 0 {
         println!(
             "No unused plugin directories under {}.",
             repos_dir.display()
         );
-        return Ok(());
     }
-
-    prune_unused_repos(&unused);
     Ok(())
 }
 
@@ -745,13 +738,7 @@ async fn run_generate() -> Result<()> {
     // `options.auto_clean = true` なら config から外されたプラグインディレクトリも
     // 自動削除 (git 操作は行わないので generate 自体のコストは増えない)。
     if config.options.auto_clean {
-        let repos_dir = resolve_repos_dir(&cache_root);
-        if repos_dir.exists() {
-            let unused = find_unused_repos(&config, &repos_dir).unwrap_or_default();
-            if !unused.is_empty() {
-                prune_unused_repos(&unused);
-            }
-        }
+        let _ = maybe_prune_unused_repos(&config, &cache_root, true);
     }
 
     print_init_lua_hint_if_missing(&config);
@@ -1853,6 +1840,32 @@ async fn run_set(
 /// 英語の単数/複数形切替。表示メッセージで使う小さなヘルパー。
 fn plural<'a>(singular: &'a str, plural: &'a str, n: usize) -> &'a str {
     if n == 1 { singular } else { plural }
+}
+
+/// `sync --prune` / `generate` (auto_clean) / 両方の末尾で使う共通の「後片付け」。
+/// 未使用 repo を検出し、`force` が true なら `prune_unused_repos` で削除する。
+/// 戻り値は検出された未使用の件数。0 以外なら呼び出し側で警告メッセージを
+/// 出せるよう、発見はしたが削除していないケースを区別できるようにする。
+fn maybe_prune_unused_repos(
+    config: &config::Config,
+    cache_root: &Path,
+    force: bool,
+) -> (usize, Vec<PathBuf>) {
+    let repos_dir = resolve_repos_dir(cache_root);
+    if !repos_dir.exists() {
+        return (0, Vec::new());
+    }
+    let unused = find_unused_repos(config, &repos_dir).unwrap_or_default();
+    if unused.is_empty() {
+        return (0, Vec::new());
+    }
+    let count = unused.len();
+    if force {
+        prune_unused_repos(&unused);
+        (count, Vec::new()) // 削除済みなのでパスは返さない
+    } else {
+        (count, unused)
+    }
 }
 
 /// 未使用 repo ディレクトリを削除する共通処理。`sync --prune` と `clean` 両方から呼ばれる。


### PR DESCRIPTION
## Summary

- With 200+ plugins, `sync --prune` just to drop a handful of no-longer-referenced clones is heavy — the full git pass dominates the cost. Add a dedicated `rvpm clean` subcommand that skips clone/pull/merge entirely and only deletes directories under `{cache_root}/plugins/repos/` whose plugin is no longer in `config.toml`.
- Add `options.auto_clean` boolean so `sync` and `generate` can prune on every run without the flag. Equivalent to always passing `--prune` to `sync`; standalone `rvpm clean` remains available.

## Implementation

- `Commands::Clean` → `run_clean()` (git-free).
- Shared helper `prune_unused_repos()` consolidates the delete-and-log loop used by `sync --prune` and the new `clean`.
- `Options::auto_clean: bool` (`#[serde(default)]`). `run_sync` prunes when `--prune || auto_clean`; `run_generate` prunes when `auto_clean`.
- Warning message (shown when unused dirs exist but no prune path is active) now mentions both `rvpm clean` and the `auto_clean` option.

## Docs

- README commands table gains `rvpm clean`.
- README options table gains `auto_clean`.
- Example `config.toml` and CLAUDE.md updated with short hints.
- CLAUDE.md drops the old `clean → sync --prune` deprecation note.

## Test plan

- [x] `cargo test` — 241 tests pass, including new ones:
  - `test_prune_unused_repos_removes_listed_dirs`
  - `test_prune_unused_repos_empty_slice_noop`
  - `test_plural_helper`
  - `test_parse_config_auto_clean_defaults_to_false`
  - `test_parse_config_accepts_auto_clean_true`
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New `clean` command: removes plugin directories no longer referenced in configuration without git operations.
  * New `auto_clean` configuration option (default: disabled) enabling automatic cleanup during sync and generate operations.
  * Enhanced warning messages guiding users to clean or prune unused directories.

* **Documentation**
  * Added documentation for new `clean` command and `auto_clean` configuration option.

* **Tests**
  * Added unit tests for cleanup functionality and configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->