### PR TITLE
feat(add): unify dedup with store's normalization and add `url_style` option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ concurrency = 10
 # config.toml から外したプラグインディレクトリを sync / generate 完了時に
 # 自動削除 (デフォルト false)。毎回 `sync --prune` を指定する代わり。
 # auto_clean = true
+# `rvpm add` の URL 書き込み形式: "short" (owner/repo, デフォルト) か
+# "full" (https://github.com/owner/repo)。重複検出は両形式を正規化して比較。
+# url_style = "full"
 # rvpm のデータ置き場 root を上書き (未指定なら ~/.cache/rvpm)
 # repos / merged / loader.lua 全部ここ配下にまとまる
 # base_dir = "~/.cache/nvim/rvpm"
@@ -274,7 +277,7 @@ let _permit = sem.acquire_owned().await.unwrap();
 | `sync [--prune]` | `run_sync()` | clone/pull + merged + loader.lua 生成。`--prune` で未使用プラグインディレクトリも削除。無指定でも未使用があれば末尾で警告表示 |
 | `generate` | `run_generate()` | loader.lua のみ再生成 |
 | `clean` | `run_clean()` | config.toml から外したプラグインの `{cache_root}/plugins/repos/<host>/<owner>/<repo>/` を削除。git 操作なしで `sync --prune` より高速 (200+ プラグインでの所要時間対策)。共有ヘルパー `prune_unused_repos()` を `sync --prune` と共用 |
-| `add <repo>` | `run_add()` | TOML 追加 + 当該プラグインだけ clone + generate |
+| `add <repo>` | `run_add()` | TOML 追加 + 当該プラグインだけ clone + generate。重複検出は `installed_full_name` で正規化 (https / owner/repo / ssh / 大文字小文字 / `.git` / 末尾 `/` の揺れを吸収し、`rvpm store` の installed マークと同じロジックを共用)。書き込み URL 形式は `options.url_style` (`short` / `full`) に従う |
 | `update [query]` | `run_update()` | 既存プラグインの pull (clone しない) |
 | `remove [query]` | `run_remove()` | TOML + ディレクトリ削除 + generate |
 | `edit [query] [--init\|--before\|--after] [--global]` | `run_edit()` | per-plugin init/before/after.lua をエディタで編集。フラグ指定でファイル選択をスキップ。`--global` で global hooks (`~/.config/rvpm/before.lua` / `after.lua`) を編集。インタラクティブ選択時は `[ Global hooks ]` sentinel でも同じ動作 |

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ concurrency = 10
 # `sync --prune`. Standalone `rvpm clean` remains available.
 # auto_clean = true
 
+# How `rvpm add` records GitHub plugin URLs in config.toml.
+# "short" (default) → owner/repo ; "full" → https://github.com/owner/repo.
+# Duplicate detection normalises between styles either way.
+# url_style = "full"
+
 # Optional: run READMEs in the store TUI through an external renderer
 # (mdcat / glow / bat). See "External README renderer" below.
 # [options.store]
@@ -184,6 +189,7 @@ for where files land).
 | `concurrency` | `integer` | `8` | Max number of parallel git operations during `sync` / `update`. Kept moderate to avoid GitHub rate limits |
 | `chezmoi` | `boolean` | `false` | When `true`, rvpm writes mutations (`config.toml`, global hooks, per-plugin hooks) directly to the chezmoi **source** file (resolved via `chezmoi source-path`) and then runs `chezmoi apply --force` to materialise the change in the target. Falls back to writing the target directly if `chezmoi` is missing. Plain files only — `.tmpl` sources are rejected (rvpm has its own Tera engine). See [chezmoi integration](#chezmoi-integration) |
 | `auto_clean` | `boolean` | `false` | When `true`, `rvpm sync` and `rvpm generate` automatically delete plugin directories under `plugins/repos/` that are no longer referenced by `config.toml`. Equivalent to always passing `--prune` to `sync`. The standalone `rvpm clean` command is still available for one-off cleanups |
+| `url_style` | `"short"` \| `"full"` | `"short"` | How `rvpm add` writes GitHub plugin URLs to `config.toml`. `"short"` → `owner/repo`, `"full"` → `https://github.com/owner/repo`. Non-GitHub URLs (gitlab etc.) are saved verbatim regardless. Duplicate detection normalizes between styles, so the two forms never produce double entries |
 
 > **💡 Leave `config_root` / `cache_root` unset.** The defaults are already
 > `<appname>`-aware. Setting a literal path (e.g. `cache_root =

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,17 @@ pub enum IconStyle {
     Ascii,
 }
 
+/// `rvpm add` が `config.toml` に書き込む URL の表記スタイル。
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UrlStyle {
+    /// `owner/repo` (GitHub 省略形、デフォルト)
+    #[default]
+    Short,
+    /// `https://github.com/owner/repo` (full URL)
+    Full,
+}
+
 #[derive(Debug, Deserialize, PartialEq, Eq, Default, Clone)]
 pub struct Options {
     /// per-plugin init/before/after.lua の置き場。
@@ -48,6 +59,13 @@ pub struct Options {
     /// `sync --prune` を毎回明示しなくてよくなる。デフォルト `false`。
     #[serde(default)]
     pub auto_clean: bool,
+    /// `rvpm add` が `config.toml` に書き込む URL の形式。
+    /// - `"short"` (デフォルト): `owner/repo`
+    /// - `"full"`: `https://github.com/owner/repo`
+    ///
+    /// GitHub 以外の URL (gitlab 等) はこの設定に関わらずそのまま保存される。
+    #[serde(default)]
+    pub url_style: UrlStyle,
     /// `rvpm store` の README preview 用オプション。
     #[serde(default)]
     pub store: StoreOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,14 +1227,20 @@ async fn run_add(
     let config_path = rvpm_config_path();
     ensure_config_exists(&config_path)?;
     let toml_content = std::fs::read_to_string(&config_path)?;
-    // url_style を読むため TOML 全体を一度 parse_config で解析する。
-    // パース失敗時は Short にフォールバック (chezmoi や他の mutation と同様に
-    // 設定ファイルが壊れていても add 操作は継続できるようにする)。
-    let url_style = match parse_config(&toml_content) {
-        Ok(cfg) => cfg.options.url_style,
-        Err(_) => crate::config::UrlStyle::default(),
-    };
     let mut doc = toml_content.parse::<DocumentMut>()?;
+    // url_style は DocumentMut から直接読む (parse_config 経由だと Tera 展開と
+    // 全フィールドのデシリアライズが走って無駄。ここでは add に必要な
+    // option だけ拾えればよい)。値が無効 / 読めないなら default (Short)。
+    let url_style = doc
+        .get("options")
+        .and_then(|o| o.get("url_style"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| match s {
+            "short" => Some(crate::config::UrlStyle::Short),
+            "full" => Some(crate::config::UrlStyle::Full),
+            _ => None,
+        })
+        .unwrap_or_default();
     if doc.get("plugins").is_none() {
         doc["plugins"] = toml_edit::ArrayOfTables::new().into();
     }
@@ -2810,13 +2816,52 @@ fn github_owner_repo(url: &str) -> Option<String> {
     if trimmed.contains("://") {
         return None;
     }
+    // スキーム無しの 2 セグメント形式は **owner/repo** のみを受理し、ローカル
+    // パスは除外する。`./foo`, `../foo`, `~/foo`, `/foo`, `\foo`,
+    // `C:/foo` (Windows drive letter) 等を GitHub shorthand と誤認しない
+    // ようガードする。
+    if looks_like_local_path(trimmed) {
+        return None;
+    }
     if trimmed.contains('/') && !trimmed.contains(' ') {
         let parts: Vec<&str> = trimmed.split('/').collect();
-        if parts.len() == 2 {
+        if parts.len() == 2 && is_valid_github_owner(parts[0]) && is_valid_github_repo(parts[1]) {
             return Some(format!("{}/{}", parts[0], parts[1]));
         }
     }
     None
+}
+
+/// ローカルパスっぽい文字列を判定する (GitHub shorthand と区別するため)。
+/// - 先頭が `./` / `../` / `~` / `/` / `\`
+/// - Windows のドライブレター (`C:`, `D:` 等) で始まる
+fn looks_like_local_path(s: &str) -> bool {
+    if s.starts_with("./") || s.starts_with("../") {
+        return true;
+    }
+    if s.starts_with('~') || s.starts_with('/') || s.starts_with('\\') {
+        return true;
+    }
+    // Windows drive letter: `C:`, `d:` 等
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return true;
+    }
+    false
+}
+
+/// GitHub owner 名の許容文字集合 (alphanumeric と hyphen)。
+/// 先頭 `-` は GitHub 側が拒否するので弾く。
+fn is_valid_github_owner(s: &str) -> bool {
+    !s.is_empty() && !s.starts_with('-') && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+}
+
+/// GitHub repo 名の許容文字集合 (alphanumeric と `- _ .`)。
+/// owner よりやや緩く、`.` や `_` を受ける。
+fn is_valid_github_repo(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
 }
 
 /// Plugin URL を GitHub の `owner/repo` 形式 (小文字) に正規化する。
@@ -3418,6 +3463,41 @@ mod tests {
         assert_eq!(
             format_plugin_url("https://gitlab.com/g/h", UrlStyle::Full),
             "https://gitlab.com/g/h"
+        );
+    }
+
+    #[test]
+    fn test_github_owner_repo_rejects_local_paths() {
+        // `./foo`, `../foo`, `~/foo`, `/foo`, `\foo`, `C:/foo` を GitHub shorthand
+        // と誤認しないこと (CodeRabbit major fix)。
+        assert_eq!(github_owner_repo("./foo"), None);
+        assert_eq!(github_owner_repo("../foo"), None);
+        assert_eq!(github_owner_repo("~/foo"), None);
+        assert_eq!(github_owner_repo("/tmp/foo"), None);
+        assert_eq!(github_owner_repo("\\foo\\bar"), None);
+        assert_eq!(github_owner_repo("C:/foo"), None);
+        assert_eq!(github_owner_repo("d:/bar/baz"), None);
+    }
+
+    #[test]
+    fn test_github_owner_repo_rejects_invalid_chars() {
+        // owner / repo の文字集合を超えるものは GitHub shorthand と認めない。
+        // owner は alphanumeric + `-`、repo は + `. _` まで許容。
+        assert_eq!(github_owner_repo("foo bar/baz"), None);
+        assert_eq!(github_owner_repo("-foo/bar"), None); // owner 先頭 `-`
+        assert_eq!(github_owner_repo("foo!/bar"), None); // owner に `!`
+    }
+
+    #[test]
+    fn test_github_owner_repo_accepts_normal_shorthand() {
+        // 正常な owner/repo は従来どおり受理される
+        assert_eq!(
+            github_owner_repo("folke/snacks.nvim"),
+            Some("folke/snacks.nvim".to_string())
+        );
+        assert_eq!(
+            github_owner_repo("nvim-lua/plenary.nvim"),
+            Some("nvim-lua/plenary.nvim".to_string())
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,6 +1227,13 @@ async fn run_add(
     let config_path = rvpm_config_path();
     ensure_config_exists(&config_path)?;
     let toml_content = std::fs::read_to_string(&config_path)?;
+    // url_style を読むため TOML 全体を一度 parse_config で解析する。
+    // パース失敗時は Short にフォールバック (chezmoi や他の mutation と同様に
+    // 設定ファイルが壊れていても add 操作は継続できるようにする)。
+    let url_style = match parse_config(&toml_content) {
+        Ok(cfg) => cfg.options.url_style,
+        Err(_) => crate::config::UrlStyle::default(),
+    };
     let mut doc = toml_content.parse::<DocumentMut>()?;
     if doc.get("plugins").is_none() {
         doc["plugins"] = toml_edit::ArrayOfTables::new().into();
@@ -1234,14 +1241,26 @@ async fn run_add(
     let plugins = doc["plugins"]
         .as_array_of_tables_mut()
         .context("plugins is not an array of tables")?;
+    // 重複検出: store TUI と同じ `installed_full_name` で両辺を正規化して比較。
+    // https / short / ssh / 大文字小文字 / `.git` / 末尾 `/` の揺れを吸収。
+    // どちらかが GitHub URL と認識できない (gitlab 等) なら生文字列一致に fallback。
+    let incoming_normalized = installed_full_name(&repo);
     for p in plugins.iter() {
-        if p.get("url").and_then(|v| v.as_str()) == Some(&repo) {
-            println!("Plugin already exists: {}", repo);
+        let existing_url = p.get("url").and_then(|v| v.as_str()).unwrap_or("");
+        let existing_normalized = installed_full_name(existing_url);
+        let matches = match (&incoming_normalized, &existing_normalized) {
+            (Some(a), Some(b)) => a == b,
+            _ => existing_url == repo,
+        };
+        if matches {
+            println!("Plugin already exists: {}", existing_url);
             return Ok(());
         }
     }
+    // 書き込み URL は options.url_style に従って整形 (GitHub 以外はそのまま)。
+    let stored_url = format_plugin_url(&repo, url_style);
     let mut new_plugin = table();
-    new_plugin["url"] = value(&repo);
+    new_plugin["url"] = value(&stored_url);
     if let Some(n) = name {
         new_plugin["name"] = value(n);
     }
@@ -2756,7 +2775,50 @@ fn build_plugin_scripts(
     }
 }
 
-/// `rvpm store` — GitHub からプラグインを検索して追加する TUI。
+/// 入力 URL を GitHub の `owner/repo` 形式 (大文字小文字保持) に正規化する。
+///
+/// - `owner/repo` → `Some("owner/repo")`
+/// - `https://github.com/Owner/Repo(.git)?(/)?` → `Some("Owner/Repo")`
+/// - `git@github.com:Owner/Repo.git` → `Some("Owner/Repo")`
+/// - `https://gitlab.com/...` 等の非 GitHub URL → `None`
+///
+/// 重複検出用 (`installed_full_name`) と config.toml 書き出し
+/// (`format_plugin_url`) の両方で再利用する。大文字小文字は保持するので、
+/// 比較目的では呼び出し側で `.to_lowercase()` すること。
+fn github_owner_repo(url: &str) -> Option<String> {
+    let trimmed = url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 2 {
+            return Some(format!("{}/{}", parts[0], parts[1]));
+        }
+        return None;
+    }
+    for prefix in ["https://github.com/", "http://github.com/"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let parts: Vec<&str> = rest.split('/').collect();
+            if parts.len() >= 2 {
+                return Some(format!("{}/{}", parts[0], parts[1]));
+            }
+            return None;
+        }
+    }
+    if trimmed.contains("://") {
+        return None;
+    }
+    if trimmed.contains('/') && !trimmed.contains(' ') {
+        let parts: Vec<&str> = trimmed.split('/').collect();
+        if parts.len() == 2 {
+            return Some(format!("{}/{}", parts[0], parts[1]));
+        }
+    }
+    None
+}
+
 /// Plugin URL を GitHub の `owner/repo` 形式 (小文字) に正規化する。
 /// GitHub の `full_name` は大文字小文字非依存なので lowercase で揃える。
 /// - `"owner/repo"` → `Some("owner/repo")`
@@ -2764,42 +2826,21 @@ fn build_plugin_scripts(
 /// - `"git@github.com:Owner/Repo.git"` → `Some("owner/repo")`
 /// - GitHub 以外 (gitlab 等) → None
 fn installed_full_name(url: &str) -> Option<String> {
-    // `.git` と末尾 `/` の順序が揺れるケースを両方受け付ける
-    let trimmed = url
-        .trim()
-        .trim_end_matches('/')
-        .trim_end_matches(".git")
-        .trim_end_matches('/');
-    // SSH 形式: git@github.com:owner/repo
-    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
-        let parts: Vec<&str> = rest.split('/').collect();
-        if parts.len() >= 2 {
-            return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
-        }
-        return None;
+    github_owner_repo(url).map(|s| s.to_lowercase())
+}
+
+/// `rvpm add` が `config.toml` に書き込む URL を `options.url_style` に従って整形する。
+/// GitHub リポジトリと認識できる入力は `Short` / `Full` で書き換え、
+/// 認識できないもの (gitlab など) は入力をそのまま返す。
+fn format_plugin_url(input: &str, style: crate::config::UrlStyle) -> String {
+    use crate::config::UrlStyle;
+    match github_owner_repo(input) {
+        Some(owner_repo) => match style {
+            UrlStyle::Short => owner_repo,
+            UrlStyle::Full => format!("https://github.com/{}", owner_repo),
+        },
+        None => input.to_string(),
     }
-    // HTTPS/HTTP
-    for prefix in ["https://github.com/", "http://github.com/"] {
-        if let Some(rest) = trimmed.strip_prefix(prefix) {
-            let parts: Vec<&str> = rest.split('/').collect();
-            if parts.len() >= 2 {
-                return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
-            }
-            return None;
-        }
-    }
-    // 別ホストの URL は GitHub ではないので None
-    if trimmed.contains("://") {
-        return None;
-    }
-    // `owner/repo` 形式 (スキーム無し)
-    if trimmed.contains('/') && !trimmed.contains(' ') {
-        let parts: Vec<&str> = trimmed.split('/').collect();
-        if parts.len() == 2 {
-            return Some(format!("{}/{}", parts[0], parts[1]).to_lowercase());
-        }
-    }
-    None
 }
 
 async fn run_store() -> Result<()> {
@@ -3305,6 +3346,104 @@ mod tests {
             installed_full_name("https://github.com/Owner/Repo.git/"),
             Some("owner/repo".to_string())
         );
+    }
+
+    #[test]
+    fn test_github_owner_repo_preserves_case() {
+        // installed_full_name と違い case は保持する (config.toml 書き込み用途)
+        assert_eq!(
+            github_owner_repo("Folke/Snacks.NVIM"),
+            Some("Folke/Snacks.NVIM".to_string())
+        );
+        assert_eq!(
+            github_owner_repo("https://github.com/Owner/Repo.git"),
+            Some("Owner/Repo".to_string())
+        );
+        assert_eq!(
+            github_owner_repo("git@github.com:Owner/Repo.git"),
+            Some("Owner/Repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_github_owner_repo_non_github_returns_none() {
+        assert_eq!(github_owner_repo("https://gitlab.com/a/b"), None);
+        assert_eq!(github_owner_repo("https://git.example/a/b"), None);
+    }
+
+    #[test]
+    fn test_format_plugin_url_short_form() {
+        use crate::config::UrlStyle;
+        // 入力がどの形式でも owner/repo に統一
+        assert_eq!(
+            format_plugin_url("folke/snacks.nvim", UrlStyle::Short),
+            "folke/snacks.nvim"
+        );
+        assert_eq!(
+            format_plugin_url("https://github.com/folke/snacks.nvim", UrlStyle::Short),
+            "folke/snacks.nvim"
+        );
+        assert_eq!(
+            format_plugin_url("https://github.com/folke/snacks.nvim.git", UrlStyle::Short),
+            "folke/snacks.nvim"
+        );
+    }
+
+    #[test]
+    fn test_format_plugin_url_full_form() {
+        use crate::config::UrlStyle;
+        // 入力がどの形式でも https://github.com/owner/repo に統一
+        assert_eq!(
+            format_plugin_url("folke/snacks.nvim", UrlStyle::Full),
+            "https://github.com/folke/snacks.nvim"
+        );
+        assert_eq!(
+            format_plugin_url("https://github.com/folke/snacks.nvim.git", UrlStyle::Full),
+            "https://github.com/folke/snacks.nvim"
+        );
+        assert_eq!(
+            format_plugin_url("git@github.com:folke/snacks.nvim.git", UrlStyle::Full),
+            "https://github.com/folke/snacks.nvim"
+        );
+    }
+
+    #[test]
+    fn test_format_plugin_url_non_github_passthrough() {
+        use crate::config::UrlStyle;
+        // GitHub 以外は入力そのまま保存 (style 無視)
+        assert_eq!(
+            format_plugin_url("https://gitlab.com/g/h", UrlStyle::Short),
+            "https://gitlab.com/g/h"
+        );
+        assert_eq!(
+            format_plugin_url("https://gitlab.com/g/h", UrlStyle::Full),
+            "https://gitlab.com/g/h"
+        );
+    }
+
+    #[test]
+    fn test_parse_config_url_style_defaults_to_short() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = crate::config::parse_config(toml).unwrap();
+        assert_eq!(config.options.url_style, crate::config::UrlStyle::Short);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_url_style_full() {
+        let toml = r#"
+[options]
+url_style = "full"
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = crate::config::parse_config(toml).unwrap();
+        assert_eq!(config.options.url_style, crate::config::UrlStyle::Full);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`rvpm add` used to compare the incoming repo against existing entries with raw string equality on the `url` field, so these pairs all ended up as **duplicate** `[[plugins]]` tables in `config.toml`:

- `folke/snacks.nvim` vs `https://github.com/folke/snacks.nvim`
- `folke/snacks.nvim` vs `Folke/Snacks.nvim`
- `owner/repo` vs `owner/repo.git` or `owner/repo/`

Meanwhile `rvpm store` already normalized via `installed_full_name` before showing the ✓ mark or the "already installed" warning. This PR pulls that logic up into a shared helper so both paths behave the same.

Also introduces a new **`options.url_style`** (`"short"` default / `"full"`) so users can choose how `rvpm add` records GitHub plugin URLs:

- `"short"` → `owner/repo`
- `"full"`  → `https://github.com/owner/repo`

Non-GitHub URLs (gitlab etc.) are saved verbatim regardless of the style. Dedup normalizes across both styles, so flipping the option never creates double entries.

## Implementation

- Factor `installed_full_name` on top of a new case-preserving `github_owner_repo` helper. `installed_full_name` remains case-insensitive (used for matching); `github_owner_repo` is used when writing config.toml so the user's casing is retained.
- `run_add` normalises both the incoming arg and each existing entry's `url`; if both look like GitHub URLs, compare normalised `owner/repo`, otherwise fall back to the pre-existing raw-equality path.
- `run_add` applies `format_plugin_url(&repo, url_style)` when writing the new entry.
- Store TUI's Enter handler already calls `run_add`, so installing from the browser honours `url_style` too.

## Test plan

- [x] `cargo test` — 250 tests pass, including 7 new ones (dedup helpers + url_style config parsing).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `url_style` configuration option under `[options]` in config file. Choose `"short"` (owner/repo, default) or `"full"` (https://github.com/owner/repo) to control how repository URLs are stored.
  * Enhanced duplicate detection in `rvpm add` to recognize repositories across different URL formats (scheme, domain, case variations, `.git` suffix, trailing slashes).

* **Documentation**
  * Updated configuration documentation to describe the new `url_style` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->