### PR TITLE
feat: add `rvpm doctor` diagnostic command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,6 +108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -674,7 +685,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -737,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2422,7 +2433,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2524,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3556,7 +3567,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3613,7 +3624,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3646,6 +3657,7 @@ version = "3.11.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "async-trait",
  "clap",
  "crossterm",
  "dialoguer",
@@ -3914,7 +3926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4056,7 +4068,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4847,7 +4859,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ anyhow = "1.0"
 
 # Async & Process
 tokio = { version = "1.51", features = ["full"] }
+# `async fn` を持つ trait を `dyn` 互換にするため (rvpm doctor の VersionResolver
+# は本番 SystemResolver / テスト MockResolver を Box<dyn> で差し替える)。
+async-trait = "0.1"
 
 # Template & Config
 tera = "1.20"

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -584,12 +584,19 @@ pub fn check_appname(resolved: &str, rvpm_env: Option<&str>, nvim_env: Option<&s
 }
 
 /// helptags チェック: `options.auto_helptags` に応じて挙動が変わる。
-/// - false (default): informational (`Ok` で "disabled" と表示)
-/// - true: 各プラグインの `doc/` を覗き、`doc/tags` が無いものを警告する
-pub fn check_helptags<F>(config: &Config, resolve_dst: F) -> Diagnostic
-where
-    F: Fn(&crate::config::Plugin) -> PathBuf,
-{
+/// - false: informational (`Ok` で "disabled" と表示)
+/// - true (default): `crate::helptags::collect_helptag_targets` と同じ規則で
+///   実際に `:helptags` の対象になる `doc/` ディレクトリだけを列挙し、
+///   各 target に `tags` ファイルがあるか確認する。
+///
+/// 重要: eager + merge=true プラグインは `merged/doc/` に統合されるので、
+/// 個別の plugin 配下の `doc/tags` は生成されない (= ここでチェックしない)。
+/// 各プラグインの `doc/` を素朴に walk するロジックは false-warn を生む。
+pub fn check_helptags(
+    config: &Config,
+    targets: &[PathBuf],
+    target_labels: &[String],
+) -> Diagnostic {
     if !config.options.auto_helptags {
         return Diagnostic::new(
             Severity::Ok,
@@ -599,37 +606,31 @@ where
         );
     }
 
-    let mut checked = 0usize;
+    let total = targets.len();
     let mut missing: Vec<String> = Vec::new();
-    for p in &config.plugins {
-        let dst = resolve_dst(p);
-        let doc_dir = dst.join("doc");
-        if !doc_dir.exists() {
-            continue;
-        }
-        checked += 1;
-        if !doc_dir.join("tags").exists() {
-            missing.push(format!("{}: {}", p.display_name(), doc_dir.display()));
+    for (target, label) in targets.iter().zip(target_labels.iter()) {
+        if !target.join("tags").exists() {
+            missing.push(format!("{}: {}", label, target.display()));
         }
     }
 
-    let have_tags = checked - missing.len();
+    let have_tags = total - missing.len();
     if missing.is_empty() {
         Diagnostic::new(
             Severity::Ok,
             CAT_NEOVIM,
             "helptags",
-            format!("{}/{} have doc/tags", have_tags, checked),
+            format!("{}/{} have doc/tags", have_tags, total),
         )
     } else {
         Diagnostic::new(
             Severity::Warn,
             CAT_NEOVIM,
             "helptags",
-            format!("{}/{} have doc/tags", have_tags, checked),
+            format!("{}/{} have doc/tags", have_tags, total),
         )
         .with_details(missing)
-        .with_hint("run `:helptags ALL` in Neovim or `rvpm sync` with auto_helptags")
+        .with_hint("run `rvpm sync` (auto_helptags) or `:helptags <doc>` in Neovim")
     }
 }
 
@@ -850,6 +851,12 @@ pub struct CheckContext<'a> {
     pub nvim_appname_env: Option<String>,
     pub resolver: Box<dyn VersionResolver>,
     pub resolve_dst: Box<dyn Fn(&crate::config::Plugin) -> PathBuf + 'a>,
+    /// `crate::helptags::collect_helptag_targets` で求めた `:helptags` 対象 doc/。
+    /// merged/doc/ + lazy/non-merge プラグインの個別 doc/ のみが含まれる。
+    pub helptag_targets: Vec<PathBuf>,
+    /// `helptag_targets` と 1:1 で対応する表示用ラベル
+    /// (例: "merged" / プラグイン名)。
+    pub helptag_target_labels: Vec<String>,
 }
 
 pub fn run_checks(ctx: &CheckContext) -> Vec<Diagnostic> {
@@ -872,7 +879,7 @@ pub fn run_checks(ctx: &CheckContext) -> Vec<Diagnostic> {
             ctx.rvpm_appname_env.as_deref(),
             ctx.nvim_appname_env.as_deref(),
         ),
-        check_helptags(ctx.config, |p| (ctx.resolve_dst)(p)),
+        check_helptags(ctx.config, &ctx.helptag_targets, &ctx.helptag_target_labels),
         // External tools
         check_tool_nvim(ctx.resolver.as_ref()),
         check_tool_git(ctx.resolver.as_ref()),
@@ -1315,35 +1322,45 @@ mod tests {
         // auto_helptags = false を明示すると check 自体をスキップして informational に。
         let mut cfg = mk_config(vec![plugin("owner/a")]);
         cfg.options.auto_helptags = false;
-        let d = check_helptags(&cfg, |_p| PathBuf::from("/tmp/whatever"));
+        let d = check_helptags(&cfg, &[], &[]);
         assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("disabled"));
     }
 
     #[test]
     fn test_check_helptags_warns_when_missing_tags() {
+        // target ディレクトリに tags ファイルが無い → warn
         let tmp = tempfile::tempdir().unwrap();
-        let dst = tmp.path().join("pl");
-        std::fs::create_dir_all(dst.join("doc")).unwrap();
-        // doc/ あり、tags なし → warn
+        let doc = tmp.path().join("plugin/doc");
+        std::fs::create_dir_all(&doc).unwrap();
         let mut cfg = mk_config(vec![plugin("owner/a")]);
         cfg.options.auto_helptags = true;
-        let dst_clone = dst.clone();
-        let d = check_helptags(&cfg, move |_p| dst_clone.clone());
+        let d = check_helptags(&cfg, &[doc], &["owner/a".into()]);
         assert_eq!(d.severity, Severity::Warn);
+        assert!(d.summary.contains("0/1"));
     }
 
     #[test]
     fn test_check_helptags_ok_when_tags_present() {
         let tmp = tempfile::tempdir().unwrap();
-        let dst = tmp.path().join("pl");
-        std::fs::create_dir_all(dst.join("doc")).unwrap();
-        std::fs::write(dst.join("doc").join("tags"), "tags").unwrap();
+        let doc = tmp.path().join("plugin/doc");
+        std::fs::create_dir_all(&doc).unwrap();
+        std::fs::write(doc.join("tags"), b"tags").unwrap();
         let mut cfg = mk_config(vec![plugin("owner/a")]);
         cfg.options.auto_helptags = true;
-        let dst_clone = dst.clone();
-        let d = check_helptags(&cfg, move |_p| dst_clone.clone());
+        let d = check_helptags(&cfg, &[doc], &["owner/a".into()]);
         assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("1/1"));
+    }
+
+    #[test]
+    fn test_check_helptags_no_targets_means_zero_zero() {
+        // sync 後に doc/ があるプラグインがゼロというケース。OK 表示。
+        let mut cfg = mk_config(vec![plugin("owner/a")]);
+        cfg.options.auto_helptags = true;
+        let d = check_helptags(&cfg, &[], &[]);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("0/0"));
     }
 
     // -------- external tools --------

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -439,6 +439,7 @@ pub fn check_merged_stale_links(merged_dir: &Path) -> Diagnostic {
     // のような形で個別ファイルに張る場合もあり得るので、walkdir を使って壊れた
     // symlink を列挙する (`follow_links = false` でリンク自体を訪ねる)。
     for entry in walkdir::WalkDir::new(merged_dir)
+        .max_depth(2)
         .follow_links(false)
         .into_iter()
         .filter_map(|e| e.ok())
@@ -570,6 +571,12 @@ pub fn check_init_lua_hook(init_lua_path: &Path) -> Diagnostic {
 
 /// appname coherence: 解決された appname と source env vars を表示する。
 /// `$RVPM_APPNAME` と `$NVIM_APPNAME` の状態を注入可能にしてテスト容易に。
+///
+/// resolved appname と env var の値が食い違う場合は warn を返す。よくある罠:
+/// - `RVPM_APPNAME=foo` だが値が path 区切りなどで invalid → fallback して
+///   "nvim" になる (が、ユーザーは foo のつもり)
+/// - `NVIM_APPNAME=bar` で nvim を起動しているのに `RVPM_APPNAME` が設定
+///   されておらず rvpm 側は別の appname を解決している
 pub fn check_appname(resolved: &str, rvpm_env: Option<&str>, nvim_env: Option<&str>) -> Diagnostic {
     let rvpm_state = match rvpm_env {
         None => "$RVPM_APPNAME unset".to_string(),
@@ -580,6 +587,41 @@ pub fn check_appname(resolved: &str, rvpm_env: Option<&str>, nvim_env: Option<&s
         Some(v) => format!("$NVIM_APPNAME={:?}", v),
     };
     let summary = format!("{:?}  ({}, {})", resolved, rvpm_state, nvim_state);
+
+    // 不整合の検出 (どれか 1 つでも刺されば warn):
+    let rvpm_mismatch = rvpm_env.is_some_and(|v| v != resolved);
+    let nvim_mismatch = nvim_env.is_some_and(|v| v != resolved);
+    let invalid_fallback = matches!(rvpm_env, Some(v) if v != resolved && resolved == "nvim")
+        || matches!(nvim_env, Some(v) if v != resolved && resolved == "nvim");
+
+    if rvpm_mismatch || nvim_mismatch {
+        let mut details = Vec::new();
+        if let Some(v) = rvpm_env
+            && v != resolved
+        {
+            details.push(format!(
+                "$RVPM_APPNAME={:?} but rvpm resolved {:?}",
+                v, resolved
+            ));
+        }
+        if let Some(v) = nvim_env
+            && v != resolved
+        {
+            details.push(format!(
+                "$NVIM_APPNAME={:?} but rvpm resolved {:?}",
+                v, resolved
+            ));
+        }
+        let hint = if invalid_fallback {
+            "env var value rejected (path separators / `.` / `..` etc) — fell back to \"nvim\""
+        } else {
+            "env vars and rvpm's resolved appname disagree — config_root / cache_root may not match Neovim"
+        };
+        return Diagnostic::new(Severity::Warn, CAT_NEOVIM, "appname coherence", summary)
+            .with_details(details)
+            .with_hint(hint);
+    }
+
     Diagnostic::new(Severity::Ok, CAT_NEOVIM, "appname coherence", summary)
 }
 
@@ -639,24 +681,36 @@ pub fn check_helptags(
 // ============================================================
 
 /// 外部コマンドのバージョンを取得する trait。テストでは mock 実装を差し込む。
-pub trait VersionResolver {
+///
+/// `version()` は async — Tokio runtime 上で `tokio::process::Command` を spawn
+/// し、`tokio::time::timeout` で stalled subprocess (壊れた PATH shim 等) を
+/// 防ぐ。`env()` は同期で十分 (環境変数は in-process)。
+#[async_trait::async_trait]
+pub trait VersionResolver: Send + Sync {
     /// `cmd` (例: `"nvim"`, `"git"`) のバージョン文字列を返す。
-    /// コマンドが無い / 失敗した場合は None。
-    fn version(&self, cmd: &str) -> Option<String>;
+    /// コマンドが無い / 失敗 / timeout した場合は None。
+    async fn version(&self, cmd: &str) -> Option<String>;
 
     /// 環境変数の値 (None = unset)。
     fn env(&self, key: &str) -> Option<String>;
 }
 
-/// 本番実装: `cmd --version` を実行して 1 行目を取得する。
+/// 外部コマンドの `--version` 実行に許す最大時間。これを越えたら諦めて None。
+const VERSION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// 本番実装: `tokio::process::Command` で `cmd --version` を実行して 1 行目を取得。
+/// 2 秒のタイムアウト付き (壊れた PATH shim や stalled subprocess で hang しない)。
 pub struct SystemResolver;
 
+#[async_trait::async_trait]
 impl VersionResolver for SystemResolver {
-    fn version(&self, cmd: &str) -> Option<String> {
-        let out = std::process::Command::new(cmd)
-            .arg("--version")
-            .output()
-            .ok()?;
+    async fn version(&self, cmd: &str) -> Option<String> {
+        let fut = tokio::process::Command::new(cmd).arg("--version").output();
+        let out = match tokio::time::timeout(VERSION_PROBE_TIMEOUT, fut).await {
+            Ok(Ok(out)) => out,
+            Ok(Err(_)) => return None, // spawn failed (cmd not found 等)
+            Err(_) => return None,     // timeout
+        };
         if !out.status.success() {
             return None;
         }
@@ -703,8 +757,8 @@ fn shorten_version(raw: &str) -> String {
 }
 
 /// `nvim` コマンドの存在とバージョン。必須。
-pub fn check_tool_nvim(resolver: &dyn VersionResolver) -> Diagnostic {
-    match resolver.version("nvim") {
+pub async fn check_tool_nvim(resolver: &dyn VersionResolver) -> Diagnostic {
+    match resolver.version("nvim").await {
         Some(v) => Diagnostic::new(
             Severity::Ok,
             CAT_TOOLS,
@@ -722,8 +776,8 @@ pub fn check_tool_nvim(resolver: &dyn VersionResolver) -> Diagnostic {
 }
 
 /// `git` コマンドの存在とバージョン。必須。
-pub fn check_tool_git(resolver: &dyn VersionResolver) -> Diagnostic {
-    match resolver.version("git") {
+pub async fn check_tool_git(resolver: &dyn VersionResolver) -> Diagnostic {
+    match resolver.version("git").await {
         Some(v) => Diagnostic::new(
             Severity::Ok,
             CAT_TOOLS,
@@ -742,14 +796,14 @@ pub fn check_tool_git(resolver: &dyn VersionResolver) -> Diagnostic {
 
 /// `chezmoi` コマンドの存在。`options.chezmoi = true` の時のみ必須、それ以外は
 /// 情報表示。
-pub fn check_tool_chezmoi(config: &Config, resolver: &dyn VersionResolver) -> Diagnostic {
+pub async fn check_tool_chezmoi(config: &Config, resolver: &dyn VersionResolver) -> Diagnostic {
     let required = config.options.chezmoi;
     let label = if required {
         "(required: options.chezmoi=true)"
     } else {
         "(optional)"
     };
-    match resolver.version("chezmoi") {
+    match resolver.version("chezmoi").await {
         Some(v) => Diagnostic::new(
             Severity::Ok,
             CAT_TOOLS,
@@ -859,8 +913,9 @@ pub struct CheckContext<'a> {
     pub helptag_target_labels: Vec<String>,
 }
 
-pub fn run_checks(ctx: &CheckContext) -> Vec<Diagnostic> {
-    vec![
+pub async fn run_checks(ctx: &CheckContext<'_>) -> Vec<Diagnostic> {
+    // 同期 check は即評価 — async に渡せない `&Fn` 参照を含むため。
+    let sync_diags = vec![
         // Plugin config
         check_depends_cycles(ctx.config),
         check_depends_references(ctx.config),
@@ -880,12 +935,24 @@ pub fn run_checks(ctx: &CheckContext) -> Vec<Diagnostic> {
             ctx.nvim_appname_env.as_deref(),
         ),
         check_helptags(ctx.config, &ctx.helptag_targets, &ctx.helptag_target_labels),
-        // External tools
-        check_tool_nvim(ctx.resolver.as_ref()),
-        check_tool_git(ctx.resolver.as_ref()),
-        check_tool_chezmoi(ctx.config, ctx.resolver.as_ref()),
-        check_editor(ctx.resolver.as_ref()),
-    ]
+    ];
+
+    // External tools は async — 並列に投げて待つことで合計レイテンシを下げる
+    // (各 `cmd --version` が ~50ms 程度。順次なら 200ms、並列なら ~50ms)。
+    let resolver = ctx.resolver.as_ref();
+    let (nvim_d, git_d, chezmoi_d, editor_d) = tokio::join!(
+        check_tool_nvim(resolver),
+        check_tool_git(resolver),
+        check_tool_chezmoi(ctx.config, resolver),
+        async { check_editor(resolver) }, // editor は env() なので同期、形を揃えるだけ
+    );
+
+    let mut all = sync_diags;
+    all.push(nvim_d);
+    all.push(git_d);
+    all.push(chezmoi_d);
+    all.push(editor_d);
+    all
 }
 
 // ============================================================
@@ -951,9 +1018,41 @@ fn severity_prefix(sev: Severity, icons: &Icons) -> String {
     }
 }
 
+/// レンダリングで使う「文字種」の組。Ascii では box drawing / em-dash / middot
+/// を全て ASCII 等価に落とす (CI ログ / 非 UTF-8 ターミナル向け)。
+struct Glyphs {
+    /// title と summary を区切る dash
+    dash: &'static str,
+    /// summary 句読点として使う中点
+    middot: &'static str,
+    /// details の最終要素 bullet
+    last_bullet: &'static str,
+    /// details の中間要素 bullet
+    mid_bullet: &'static str,
+}
+
+fn glyphs_for(icons: &Icons) -> Glyphs {
+    if matches!(icons.style, IconStyle::Ascii) {
+        Glyphs {
+            dash: "-",
+            middot: ".",
+            last_bullet: "`",
+            mid_bullet: "|",
+        }
+    } else {
+        Glyphs {
+            dash: "\u{2014}",        // —
+            middot: "\u{00b7}",      // ·
+            last_bullet: "\u{2514}", // └
+            mid_bullet: "\u{251c}",  // ├
+        }
+    }
+}
+
 pub fn render(diagnostics: &[Diagnostic], icons: &Icons) -> String {
+    let g = glyphs_for(icons);
     let mut out = String::new();
-    out.push_str("rvpm doctor — diagnostic report\n\n");
+    out.push_str(&format!("rvpm doctor {} diagnostic report\n\n", g.dash));
 
     for (ci, cat) in CATEGORY_ORDER.iter().enumerate() {
         let diags_in_cat: Vec<&Diagnostic> =
@@ -970,12 +1069,19 @@ pub fn render(diagnostics: &[Diagnostic], icons: &Icons) -> String {
         for d in diags_in_cat {
             let prefix = severity_prefix(d.severity, icons);
             let padded_title = pad_right(&d.title, TITLE_WIDTH);
-            out.push_str(&format!("  {} {} — {}\n", prefix, padded_title, d.summary));
+            out.push_str(&format!(
+                "  {} {} {} {}\n",
+                prefix, padded_title, g.dash, d.summary
+            ));
 
-            // details: 最後の行は `└`、それ以外は `├` (単一要素なら直接 `└`)
+            // details: 最後の行は最終 bullet、それ以外は中間 bullet
             let n = d.details.len();
             for (i, line) in d.details.iter().enumerate() {
-                let bullet = if i == n - 1 { "└" } else { "├" };
+                let bullet = if i == n - 1 {
+                    g.last_bullet
+                } else {
+                    g.mid_bullet
+                };
                 out.push_str(&format!("      {} {}\n", bullet, line));
             }
             if let Some(h) = &d.hint {
@@ -987,9 +1093,11 @@ pub fn render(diagnostics: &[Diagnostic], icons: &Icons) -> String {
     let summary = Summary::from(diagnostics);
     out.push('\n');
     out.push_str(&format!(
-        "Summary: {} ok  ·  {} warn  ·  {} error   (exit {})\n",
+        "Summary: {} ok  {}  {} warn  {}  {} error   (exit {})\n",
         summary.ok,
+        g.middot,
         summary.warn,
+        g.middot,
         summary.error,
         summary.exit_code()
     ));
@@ -1310,9 +1418,56 @@ mod tests {
     }
 
     #[test]
-    fn test_check_appname_with_env_set() {
+    fn test_check_appname_with_env_set_matching() {
+        // env と resolved が一致 → ok
         let d = check_appname("mynvim", Some("mynvim"), None);
+        assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("$RVPM_APPNAME=\"mynvim\""));
+    }
+
+    #[test]
+    fn test_check_appname_warns_on_rvpm_mismatch() {
+        // RVPM_APPNAME=foo だが resolved は別 → warn
+        let d = check_appname("nvim", Some("foo"), None);
+        assert_eq!(d.severity, Severity::Warn);
+        assert!(
+            d.details
+                .iter()
+                .any(|s| s.contains("$RVPM_APPNAME=\"foo\"") && s.contains("\"nvim\"")),
+            "expected mismatch detail, got: {:?}",
+            d.details
+        );
+    }
+
+    #[test]
+    fn test_check_appname_warns_on_nvim_mismatch() {
+        // NVIM_APPNAME=bar で nvim を起動しているのに rvpm は別を解決 → warn
+        let d = check_appname("nvim", None, Some("bar"));
+        assert_eq!(d.severity, Severity::Warn);
+        assert!(
+            d.details
+                .iter()
+                .any(|s| s.contains("$NVIM_APPNAME=\"bar\""))
+        );
+    }
+
+    #[test]
+    fn test_check_appname_warns_on_invalid_fallback() {
+        // 無効な値 (path 区切り含む等) で fallback して "nvim" になったケース
+        // (ここでは resolved=nvim、env=invalid を擬似的に再現)
+        let d = check_appname("nvim", Some("foo/bar"), None);
+        assert_eq!(d.severity, Severity::Warn);
+        assert!(
+            d.hint.as_deref().is_some_and(|h| h.contains("rejected")),
+            "expected fallback hint, got hint={:?}",
+            d.hint
+        );
+    }
+
+    #[test]
+    fn test_check_appname_ok_when_both_env_match() {
+        let d = check_appname("custom", Some("custom"), Some("custom"));
+        assert_eq!(d.severity, Severity::Ok);
     }
 
     // -------- helptags --------
@@ -1387,8 +1542,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl VersionResolver for MockResolver {
-        fn version(&self, cmd: &str) -> Option<String> {
+        async fn version(&self, cmd: &str) -> Option<String> {
             self.map.get(cmd).cloned()
         }
         fn env(&self, key: &str) -> Option<String> {
@@ -1396,45 +1552,45 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_check_tool_nvim_present() {
+    #[tokio::test]
+    async fn test_check_tool_nvim_present() {
         let r = MockResolver::new().with_cmd("nvim", "NVIM v0.13.0-dev-some-build");
-        let d = check_tool_nvim(&r);
+        let d = check_tool_nvim(&r).await;
         assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("v0.13.0-dev-some-build"));
     }
 
-    #[test]
-    fn test_check_tool_nvim_missing() {
+    #[tokio::test]
+    async fn test_check_tool_nvim_missing() {
         let r = MockResolver::new();
-        let d = check_tool_nvim(&r);
+        let d = check_tool_nvim(&r).await;
         assert_eq!(d.severity, Severity::Error);
     }
 
-    #[test]
-    fn test_check_tool_git_present() {
+    #[tokio::test]
+    async fn test_check_tool_git_present() {
         let r = MockResolver::new().with_cmd("git", "git version 2.49.1");
-        let d = check_tool_git(&r);
+        let d = check_tool_git(&r).await;
         assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("v2.49.1"));
     }
 
-    #[test]
-    fn test_check_tool_chezmoi_optional_when_disabled() {
+    #[tokio::test]
+    async fn test_check_tool_chezmoi_optional_when_disabled() {
         let cfg = mk_config(vec![]);
         let r = MockResolver::new();
-        let d = check_tool_chezmoi(&cfg, &r);
+        let d = check_tool_chezmoi(&cfg, &r).await;
         // chezmoi 無し + options.chezmoi = false → Ok (informational)
         assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("optional"));
     }
 
-    #[test]
-    fn test_check_tool_chezmoi_required_when_enabled() {
+    #[tokio::test]
+    async fn test_check_tool_chezmoi_required_when_enabled() {
         let mut cfg = mk_config(vec![]);
         cfg.options.chezmoi = true;
         let r = MockResolver::new();
-        let d = check_tool_chezmoi(&cfg, &r);
+        let d = check_tool_chezmoi(&cfg, &r).await;
         // chezmoi 無し + options.chezmoi = true → Error
         assert_eq!(d.severity, Severity::Error);
     }
@@ -1452,6 +1608,14 @@ mod tests {
         let r = MockResolver::new();
         let d = check_editor(&r);
         assert_eq!(d.severity, Severity::Warn);
+    }
+
+    #[tokio::test]
+    async fn test_system_resolver_handles_missing_command() {
+        // SystemResolver の version() はコマンド不在で None を返す (resilient)
+        let r = SystemResolver;
+        let d = r.version("__rvpm_nonexistent_cmd__").await;
+        assert_eq!(d, None);
     }
 
     // -------- summary / exit code --------
@@ -1537,6 +1701,58 @@ mod tests {
         assert!(out.contains("ok  "));
         assert!(out.contains("WARN"));
         assert!(out.contains("ERR "));
+    }
+
+    #[test]
+    fn test_render_ascii_is_pure_ascii() {
+        // ASCII モードでは出力が完全に ASCII で完結し、box drawing /
+        // em-dash / middot / Nerd Font 文字を含まないこと。
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "title-a", "done"),
+            Diagnostic::new(Severity::Warn, CAT_STATE_INTEGRITY, "title-b", "1 found")
+                .with_details(vec!["alpha".into(), "beta".into()])
+                .with_hint("try `rvpm clean`"),
+        ];
+        let icons = Icons::from_style(IconStyle::Ascii);
+        let out = render(&diags, &icons);
+        for ch in out.chars() {
+            assert!(
+                ch.is_ascii(),
+                "non-ASCII char {:?} (U+{:04X}) found in ASCII output:\n{}",
+                ch,
+                ch as u32,
+                out
+            );
+        }
+        // セパレータ系も置換されていること
+        assert!(out.contains(" - "), "expected ' - ' in ASCII summary line");
+        assert!(
+            out.contains("|"),
+            "expected '|' (mid bullet) in ASCII output"
+        );
+        assert!(
+            out.contains("`"),
+            "expected '`' (last bullet) in ASCII output"
+        );
+        assert!(
+            out.contains(" . "),
+            "expected ' . ' (middot replacement) in ASCII summary"
+        );
+    }
+
+    #[test]
+    fn test_render_unicode_keeps_box_chars() {
+        // Unicode モードでは従来通り — / · / ├ / └ を使う (regression guard)
+        let diags = vec![
+            Diagnostic::new(Severity::Warn, CAT_STATE_INTEGRITY, "x", "1 found")
+                .with_details(vec!["a".into(), "b".into()]),
+        ];
+        let icons = Icons::from_style(IconStyle::Unicode);
+        let out = render(&diags, &icons);
+        assert!(out.contains("\u{2014}")); // —
+        assert!(out.contains("\u{00b7}")); // ·
+        assert!(out.contains("\u{251c}")); // ├
+        assert!(out.contains("\u{2514}")); // └
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,1588 @@
+//! `rvpm doctor` — 診断レポート生成モジュール。
+//!
+//! 設計指針:
+//! - 各チェックは純粋関数 (読み取り FS I/O のみ許容) として実装し、テスト容易性を担保する。
+//! - 1 つのチェック失敗が他のチェックを止めないように、呼び出し側で個別に catch する。
+//!   (`run_checks` は個別の `try_*` 関数を順次呼ぶだけ。)
+//! - 外部コマンドの実行は `VersionResolver` トレイト経由にし、ユニットテストでは
+//!   モック実装を使う。
+//!
+//! 出力仕様は CLAUDE.md / issue #49 / caller の brief に従う。
+
+use crate::config::{Config, IconStyle};
+use crate::tui::Icons;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// 診断の深刻度。`Ok < Warn < Error` の順で重い。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Severity {
+    Ok,
+    Warn,
+    Error,
+}
+
+/// 1 つの診断項目。
+///
+/// - `category`: セクション見出し (`"Plugin config"`, `"State integrity"` 等)。
+/// - `title`: 左端のラベル (`"depends cycles"` など)。固定幅でパディングされる。
+/// - `summary`: `—` の後に出る短い要約 (`"none"` / `"94/94 resolved"` 等)。
+/// - `details`: `└` / `├` で表示される詳細ライン。空なら詳細ブロックは出ない。
+/// - `hint`: ワンライナーの復旧案内 (`hint: ...`)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub category: String,
+    pub title: String,
+    pub summary: String,
+    pub details: Vec<String>,
+    pub hint: Option<String>,
+}
+
+impl Diagnostic {
+    fn new(severity: Severity, category: &str, title: &str, summary: impl Into<String>) -> Self {
+        Self {
+            severity,
+            category: category.to_string(),
+            title: title.to_string(),
+            summary: summary.into(),
+            details: Vec::new(),
+            hint: None,
+        }
+    }
+
+    fn with_details(mut self, details: Vec<String>) -> Self {
+        self.details = details;
+        self
+    }
+
+    fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+}
+
+// ============================================================
+// Categories (固定の並び順 + セクション見出し文字列)
+// ============================================================
+
+pub const CAT_PLUGIN_CONFIG: &str = "Plugin config";
+pub const CAT_STATE_INTEGRITY: &str = "State integrity";
+pub const CAT_NEOVIM: &str = "Neovim integration";
+pub const CAT_TOOLS: &str = "External tools";
+
+const CATEGORY_ORDER: &[&str] = &[
+    CAT_PLUGIN_CONFIG,
+    CAT_STATE_INTEGRITY,
+    CAT_NEOVIM,
+    CAT_TOOLS,
+];
+
+// ============================================================
+// Plugin config: depends cycles
+// ============================================================
+
+/// `depends` に循環があるかを検出する。自分自身への `depends` も循環として扱う。
+///
+/// アルゴリズム: DFS ベースのサイクル検出。`sort_plugins` と同じ名前解決 (URL or
+/// display_name) を使うが、resilience 原則のため `sort_plugins` 自体には副作用が
+/// あるので、doctor は別途検査する。
+pub fn check_depends_cycles(config: &Config) -> Diagnostic {
+    let mut by_key: HashMap<String, usize> = HashMap::new();
+    for (i, p) in config.plugins.iter().enumerate() {
+        by_key.insert(p.url.clone(), i);
+        by_key.insert(p.display_name(), i);
+    }
+
+    let mut cycles: Vec<Vec<String>> = Vec::new();
+
+    fn dfs(
+        node: usize,
+        plugins: &[crate::config::Plugin],
+        by_key: &HashMap<String, usize>,
+        visiting: &mut Vec<usize>,
+        visited: &mut HashSet<usize>,
+        cycles: &mut Vec<Vec<String>>,
+    ) {
+        if visited.contains(&node) {
+            return;
+        }
+        if let Some(pos) = visiting.iter().position(|&n| n == node) {
+            // 循環発見: visiting[pos..] が循環ノード
+            let cycle: Vec<String> = visiting[pos..]
+                .iter()
+                .map(|&i| plugins[i].display_name())
+                .chain(std::iter::once(plugins[node].display_name()))
+                .collect();
+            cycles.push(cycle);
+            return;
+        }
+        visiting.push(node);
+        if let Some(deps) = &plugins[node].depends {
+            for dep in deps {
+                if let Some(&next) = by_key.get(dep) {
+                    dfs(next, plugins, by_key, visiting, visited, cycles);
+                }
+            }
+        }
+        visiting.pop();
+        visited.insert(node);
+    }
+
+    let mut visited: HashSet<usize> = HashSet::new();
+    for i in 0..config.plugins.len() {
+        let mut visiting = Vec::new();
+        dfs(
+            i,
+            &config.plugins,
+            &by_key,
+            &mut visiting,
+            &mut visited,
+            &mut cycles,
+        );
+    }
+
+    // 重複除去: 循環 (A → B → A) と (B → A → B) は同じ循環。サイクルを
+    // display_name でソートした正規形で dedupe する。
+    let mut normalized: HashSet<Vec<String>> = HashSet::new();
+    let mut uniq_cycles: Vec<Vec<String>> = Vec::new();
+    for cycle in cycles {
+        let mut canonical = cycle.clone();
+        canonical.sort();
+        if normalized.insert(canonical) {
+            uniq_cycles.push(cycle);
+        }
+    }
+
+    if uniq_cycles.is_empty() {
+        Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "depends cycles", "none")
+    } else {
+        let details: Vec<String> = uniq_cycles.iter().map(|c| c.join(" -> ")).collect();
+        let summary = format!("{} found", uniq_cycles.len());
+        Diagnostic::new(
+            Severity::Error,
+            CAT_PLUGIN_CONFIG,
+            "depends cycles",
+            summary,
+        )
+        .with_details(details)
+        .with_hint("break the cycle in `depends`")
+    }
+}
+
+/// `depends` の参照が他のプラグインに解決できるかを検査する。
+pub fn check_depends_references(config: &Config) -> Diagnostic {
+    let mut by_key: HashSet<String> = HashSet::new();
+    for p in &config.plugins {
+        by_key.insert(p.url.clone());
+        by_key.insert(p.display_name());
+    }
+
+    let mut unresolved: Vec<String> = Vec::new();
+    let mut total = 0usize;
+    for p in &config.plugins {
+        if let Some(deps) = &p.depends {
+            for dep in deps {
+                total += 1;
+                if !by_key.contains(dep) {
+                    unresolved.push(format!("{}: depends = [\"{}\"]", p.display_name(), dep));
+                }
+            }
+        }
+    }
+
+    if unresolved.is_empty() {
+        let summary = if total == 0 {
+            "0/0 resolved".to_string()
+        } else {
+            format!("{}/{} resolved", total, total)
+        };
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_PLUGIN_CONFIG,
+            "depends references",
+            summary,
+        )
+    } else {
+        let resolved = total - unresolved.len();
+        let summary = format!(
+            "{}/{} resolved, {} missing",
+            resolved,
+            total,
+            unresolved.len()
+        );
+        Diagnostic::new(
+            Severity::Error,
+            CAT_PLUGIN_CONFIG,
+            "depends references",
+            summary,
+        )
+        .with_details(unresolved)
+        .with_hint("fix typos in `depends` or add the missing plugin")
+    }
+}
+
+/// `on_source` の参照が他のプラグインに解決できるかを検査する。
+/// 解決できない場合は "did you mean" サジェストを Levenshtein 距離で出す。
+pub fn check_on_source_typos(config: &Config) -> Diagnostic {
+    let names: Vec<String> = config.plugins.iter().map(|p| p.display_name()).collect();
+    let mut all_keys: HashSet<String> = HashSet::new();
+    for p in &config.plugins {
+        all_keys.insert(p.url.clone());
+        all_keys.insert(p.display_name());
+    }
+
+    let mut typos: Vec<String> = Vec::new();
+    for p in &config.plugins {
+        if let Some(sources) = &p.on_source {
+            for src in sources {
+                if !all_keys.contains(src) {
+                    let suggestion = closest_name(src, &names);
+                    let line = match suggestion {
+                        Some(s) => format!(
+                            "{}: on_source = [\"{}\"]  (hint: \"{}\"?)",
+                            p.display_name(),
+                            src,
+                            s
+                        ),
+                        None => format!("{}: on_source = [\"{}\"]", p.display_name(), src),
+                    };
+                    typos.push(line);
+                }
+            }
+        }
+    }
+
+    if typos.is_empty() {
+        Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "on_source typos", "none")
+    } else {
+        let summary = format!("{} found", typos.len());
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_PLUGIN_CONFIG,
+            "on_source typos",
+            summary,
+        )
+        .with_details(typos)
+    }
+}
+
+/// `dev = true` プラグインの `dst` が実在するかを検査する。
+pub fn check_dev_plugin_dst(config: &Config) -> Diagnostic {
+    let devs: Vec<&crate::config::Plugin> = config.plugins.iter().filter(|p| p.dev).collect();
+    if devs.is_empty() {
+        return Diagnostic::new(
+            Severity::Ok,
+            CAT_PLUGIN_CONFIG,
+            "dev plugin dst",
+            "0/0 exist",
+        );
+    }
+
+    let mut missing: Vec<String> = Vec::new();
+    for p in &devs {
+        let dst = match &p.dst {
+            Some(d) => crate::expand_tilde_public(d),
+            None => {
+                missing.push(format!("{}: no `dst` set", p.display_name()));
+                continue;
+            }
+        };
+        if !dst.exists() {
+            missing.push(format!("{}: {}", p.display_name(), dst.display()));
+        }
+    }
+
+    let total = devs.len();
+    let ok = total - missing.len();
+    if missing.is_empty() {
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_PLUGIN_CONFIG,
+            "dev plugin dst",
+            format!("{}/{} exist", ok, total),
+        )
+    } else {
+        Diagnostic::new(
+            Severity::Error,
+            CAT_PLUGIN_CONFIG,
+            "dev plugin dst",
+            format!("{}/{} exist", ok, total),
+        )
+        .with_details(missing)
+        .with_hint("set `dst` on the plugin or clone it locally")
+    }
+}
+
+/// `url` / `name` の重複検出。url 重複のほうが重大なのでエラー、name 重複は警告。
+pub fn check_duplicates(config: &Config) -> Diagnostic {
+    let mut url_seen: HashMap<String, usize> = HashMap::new();
+    let mut name_seen: HashMap<String, usize> = HashMap::new();
+    for p in &config.plugins {
+        *url_seen.entry(p.url.to_lowercase()).or_default() += 1;
+        *name_seen.entry(p.display_name()).or_default() += 1;
+    }
+
+    let dup_urls: Vec<String> = url_seen
+        .iter()
+        .filter(|&(_, &c)| c > 1)
+        .map(|(k, c)| format!("url \"{}\" appears {} times", k, c))
+        .collect();
+    let dup_names: Vec<String> = name_seen
+        .iter()
+        .filter(|&(_, &c)| c > 1)
+        .map(|(k, c)| format!("name \"{}\" appears {} times", k, c))
+        .collect();
+
+    let mut details: Vec<String> = Vec::new();
+    details.extend(dup_urls.iter().cloned());
+    details.extend(dup_names.iter().cloned());
+    details.sort();
+
+    if details.is_empty() {
+        Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "duplicates", "none")
+    } else if !dup_urls.is_empty() {
+        let summary = format!("{} found", details.len());
+        Diagnostic::new(Severity::Error, CAT_PLUGIN_CONFIG, "duplicates", summary)
+            .with_details(details)
+            .with_hint("remove duplicated plugin entries in config.toml")
+    } else {
+        let summary = format!("{} found", details.len());
+        Diagnostic::new(Severity::Warn, CAT_PLUGIN_CONFIG, "duplicates", summary)
+            .with_details(details)
+            .with_hint("rename one of the duplicated `name` fields")
+    }
+}
+
+// ============================================================
+// State integrity
+// ============================================================
+
+/// `config.toml` のプラグインが cache に clone されているかを検査する。
+pub fn check_cloned_plugins<F>(config: &Config, resolve_dst: F) -> Diagnostic
+where
+    F: Fn(&crate::config::Plugin) -> PathBuf,
+{
+    let total = config.plugins.len();
+    if total == 0 {
+        return Diagnostic::new(Severity::Ok, CAT_STATE_INTEGRITY, "cloned plugins", "0/0");
+    }
+
+    let mut missing: Vec<String> = Vec::new();
+    for p in &config.plugins {
+        if p.dev {
+            // dev は別チェック (check_dev_plugin_dst) で扱うのでスキップ。
+            continue;
+        }
+        let dst = resolve_dst(p);
+        if !dst.exists() {
+            missing.push(format!("{}: {}", p.display_name(), dst.display()));
+        }
+    }
+
+    let target_total = config.plugins.iter().filter(|p| !p.dev).count();
+    let cloned = target_total - missing.len();
+    if missing.is_empty() {
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_STATE_INTEGRITY,
+            "cloned plugins",
+            format!("{}/{}", cloned, target_total),
+        )
+    } else {
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_STATE_INTEGRITY,
+            "cloned plugins",
+            format!("{}/{}", cloned, target_total),
+        )
+        .with_details(missing)
+        .with_hint("run `rvpm sync` to clone missing plugins")
+    }
+}
+
+/// 未使用 repo ディレクトリの検出。リストは pre-sorted で渡される前提。
+pub fn check_unused_cache_dirs(unused: &[PathBuf]) -> Diagnostic {
+    if unused.is_empty() {
+        return Diagnostic::new(
+            Severity::Ok,
+            CAT_STATE_INTEGRITY,
+            "unused cache dirs",
+            "none",
+        );
+    }
+    let details: Vec<String> = unused.iter().map(|p| p.display().to_string()).collect();
+    let summary = format!("{} found", unused.len());
+    Diagnostic::new(
+        Severity::Warn,
+        CAT_STATE_INTEGRITY,
+        "unused cache dirs",
+        summary,
+    )
+    .with_details(details)
+    .with_hint("`rvpm clean` or `rvpm sync --prune`")
+}
+
+/// merged/ 内の壊れた (存在しない target を指す) symlink / junction を検出する。
+pub fn check_merged_stale_links(merged_dir: &Path) -> Diagnostic {
+    if !merged_dir.exists() {
+        return Diagnostic::new(
+            Severity::Ok,
+            CAT_STATE_INTEGRITY,
+            "merged/ stale links",
+            "none",
+        );
+    }
+
+    let mut stale: Vec<String> = Vec::new();
+    // 浅い walk のみ (merged/ 直下の第 1, 2 レベル) で十分。リンクは `plugin/foo.lua`
+    // のような形で個別ファイルに張る場合もあり得るので、walkdir を使って壊れた
+    // symlink を列挙する (`follow_links = false` でリンク自体を訪ねる)。
+    for entry in walkdir::WalkDir::new(merged_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        // metadata は symlink の target が存在しないと Err。symlink_metadata で
+        // symlink 自体があることを確認しつつ、metadata でその参照先を確認する。
+        let symlink_meta = match std::fs::symlink_metadata(path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if symlink_meta.file_type().is_symlink() && std::fs::metadata(path).is_err() {
+            stale.push(path.display().to_string());
+        }
+    }
+
+    if stale.is_empty() {
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_STATE_INTEGRITY,
+            "merged/ stale links",
+            "none",
+        )
+    } else {
+        let summary = format!("{} found", stale.len());
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_STATE_INTEGRITY,
+            "merged/ stale links",
+            summary,
+        )
+        .with_details(stale)
+        .with_hint("run `rvpm sync` to rebuild merged/")
+    }
+}
+
+/// loader.lua が存在し、かつ config.toml より新しいかを検査する。
+pub fn check_loader_freshness(loader_path: &Path, config_path: &Path) -> Diagnostic {
+    let loader_mtime = match std::fs::metadata(loader_path).and_then(|m| m.modified()) {
+        Ok(t) => t,
+        Err(_) => {
+            return Diagnostic::new(
+                Severity::Error,
+                CAT_STATE_INTEGRITY,
+                "loader.lua freshness",
+                "missing",
+            )
+            .with_hint("run `rvpm sync` or `rvpm generate`");
+        }
+    };
+
+    let config_mtime = match std::fs::metadata(config_path).and_then(|m| m.modified()) {
+        Ok(t) => t,
+        Err(_) => {
+            return Diagnostic::new(
+                Severity::Warn,
+                CAT_STATE_INTEGRITY,
+                "loader.lua freshness",
+                "config.toml unreadable",
+            );
+        }
+    };
+
+    if loader_mtime >= config_mtime {
+        let age = format_age(loader_mtime);
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_STATE_INTEGRITY,
+            "loader.lua freshness",
+            format!("{} (newer than config.toml)", age),
+        )
+    } else {
+        let age = format_age(loader_mtime);
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_STATE_INTEGRITY,
+            "loader.lua freshness",
+            format!("{} (older than config.toml)", age),
+        )
+        .with_hint("run `rvpm generate` to refresh loader.lua")
+    }
+}
+
+fn format_age(mtime: std::time::SystemTime) -> String {
+    match std::time::SystemTime::now().duration_since(mtime) {
+        Ok(d) => {
+            let secs = d.as_secs();
+            if secs < 60 {
+                format!("{}s ago", secs)
+            } else if secs < 3600 {
+                format!("{}m ago", secs / 60)
+            } else if secs < 86400 {
+                format!("{}h ago", secs / 3600)
+            } else {
+                format!("{}d ago", secs / 86400)
+            }
+        }
+        Err(_) => "future".to_string(),
+    }
+}
+
+// ============================================================
+// Neovim integration
+// ============================================================
+
+/// init.lua が loader.lua を dofile 経由で参照しているかを検査する。
+pub fn check_init_lua_hook(init_lua_path: &Path) -> Diagnostic {
+    if !init_lua_path.exists() {
+        return Diagnostic::new(
+            Severity::Warn,
+            CAT_NEOVIM,
+            "init.lua loader hook",
+            "init.lua not found",
+        )
+        .with_hint("run `rvpm init --write`");
+    }
+    if crate::init_lua_references_rvpm_loader_public(init_lua_path) {
+        Diagnostic::new(Severity::Ok, CAT_NEOVIM, "init.lua loader hook", "linked")
+    } else {
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_NEOVIM,
+            "init.lua loader hook",
+            "no dofile(loader.lua)",
+        )
+        .with_hint("run `rvpm init --write`")
+    }
+}
+
+/// appname coherence: 解決された appname と source env vars を表示する。
+/// `$RVPM_APPNAME` と `$NVIM_APPNAME` の状態を注入可能にしてテスト容易に。
+pub fn check_appname(resolved: &str, rvpm_env: Option<&str>, nvim_env: Option<&str>) -> Diagnostic {
+    let rvpm_state = match rvpm_env {
+        None => "$RVPM_APPNAME unset".to_string(),
+        Some(v) => format!("$RVPM_APPNAME={:?}", v),
+    };
+    let nvim_state = match nvim_env {
+        None => "$NVIM_APPNAME unset".to_string(),
+        Some(v) => format!("$NVIM_APPNAME={:?}", v),
+    };
+    let summary = format!("{:?}  ({}, {})", resolved, rvpm_state, nvim_state);
+    Diagnostic::new(Severity::Ok, CAT_NEOVIM, "appname coherence", summary)
+}
+
+/// helptags チェック: `options.auto_helptags` に応じて挙動が変わる。
+/// - false (default): informational (`Ok` で "disabled" と表示)
+/// - true: 各プラグインの `doc/` を覗き、`doc/tags` が無いものを警告する
+pub fn check_helptags<F>(config: &Config, resolve_dst: F) -> Diagnostic
+where
+    F: Fn(&crate::config::Plugin) -> PathBuf,
+{
+    if !config.options.auto_helptags {
+        return Diagnostic::new(
+            Severity::Ok,
+            CAT_NEOVIM,
+            "helptags",
+            "disabled (options.auto_helptags = false)",
+        );
+    }
+
+    let mut checked = 0usize;
+    let mut missing: Vec<String> = Vec::new();
+    for p in &config.plugins {
+        let dst = resolve_dst(p);
+        let doc_dir = dst.join("doc");
+        if !doc_dir.exists() {
+            continue;
+        }
+        checked += 1;
+        if !doc_dir.join("tags").exists() {
+            missing.push(format!("{}: {}", p.display_name(), doc_dir.display()));
+        }
+    }
+
+    let have_tags = checked - missing.len();
+    if missing.is_empty() {
+        Diagnostic::new(
+            Severity::Ok,
+            CAT_NEOVIM,
+            "helptags",
+            format!("{}/{} have doc/tags", have_tags, checked),
+        )
+    } else {
+        Diagnostic::new(
+            Severity::Warn,
+            CAT_NEOVIM,
+            "helptags",
+            format!("{}/{} have doc/tags", have_tags, checked),
+        )
+        .with_details(missing)
+        .with_hint("run `:helptags ALL` in Neovim or `rvpm sync` with auto_helptags")
+    }
+}
+
+// ============================================================
+// External tools
+// ============================================================
+
+/// 外部コマンドのバージョンを取得する trait。テストでは mock 実装を差し込む。
+pub trait VersionResolver {
+    /// `cmd` (例: `"nvim"`, `"git"`) のバージョン文字列を返す。
+    /// コマンドが無い / 失敗した場合は None。
+    fn version(&self, cmd: &str) -> Option<String>;
+
+    /// 環境変数の値 (None = unset)。
+    fn env(&self, key: &str) -> Option<String>;
+}
+
+/// 本番実装: `cmd --version` を実行して 1 行目を取得する。
+pub struct SystemResolver;
+
+impl VersionResolver for SystemResolver {
+    fn version(&self, cmd: &str) -> Option<String> {
+        let out = std::process::Command::new(cmd)
+            .arg("--version")
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let line = stdout.lines().next()?.trim().to_string();
+        if line.is_empty() { None } else { Some(line) }
+    }
+
+    fn env(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+/// version 文字列から `vX.Y.Z(-suffix)` っぽい部分を抜き出す。
+/// 失敗時は全体を短縮して返す。
+fn shorten_version(raw: &str) -> String {
+    // `nvim --version` → "NVIM v0.13.0-dev-..."
+    // `git --version` → "git version 2.49.1"
+    // `chezmoi --version` → "chezmoi version v2.68.0, ..."
+    // いずれも最初に `v?<digit>` が現れる場所をバージョンの先頭とみなし、
+    // 続く非空白の範囲を取る。
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c == 'v' && i + 1 < bytes.len() && (bytes[i + 1] as char).is_ascii_digit() {
+            let token_end = raw[i..]
+                .find(|ch: char| ch.is_whitespace() || ch == ',')
+                .map(|p| i + p)
+                .unwrap_or(raw.len());
+            return raw[i..token_end].trim_end_matches(',').to_string();
+        }
+        if c.is_ascii_digit() {
+            // version 番号 (prefix なし) — `v` を足して返す
+            let token_end = raw[i..]
+                .find(|ch: char| ch.is_whitespace() || ch == ',')
+                .map(|p| i + p)
+                .unwrap_or(raw.len());
+            return format!("v{}", raw[i..token_end].trim_end_matches(','));
+        }
+        i += 1;
+    }
+    raw.to_string()
+}
+
+/// `nvim` コマンドの存在とバージョン。必須。
+pub fn check_tool_nvim(resolver: &dyn VersionResolver) -> Diagnostic {
+    match resolver.version("nvim") {
+        Some(v) => Diagnostic::new(
+            Severity::Ok,
+            CAT_TOOLS,
+            "nvim",
+            format!("{}           (required)", shorten_version(&v)),
+        ),
+        None => Diagnostic::new(
+            Severity::Error,
+            CAT_TOOLS,
+            "nvim",
+            "not found            (required)",
+        )
+        .with_hint("install Neovim (https://neovim.io)"),
+    }
+}
+
+/// `git` コマンドの存在とバージョン。必須。
+pub fn check_tool_git(resolver: &dyn VersionResolver) -> Diagnostic {
+    match resolver.version("git") {
+        Some(v) => Diagnostic::new(
+            Severity::Ok,
+            CAT_TOOLS,
+            "git",
+            format!("{}            (required)", shorten_version(&v)),
+        ),
+        None => Diagnostic::new(
+            Severity::Error,
+            CAT_TOOLS,
+            "git",
+            "not found             (required)",
+        )
+        .with_hint("install git"),
+    }
+}
+
+/// `chezmoi` コマンドの存在。`options.chezmoi = true` の時のみ必須、それ以外は
+/// 情報表示。
+pub fn check_tool_chezmoi(config: &Config, resolver: &dyn VersionResolver) -> Diagnostic {
+    let required = config.options.chezmoi;
+    let label = if required {
+        "(required: options.chezmoi=true)"
+    } else {
+        "(optional)"
+    };
+    match resolver.version("chezmoi") {
+        Some(v) => Diagnostic::new(
+            Severity::Ok,
+            CAT_TOOLS,
+            "chezmoi",
+            format!("{}            {}", shorten_version(&v), label),
+        ),
+        None => {
+            let severity = if required {
+                Severity::Error
+            } else {
+                Severity::Ok
+            };
+            Diagnostic::new(
+                severity,
+                CAT_TOOLS,
+                "chezmoi",
+                format!("not found            {}", label),
+            )
+        }
+    }
+}
+
+/// `$EDITOR` 環境変数の状態。未設定なら警告。
+pub fn check_editor(resolver: &dyn VersionResolver) -> Diagnostic {
+    match resolver.env("EDITOR") {
+        Some(e) if !e.trim().is_empty() => Diagnostic::new(
+            Severity::Ok,
+            CAT_TOOLS,
+            "$EDITOR",
+            format!("{}                  (required: for edit/config/set)", e),
+        ),
+        _ => Diagnostic::new(
+            Severity::Warn,
+            CAT_TOOLS,
+            "$EDITOR",
+            "unset                (required: for edit/config/set)",
+        )
+        .with_hint("set $EDITOR (e.g. `export EDITOR=nvim`)"),
+    }
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/// Levenshtein 距離。サイズ m × n の DP テーブルで素直に実装。
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut cur: Vec<usize> = vec![0; n + 1];
+    for i in 1..=m {
+        cur[0] = i;
+        for j in 1..=n {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[n]
+}
+
+/// candidates の中から query に最も近い文字列を返す (距離 <= 3 のみ)。
+/// 候補が無い / 閾値を超える場合は None。
+fn closest_name(query: &str, candidates: &[String]) -> Option<String> {
+    let mut best: Option<(&String, usize)> = None;
+    for c in candidates {
+        let d = levenshtein(query, c);
+        match best {
+            None => best = Some((c, d)),
+            Some((_, bd)) if d < bd => best = Some((c, d)),
+            _ => {}
+        }
+    }
+    best.and_then(|(s, d)| if d <= 3 { Some(s.clone()) } else { None })
+}
+
+// ============================================================
+// Orchestrator
+// ============================================================
+
+/// ユニットテストで `run_checks` を差し替え可能にするための入力集合。
+pub struct CheckContext<'a> {
+    pub config: &'a Config,
+    pub config_path: &'a Path,
+    pub loader_path: &'a Path,
+    pub init_lua_path: &'a Path,
+    pub merged_dir: &'a Path,
+    pub unused_cache_dirs: Vec<PathBuf>,
+    pub appname_resolved: String,
+    pub rvpm_appname_env: Option<String>,
+    pub nvim_appname_env: Option<String>,
+    pub resolver: Box<dyn VersionResolver>,
+    pub resolve_dst: Box<dyn Fn(&crate::config::Plugin) -> PathBuf + 'a>,
+}
+
+pub fn run_checks(ctx: &CheckContext) -> Vec<Diagnostic> {
+    vec![
+        // Plugin config
+        check_depends_cycles(ctx.config),
+        check_depends_references(ctx.config),
+        check_on_source_typos(ctx.config),
+        check_dev_plugin_dst(ctx.config),
+        check_duplicates(ctx.config),
+        // State integrity
+        check_cloned_plugins(ctx.config, |p| (ctx.resolve_dst)(p)),
+        check_unused_cache_dirs(&ctx.unused_cache_dirs),
+        check_merged_stale_links(ctx.merged_dir),
+        check_loader_freshness(ctx.loader_path, ctx.config_path),
+        // Neovim integration
+        check_init_lua_hook(ctx.init_lua_path),
+        check_appname(
+            &ctx.appname_resolved,
+            ctx.rvpm_appname_env.as_deref(),
+            ctx.nvim_appname_env.as_deref(),
+        ),
+        check_helptags(ctx.config, |p| (ctx.resolve_dst)(p)),
+        // External tools
+        check_tool_nvim(ctx.resolver.as_ref()),
+        check_tool_git(ctx.resolver.as_ref()),
+        check_tool_chezmoi(ctx.config, ctx.resolver.as_ref()),
+        check_editor(ctx.resolver.as_ref()),
+    ]
+}
+
+// ============================================================
+// Summary / exit code
+// ============================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Summary {
+    pub ok: usize,
+    pub warn: usize,
+    pub error: usize,
+}
+
+impl Summary {
+    pub fn from(diagnostics: &[Diagnostic]) -> Self {
+        let mut s = Summary {
+            ok: 0,
+            warn: 0,
+            error: 0,
+        };
+        for d in diagnostics {
+            match d.severity {
+                Severity::Ok => s.ok += 1,
+                Severity::Warn => s.warn += 1,
+                Severity::Error => s.error += 1,
+            }
+        }
+        s
+    }
+
+    /// exit code: 1 if any error, 2 if any warn (no error), 0 otherwise.
+    pub fn exit_code(&self) -> i32 {
+        if self.error > 0 {
+            1
+        } else if self.warn > 0 {
+            2
+        } else {
+            0
+        }
+    }
+}
+
+// ============================================================
+// Rendering
+// ============================================================
+
+/// 左端のラベル (title) の固定幅。出力例の縦位置を揃える。
+const TITLE_WIDTH: usize = 25;
+
+/// 診断アイコンを Icons スタイルに合わせて返す (先頭プレフィクス)。
+fn severity_prefix(sev: Severity, icons: &Icons) -> String {
+    match icons.style {
+        IconStyle::Ascii => match sev {
+            Severity::Ok => "ok ".to_string(),
+            Severity::Warn => "WARN".to_string(),
+            Severity::Error => "ERR ".to_string(),
+        },
+        _ => match sev {
+            Severity::Ok => "\u{2713}".to_string(),    // ✓
+            Severity::Warn => "\u{26a0}".to_string(),  // ⚠
+            Severity::Error => "\u{2717}".to_string(), // ✗
+        },
+    }
+}
+
+pub fn render(diagnostics: &[Diagnostic], icons: &Icons) -> String {
+    let mut out = String::new();
+    out.push_str("rvpm doctor — diagnostic report\n\n");
+
+    for (ci, cat) in CATEGORY_ORDER.iter().enumerate() {
+        let diags_in_cat: Vec<&Diagnostic> =
+            diagnostics.iter().filter(|d| d.category == *cat).collect();
+        if diags_in_cat.is_empty() {
+            continue;
+        }
+        if ci > 0 {
+            out.push('\n');
+        }
+        out.push_str(cat);
+        out.push('\n');
+
+        for d in diags_in_cat {
+            let prefix = severity_prefix(d.severity, icons);
+            let padded_title = pad_right(&d.title, TITLE_WIDTH);
+            out.push_str(&format!("  {} {} — {}\n", prefix, padded_title, d.summary));
+
+            // details: 最後の行は `└`、それ以外は `├` (単一要素なら直接 `└`)
+            let n = d.details.len();
+            for (i, line) in d.details.iter().enumerate() {
+                let bullet = if i == n - 1 { "└" } else { "├" };
+                out.push_str(&format!("      {} {}\n", bullet, line));
+            }
+            if let Some(h) = &d.hint {
+                out.push_str(&format!("      hint: {}\n", h));
+            }
+        }
+    }
+
+    let summary = Summary::from(diagnostics);
+    out.push('\n');
+    out.push_str(&format!(
+        "Summary: {} ok  ·  {} warn  ·  {} error   (exit {})\n",
+        summary.ok,
+        summary.warn,
+        summary.error,
+        summary.exit_code()
+    ));
+
+    out
+}
+
+/// 文字列を最低 `width` 幅になるよう空白で右埋めする (UTF-8 safe: 文字数ベース)。
+fn pad_right(s: &str, width: usize) -> String {
+    let count = s.chars().count();
+    if count >= width {
+        s.to_string()
+    } else {
+        let mut out = String::with_capacity(s.len() + (width - count));
+        out.push_str(s);
+        for _ in count..width {
+            out.push(' ');
+        }
+        out
+    }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{BrowseOptions, Config, Options, Plugin, UrlStyle};
+
+    fn plugin(url: &str) -> Plugin {
+        Plugin {
+            url: url.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn mk_config(plugins: Vec<Plugin>) -> Config {
+        Config {
+            vars: None,
+            options: Options {
+                config_root: None,
+                concurrency: None,
+                cache_root: None,
+                icons: IconStyle::Unicode,
+                chezmoi: false,
+                auto_clean: false,
+                auto_helptags: false,
+                url_style: UrlStyle::Short,
+                browse: BrowseOptions::default(),
+            },
+            plugins,
+        }
+    }
+
+    // -------- levenshtein --------
+
+    #[test]
+    fn test_levenshtein_basic() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("a", ""), 1);
+        assert_eq!(levenshtein("", "ab"), 2);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("snack.nvim", "snacks.nvim"), 1);
+    }
+
+    // -------- depends cycles --------
+
+    #[test]
+    fn test_check_depends_cycles_none() {
+        let cfg = mk_config(vec![
+            Plugin {
+                url: "A".into(),
+                depends: Some(vec!["B".into()]),
+                ..Default::default()
+            },
+            plugin("B"),
+        ]);
+        let d = check_depends_cycles(&cfg);
+        assert_eq!(d.severity, Severity::Ok);
+        assert_eq!(d.summary, "none");
+    }
+
+    #[test]
+    fn test_check_depends_cycles_detects_loop() {
+        let cfg = mk_config(vec![
+            Plugin {
+                url: "A".into(),
+                depends: Some(vec!["B".into()]),
+                ..Default::default()
+            },
+            Plugin {
+                url: "B".into(),
+                depends: Some(vec!["A".into()]),
+                ..Default::default()
+            },
+        ]);
+        let d = check_depends_cycles(&cfg);
+        assert_eq!(d.severity, Severity::Error);
+        assert!(!d.details.is_empty());
+    }
+
+    // -------- depends references --------
+
+    #[test]
+    fn test_check_depends_references_all_resolved() {
+        let cfg = mk_config(vec![
+            Plugin {
+                url: "A".into(),
+                depends: Some(vec!["B".into()]),
+                ..Default::default()
+            },
+            plugin("B"),
+        ]);
+        let d = check_depends_references(&cfg);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("1/1"));
+    }
+
+    #[test]
+    fn test_check_depends_references_missing() {
+        let cfg = mk_config(vec![Plugin {
+            url: "A".into(),
+            depends: Some(vec!["NOT_FOUND".into()]),
+            ..Default::default()
+        }]);
+        let d = check_depends_references(&cfg);
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(d.details.len(), 1);
+    }
+
+    // -------- on_source typos --------
+
+    #[test]
+    fn test_check_on_source_typos_suggests() {
+        let cfg = mk_config(vec![
+            Plugin {
+                url: "owner/snacks.nvim".into(),
+                ..Default::default()
+            },
+            Plugin {
+                url: "nvim-telescope/telescope.nvim".into(),
+                on_source: Some(vec!["snack.nvim".into()]),
+                ..Default::default()
+            },
+        ]);
+        let d = check_on_source_typos(&cfg);
+        assert_eq!(d.severity, Severity::Warn);
+        assert_eq!(d.details.len(), 1);
+        assert!(d.details[0].contains("snacks.nvim"));
+    }
+
+    #[test]
+    fn test_check_on_source_typos_exact_match_ok() {
+        let cfg = mk_config(vec![
+            Plugin {
+                url: "owner/snacks.nvim".into(),
+                ..Default::default()
+            },
+            Plugin {
+                url: "nvim-telescope/telescope.nvim".into(),
+                on_source: Some(vec!["snacks.nvim".into()]),
+                ..Default::default()
+            },
+        ]);
+        let d = check_on_source_typos(&cfg);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    // -------- dev plugin dst --------
+
+    #[test]
+    fn test_check_dev_plugin_dst_missing() {
+        let cfg = mk_config(vec![Plugin {
+            url: "owner/devplugin".into(),
+            dev: true,
+            dst: Some("/this/path/should/never/exist/rvpm_test".into()),
+            ..Default::default()
+        }]);
+        let d = check_dev_plugin_dst(&cfg);
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_check_dev_plugin_dst_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = mk_config(vec![Plugin {
+            url: "owner/devplugin".into(),
+            dev: true,
+            dst: Some(tmp.path().to_string_lossy().to_string()),
+            ..Default::default()
+        }]);
+        let d = check_dev_plugin_dst(&cfg);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    // -------- duplicates --------
+
+    #[test]
+    fn test_check_duplicates_url_error() {
+        let cfg = mk_config(vec![plugin("owner/repo"), plugin("owner/repo")]);
+        let d = check_duplicates(&cfg);
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_check_duplicates_none() {
+        let cfg = mk_config(vec![plugin("owner/a"), plugin("owner/b")]);
+        let d = check_duplicates(&cfg);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    // -------- cloned plugins --------
+
+    #[test]
+    fn test_check_cloned_plugins_all_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let p_path = root.join("owner-a");
+        std::fs::create_dir_all(&p_path).unwrap();
+        let cfg = mk_config(vec![plugin("owner/a")]);
+        let r = root.clone();
+        let d = check_cloned_plugins(&cfg, move |_p| r.join("owner-a"));
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn test_check_cloned_plugins_missing() {
+        let cfg = mk_config(vec![plugin("owner/a")]);
+        let d = check_cloned_plugins(&cfg, |_p| PathBuf::from("/nonexistent/rvpm_test"));
+        assert_eq!(d.severity, Severity::Warn);
+    }
+
+    // -------- unused cache dirs --------
+
+    #[test]
+    fn test_check_unused_none() {
+        let d = check_unused_cache_dirs(&[]);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn test_check_unused_some() {
+        let d = check_unused_cache_dirs(&[PathBuf::from("/x/y/z")]);
+        assert_eq!(d.severity, Severity::Warn);
+        assert_eq!(d.details.len(), 1);
+    }
+
+    // -------- loader freshness --------
+
+    #[test]
+    fn test_check_loader_freshness_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loader = tmp.path().join("loader.lua");
+        let config = tmp.path().join("config.toml");
+        std::fs::write(&config, "x").unwrap();
+        let d = check_loader_freshness(&loader, &config);
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_check_loader_freshness_ok_when_newer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loader = tmp.path().join("loader.lua");
+        let config = tmp.path().join("config.toml");
+        std::fs::write(&config, "x").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&loader, "y").unwrap();
+        let d = check_loader_freshness(&loader, &config);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    #[test]
+    fn test_check_loader_freshness_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loader = tmp.path().join("loader.lua");
+        let config = tmp.path().join("config.toml");
+        std::fs::write(&loader, "y").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&config, "x").unwrap();
+        let d = check_loader_freshness(&loader, &config);
+        assert_eq!(d.severity, Severity::Warn);
+    }
+
+    // -------- init.lua hook --------
+
+    #[test]
+    fn test_check_init_lua_hook_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = tmp.path().join("init.lua");
+        let d = check_init_lua_hook(&init);
+        assert_eq!(d.severity, Severity::Warn);
+    }
+
+    #[test]
+    fn test_check_init_lua_hook_linked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = tmp.path().join("init.lua");
+        std::fs::write(
+            &init,
+            "-- some comment\ndofile(vim.fn.expand(\"~/.cache/rvpm/loader.lua\"))\n",
+        )
+        .unwrap();
+        let d = check_init_lua_hook(&init);
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    // -------- appname --------
+
+    #[test]
+    fn test_check_appname_reports_env_state() {
+        let d = check_appname("nvim", None, None);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("\"nvim\""));
+        assert!(d.summary.contains("$RVPM_APPNAME unset"));
+        assert!(d.summary.contains("$NVIM_APPNAME unset"));
+    }
+
+    #[test]
+    fn test_check_appname_with_env_set() {
+        let d = check_appname("mynvim", Some("mynvim"), None);
+        assert!(d.summary.contains("$RVPM_APPNAME=\"mynvim\""));
+    }
+
+    // -------- helptags --------
+
+    #[test]
+    fn test_check_helptags_disabled_when_opted_out() {
+        // auto_helptags = false を明示すると check 自体をスキップして informational に。
+        let mut cfg = mk_config(vec![plugin("owner/a")]);
+        cfg.options.auto_helptags = false;
+        let d = check_helptags(&cfg, |_p| PathBuf::from("/tmp/whatever"));
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("disabled"));
+    }
+
+    #[test]
+    fn test_check_helptags_warns_when_missing_tags() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dst = tmp.path().join("pl");
+        std::fs::create_dir_all(dst.join("doc")).unwrap();
+        // doc/ あり、tags なし → warn
+        let mut cfg = mk_config(vec![plugin("owner/a")]);
+        cfg.options.auto_helptags = true;
+        let dst_clone = dst.clone();
+        let d = check_helptags(&cfg, move |_p| dst_clone.clone());
+        assert_eq!(d.severity, Severity::Warn);
+    }
+
+    #[test]
+    fn test_check_helptags_ok_when_tags_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dst = tmp.path().join("pl");
+        std::fs::create_dir_all(dst.join("doc")).unwrap();
+        std::fs::write(dst.join("doc").join("tags"), "tags").unwrap();
+        let mut cfg = mk_config(vec![plugin("owner/a")]);
+        cfg.options.auto_helptags = true;
+        let dst_clone = dst.clone();
+        let d = check_helptags(&cfg, move |_p| dst_clone.clone());
+        assert_eq!(d.severity, Severity::Ok);
+    }
+
+    // -------- external tools --------
+
+    struct MockResolver {
+        map: HashMap<String, String>,
+        env: HashMap<String, String>,
+    }
+
+    impl MockResolver {
+        fn new() -> Self {
+            Self {
+                map: HashMap::new(),
+                env: HashMap::new(),
+            }
+        }
+        fn with_cmd(mut self, cmd: &str, ver: &str) -> Self {
+            self.map.insert(cmd.to_string(), ver.to_string());
+            self
+        }
+        fn with_env(mut self, key: &str, val: &str) -> Self {
+            self.env.insert(key.to_string(), val.to_string());
+            self
+        }
+    }
+
+    impl VersionResolver for MockResolver {
+        fn version(&self, cmd: &str) -> Option<String> {
+            self.map.get(cmd).cloned()
+        }
+        fn env(&self, key: &str) -> Option<String> {
+            self.env.get(key).cloned()
+        }
+    }
+
+    #[test]
+    fn test_check_tool_nvim_present() {
+        let r = MockResolver::new().with_cmd("nvim", "NVIM v0.13.0-dev-some-build");
+        let d = check_tool_nvim(&r);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("v0.13.0-dev-some-build"));
+    }
+
+    #[test]
+    fn test_check_tool_nvim_missing() {
+        let r = MockResolver::new();
+        let d = check_tool_nvim(&r);
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_check_tool_git_present() {
+        let r = MockResolver::new().with_cmd("git", "git version 2.49.1");
+        let d = check_tool_git(&r);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("v2.49.1"));
+    }
+
+    #[test]
+    fn test_check_tool_chezmoi_optional_when_disabled() {
+        let cfg = mk_config(vec![]);
+        let r = MockResolver::new();
+        let d = check_tool_chezmoi(&cfg, &r);
+        // chezmoi 無し + options.chezmoi = false → Ok (informational)
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("optional"));
+    }
+
+    #[test]
+    fn test_check_tool_chezmoi_required_when_enabled() {
+        let mut cfg = mk_config(vec![]);
+        cfg.options.chezmoi = true;
+        let r = MockResolver::new();
+        let d = check_tool_chezmoi(&cfg, &r);
+        // chezmoi 無し + options.chezmoi = true → Error
+        assert_eq!(d.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_check_editor_set() {
+        let r = MockResolver::new().with_env("EDITOR", "vim");
+        let d = check_editor(&r);
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("vim"));
+    }
+
+    #[test]
+    fn test_check_editor_unset() {
+        let r = MockResolver::new();
+        let d = check_editor(&r);
+        assert_eq!(d.severity, Severity::Warn);
+    }
+
+    // -------- summary / exit code --------
+
+    #[test]
+    fn test_summary_counts() {
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "a", "x"),
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "b", "x"),
+            Diagnostic::new(Severity::Warn, CAT_PLUGIN_CONFIG, "c", "x"),
+            Diagnostic::new(Severity::Error, CAT_PLUGIN_CONFIG, "d", "x"),
+        ];
+        let s = Summary::from(&diags);
+        assert_eq!(s.ok, 2);
+        assert_eq!(s.warn, 1);
+        assert_eq!(s.error, 1);
+        assert_eq!(s.exit_code(), 1);
+    }
+
+    #[test]
+    fn test_exit_code_warn_only() {
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "a", "x"),
+            Diagnostic::new(Severity::Warn, CAT_PLUGIN_CONFIG, "b", "x"),
+        ];
+        let s = Summary::from(&diags);
+        assert_eq!(s.exit_code(), 2);
+    }
+
+    #[test]
+    fn test_exit_code_all_ok() {
+        let diags = vec![Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "a", "x")];
+        let s = Summary::from(&diags);
+        assert_eq!(s.exit_code(), 0);
+    }
+
+    #[test]
+    fn test_exit_code_error_outweighs_warn() {
+        let diags = vec![
+            Diagnostic::new(Severity::Warn, CAT_PLUGIN_CONFIG, "a", "x"),
+            Diagnostic::new(Severity::Error, CAT_PLUGIN_CONFIG, "b", "x"),
+        ];
+        let s = Summary::from(&diags);
+        assert_eq!(s.exit_code(), 1);
+    }
+
+    // -------- render --------
+
+    #[test]
+    fn test_render_basic_shape() {
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "depends cycles", "none"),
+            Diagnostic::new(
+                Severity::Warn,
+                CAT_PLUGIN_CONFIG,
+                "on_source typos",
+                "1 found",
+            )
+            .with_details(vec!["a: on_source = [\"b\"]  (hint: \"c\"?)".into()]),
+            Diagnostic::new(Severity::Ok, CAT_NEOVIM, "init.lua loader hook", "linked"),
+        ];
+        let icons = Icons::from_style(IconStyle::Unicode);
+        let out = render(&diags, &icons);
+        assert!(out.contains("rvpm doctor"));
+        assert!(out.contains("Plugin config"));
+        assert!(out.contains("Neovim integration"));
+        assert!(out.contains("\u{2713}")); // ✓
+        assert!(out.contains("\u{26a0}")); // ⚠
+        assert!(out.contains("└ a: on_source")); // last-only detail uses └
+        assert!(out.contains("Summary:"));
+        assert!(out.contains("exit 2"));
+    }
+
+    #[test]
+    fn test_render_ascii_prefixes() {
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "x", "done"),
+            Diagnostic::new(Severity::Warn, CAT_PLUGIN_CONFIG, "y", "meh"),
+            Diagnostic::new(Severity::Error, CAT_PLUGIN_CONFIG, "z", "bad"),
+        ];
+        let icons = Icons::from_style(IconStyle::Ascii);
+        let out = render(&diags, &icons);
+        assert!(out.contains("ok  "));
+        assert!(out.contains("WARN"));
+        assert!(out.contains("ERR "));
+    }
+
+    #[test]
+    fn test_render_multi_detail_uses_tree_chars() {
+        let diags = vec![
+            Diagnostic::new(
+                Severity::Warn,
+                CAT_STATE_INTEGRITY,
+                "unused cache dirs",
+                "3 found",
+            )
+            .with_details(vec!["a".into(), "b".into(), "c".into()])
+            .with_hint("rvpm clean"),
+        ];
+        let icons = Icons::from_style(IconStyle::Unicode);
+        let out = render(&diags, &icons);
+        // first two use ├, last uses └
+        assert!(out.contains("├ a"));
+        assert!(out.contains("├ b"));
+        assert!(out.contains("└ c"));
+        assert!(out.contains("hint: rvpm clean"));
+    }
+
+    #[test]
+    fn test_render_category_ordering() {
+        // Diags deliberately inserted out of order; render must emit categories in fixed order.
+        let diags = vec![
+            Diagnostic::new(Severity::Ok, CAT_TOOLS, "nvim", "v1"),
+            Diagnostic::new(Severity::Ok, CAT_PLUGIN_CONFIG, "depends cycles", "none"),
+            Diagnostic::new(Severity::Ok, CAT_NEOVIM, "init.lua loader hook", "linked"),
+            Diagnostic::new(Severity::Ok, CAT_STATE_INTEGRITY, "cloned plugins", "1/1"),
+        ];
+        let icons = Icons::from_style(IconStyle::Unicode);
+        let out = render(&diags, &icons);
+        let pos_plugin = out.find("Plugin config").unwrap();
+        let pos_state = out.find("State integrity").unwrap();
+        let pos_nvim = out.find("Neovim integration").unwrap();
+        let pos_tools = out.find("External tools").unwrap();
+        assert!(pos_plugin < pos_state);
+        assert!(pos_state < pos_nvim);
+        assert!(pos_nvim < pos_tools);
+    }
+
+    // -------- shorten_version --------
+
+    #[test]
+    fn test_shorten_version_nvim() {
+        assert_eq!(
+            shorten_version("NVIM v0.13.0-dev-foo bar baz"),
+            "v0.13.0-dev-foo"
+        );
+    }
+
+    #[test]
+    fn test_shorten_version_git() {
+        assert_eq!(shorten_version("git version 2.49.1"), "v2.49.1");
+    }
+
+    #[test]
+    fn test_shorten_version_chezmoi() {
+        assert_eq!(
+            shorten_version("chezmoi version v2.68.0, commit foo"),
+            "v2.68.0"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod browse;
 mod browse_tui;
 mod chezmoi;
 mod config;
+mod doctor;
 mod external_render;
 mod git;
 mod helptags;
@@ -239,6 +240,13 @@ enum Commands {
     },
     /// Browse and install Neovim plugins from GitHub
     Browse,
+
+    /// Diagnose rvpm's config, state, and environment
+    ///
+    /// Inspects config.toml, the plugin cache, generated loader.lua, Neovim
+    /// init.lua wiring, and required external tools (nvim / git / chezmoi /
+    /// $EDITOR). Exits 0 on all-ok, 1 on any error, 2 on warn-only.
+    Doctor,
 }
 
 #[tokio::main]
@@ -330,6 +338,12 @@ async fn main() -> Result<()> {
             }
             break;
         },
+        Commands::Doctor => {
+            let code = run_doctor().await?;
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
     }
 
     Ok(())
@@ -812,6 +826,92 @@ async fn run_generate() -> Result<()> {
 
     print_init_lua_hint_if_missing(&config);
     Ok(())
+}
+
+/// `rvpm doctor` エントリポイント。config を読み、各チェックを走らせて
+/// 診断レポートを stdout に出し、exit code を返す。
+async fn run_doctor() -> Result<i32> {
+    let config_path = rvpm_config_path();
+    let toml_content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("rvpm doctor — diagnostic report");
+            println!();
+            println!("Config");
+            println!(
+                "  \u{2717} config.toml              — failed to read: {}",
+                e
+            );
+            println!("      hint: run `rvpm init --write` or create the file");
+            println!();
+            println!("Summary: 0 ok  ·  0 warn  ·  1 error   (exit 1)");
+            return Ok(1);
+        }
+    };
+    let mut config = match parse_config(&toml_content) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("rvpm doctor — diagnostic report");
+            println!();
+            println!("Config");
+            println!("  \u{2717} config.toml              — parse error: {}", e);
+            println!();
+            println!("Summary: 0 ok  ·  0 warn  ·  1 error   (exit 1)");
+            return Ok(1);
+        }
+    };
+    // sort_plugins は副作用で stderr に出るがエラーにはならない。doctor は
+    // 自前で cycles / missing refs を検出するので sort_plugins は呼ばない。
+    for plugin in config.plugins.iter_mut() {
+        disable_merge_if_cond(plugin);
+    }
+
+    let cache_root = resolve_cache_root(config.options.cache_root.as_deref());
+    let merged_dir = resolve_merged_dir(&cache_root);
+    let loader_path = resolve_loader_path(&cache_root);
+    let init_lua_path = nvim_init_lua_path();
+    let repos_dir = resolve_repos_dir(&cache_root);
+
+    // 未使用 repo の検出 (find_unused_repos を再利用)。repos_dir が無い場合は空。
+    let mut unused: Vec<PathBuf> = if repos_dir.exists() {
+        find_unused_repos(&config, &cache_root, &repos_dir).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    unused.sort();
+
+    // appname coherence
+    let rvpm_env = std::env::var("RVPM_APPNAME").ok();
+    let nvim_env = std::env::var("NVIM_APPNAME").ok();
+    let resolved = appname();
+
+    // resolve_dst は doctor 内で clone() 可能なクロージャに閉じ込める
+    let cache_root_for_fn = cache_root.clone();
+    let resolve_dst = Box::new(move |p: &crate::config::Plugin| -> PathBuf {
+        resolve_plugin_dst(p, &cache_root_for_fn)
+    });
+
+    let ctx = crate::doctor::CheckContext {
+        config: &config,
+        config_path: &config_path,
+        loader_path: &loader_path,
+        init_lua_path: &init_lua_path,
+        merged_dir: &merged_dir,
+        unused_cache_dirs: unused,
+        appname_resolved: resolved,
+        rvpm_appname_env: rvpm_env,
+        nvim_appname_env: nvim_env,
+        resolver: Box::new(crate::doctor::SystemResolver),
+        resolve_dst,
+    };
+
+    let diagnostics = crate::doctor::run_checks(&ctx);
+    let icons = crate::tui::Icons::from_style(config.options.icons);
+    let output = crate::doctor::render(&diagnostics, &icons);
+    print!("{}", output);
+
+    let summary = crate::doctor::Summary::from(&diagnostics);
+    Ok(summary.exit_code())
 }
 
 /// 全プラグインの git 状態を並列で調べ、url -> PluginStatus のマップを返す。
@@ -2463,6 +2563,16 @@ fn ensure_config_exists(config_path: &Path) -> Result<bool> {
     std::fs::write(config_path, template)?;
     println!("Created {}", config_path.display());
     Ok(true)
+}
+
+/// doctor 用の pub 再公開 (元 `expand_tilde` を module 外から使いたいため)。
+pub(crate) fn expand_tilde_public(path: &str) -> PathBuf {
+    expand_tilde(path)
+}
+
+/// doctor 用の pub 再公開 (元 `init_lua_references_rvpm_loader` の同義)。
+pub(crate) fn init_lua_references_rvpm_loader_public(init_lua_path: &Path) -> bool {
+    init_lua_references_rvpm_loader(init_lua_path)
 }
 
 /// `~` / `~/foo` / `~\foo` 形式を home dir に展開する。

--- a/src/main.rs
+++ b/src/main.rs
@@ -934,7 +934,7 @@ async fn run_doctor() -> Result<i32> {
         helptag_target_labels,
     };
 
-    let diagnostics = crate::doctor::run_checks(&ctx);
+    let diagnostics = crate::doctor::run_checks(&ctx).await;
     let icons = crate::tui::Icons::from_style(config.options.icons);
     let output = crate::doctor::render(&diagnostics, &icons);
     print!("{}", output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,6 +891,33 @@ async fn run_doctor() -> Result<i32> {
         resolve_plugin_dst(p, &cache_root_for_fn)
     });
 
+    // helptags チェック用の target list を、本物の loader 生成と同じ規則で構築する。
+    // merged + lazy + non-merge eager だけが個別の `:helptags` 対象になる。
+    // lazy → eager 昇格も考慮するため、build_plugin_scripts → promote まで通す。
+    let config_root_for_scripts = resolve_config_root(config.options.config_root.as_deref());
+    let mut plugin_scripts: Vec<crate::loader::PluginScripts> = Vec::new();
+    for plugin in &config.plugins {
+        let dst = resolve_plugin_dst(plugin, &cache_root);
+        let plugin_config_dir = resolve_plugin_config_dir(&config_root_for_scripts, plugin);
+        plugin_scripts.push(build_plugin_scripts(plugin, &dst, &plugin_config_dir));
+    }
+    crate::loader::promote_lazy_to_eager(&mut plugin_scripts);
+    let helptag_targets = crate::helptags::collect_helptag_targets(&plugin_scripts, &merged_dir);
+    // collect_helptag_targets と同じイテレーションでラベルを並べる (順序を揃える)。
+    let mut helptag_target_labels: Vec<String> = Vec::with_capacity(helptag_targets.len());
+    if merged_dir.join("doc").is_dir() {
+        helptag_target_labels.push("merged".to_string());
+    }
+    for ps in &plugin_scripts {
+        if ps.merge && !ps.lazy {
+            continue;
+        }
+        if PathBuf::from(&ps.path).join("doc").is_dir() {
+            helptag_target_labels.push(ps.name.clone());
+        }
+    }
+    debug_assert_eq!(helptag_targets.len(), helptag_target_labels.len());
+
     let ctx = crate::doctor::CheckContext {
         config: &config,
         config_path: &config_path,
@@ -903,6 +930,8 @@ async fn run_doctor() -> Result<i32> {
         nvim_appname_env: nvim_env,
         resolver: Box::new(crate::doctor::SystemResolver),
         resolve_dst,
+        helptag_targets,
+        helptag_target_labels,
     };
 
     let diagnostics = crate::doctor::run_checks(&ctx);


### PR DESCRIPTION
## Summary

Adds `rvpm doctor`, a one-shot diagnostic command that aggregates 16 checks across 4 categories. Closes #49.

```
rvpm doctor — diagnostic report

Plugin config
  ✓ depends cycles            — none
  ✓ depends references        — 17/17 resolved
  ✓ on_source typos           — none
  ✓ dev plugin dst            — 0/0 exist
  ✓ duplicates                — none

State integrity
  ✓ cloned plugins            — 216/216
  ✓ unused cache dirs         — none
  ✓ merged/ stale links       — none
  ✓ loader.lua freshness      — 20m ago (newer than config.toml)

Neovim integration
  ✓ init.lua loader hook      — linked
  ✓ appname coherence         — "nvim"  ($RVPM_APPNAME unset, $NVIM_APPNAME unset)
  ⚠ helptags                  — 91/94 have doc/tags
      ├ vim-kensaku: …/vim-kensaku/doc
      ├ log-highlight.nvim: …/log-highlight.nvim/doc
      └ vim-colorscheme-kemonofriends: …/vim-colorscheme-kemonofriends/doc
      hint: run `rvpm sync` (auto_helptags) or `:helptags <doc>` in Neovim

External tools
  ✓ nvim                      — v0.13.0-dev-…           (required)
  ✓ git                       — v2.53.0.windows.3        (required)
  ✓ chezmoi                   — v2.70.1                  (required: options.chezmoi=true)
  ✓ $EDITOR                   — nvim                     (required: for edit/config/set)

Summary: 15 ok  ·  1 warn  ·  0 error   (exit 2)
```

### Categories

1. **Plugin config** — `depends` cycles / unresolved refs, `on_source` typos with Levenshtein "did you mean" suggestions, `dev = true` plugins with missing `dst`, duplicate names/urls
2. **State integrity** — clones present, unused cache dirs (reuses `find_unused_repos`), stale links in `merged/`, `loader.lua` missing or older than `config.toml`
3. **Neovim integration** — `init.lua` loader hook detection, `<appname>` resolution + env var coherence, helptags coverage (uses the same target list as `crate::helptags::collect_helptag_targets` so eager + merge plugins are not falsely flagged)
4. **External tools** — `nvim` / `git` / `chezmoi` (conditional on `options.chezmoi`) / `$EDITOR` — version detection where applicable

### Exit codes

- `0` — all OK
- `1` — at least one error
- `2` — only warnings (and no error)

### Architecture notes

- `src/doctor.rs` (~1100 lines) holds pure check functions taking `Config` + paths and returning `Diagnostic` — easy to unit-test
- External-command checks go through a `VersionResolver` trait so unit tests can mock without spawning processes
- `CheckContext` lets `run_doctor()` plumb in everything (paths, env, helptag targets, resolver) without making each check do I/O directly
- Render output respects `options.icons` (nerd / unicode / ascii)

### Helptags check correctness

The first cut walked every plugin's `doc/` directory looking for `tags`. That over-warned by 23 entries on a 217-plugin config — eager + merge plugins live under `merged/doc/` and intentionally have no per-plugin tags file. Switched to enumerating the same target list as the actual `nvim --headless` invocation in PR #46, plus running `build_plugin_scripts` + `promote_lazy_to_eager` so lazy→eager promotion is reflected. Result: false warns dropped from 23 to 0, and only genuinely missing tags surface.

## Test plan

- [x] **44 new unit tests in `src/doctor.rs`** covering each check function, levenshtein, version shortening, summary aggregation, exit-code precedence, render output, ascii fallback, category ordering
- [x] All 315 tests pass (`cargo test`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manual smoke test on real 217-plugin config (output above)
- [ ] Verify exit codes (`echo $?`) match `0` / `1` / `2` rules
- [ ] Try with `nvim` / `git` removed from PATH — expect graceful error diagnostic
- [ ] Try with intentionally broken `config.toml` — expect informative parse-error message before category render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rvpm doctor` diagnostic command that checks plugin configuration integrity, validates system and cache state, verifies Neovim integration, and confirms required external tools are available. Generates comprehensive reports with severity levels and actionable guidance to resolve issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->