### PR TITLE
fix(lockfile): write rvpm.lock via chezmoi when chezmoi=true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,10 @@ commit、それも無ければ default branch の HEAD を pull する。
   fallback (resilience)。
 - `dev = true` プラグインは lockfile 対象外 (ローカル work in progress なので
   commit hash を pin する意味が無い)。
+- `options.chezmoi = true` のとき、lockfile も config.toml / hook と同じく
+  `chezmoi::write_path` + `chezmoi::apply` 経由で source 側に書いてから target に
+  反映する。これをやらないと chezmoi の「source が truth」原則と衝突して、
+  次回 `chezmoi apply` で古い lockfile に巻き戻る。
 
 ### helptags 自動生成 (`src/helptags.rs`)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -890,6 +890,8 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool) -> Result<()> {
     // lockfile save: config.toml から外されたプラグインの entry を drop してから
     // atomic write。`--no-lock` 時は完全スキップ (ディスクに触らない = 既存の
     // lockfile がユーザーの dotfile にあってもそのまま保つ)。
+    // `options.chezmoi = true` なら source 側に書いて `chezmoi apply` で target
+    // へ反映する (config.toml / hook ファイルと同じ流儀)。
     if !no_lock {
         let active: std::collections::HashSet<String> = config
             .plugins
@@ -898,12 +900,15 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool) -> Result<()> {
             .map(|p| p.display_name())
             .collect();
         lockfile.retain_by_names(&active);
-        if let Err(e) = lockfile.save(&lockfile_path) {
+        let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path);
+        if let Err(e) = lockfile.save(&wp) {
             eprintln!(
                 "\u{26a0} failed to save {}: {} (lockfile not updated)",
-                lockfile_path.display(),
+                wp.display(),
                 e
             );
+        } else {
+            chezmoi::apply(&wp, &lockfile_path);
         }
     }
 
@@ -1677,12 +1682,16 @@ async fn run_update(query: Option<String>) -> Result<()> {
     // **かけない** — 更新対象外のプラグインの entry を削りたくないため。
     // ここでは単に新 HEAD を反映した lockfile を atomic write するだけ。
     // (config.toml から外されたプラグインの整理は次の full `rvpm sync` で行う)。
-    if let Err(e) = lockfile.save(&lockfile_path) {
+    // chezmoi 連携: source 側に書いてから `chezmoi apply` で target に反映。
+    let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path);
+    if let Err(e) = lockfile.save(&wp) {
         eprintln!(
             "\u{26a0} failed to save {}: {} (lockfile not updated)",
-            lockfile_path.display(),
+            wp.display(),
             e
         );
+    } else {
+        chezmoi::apply(&wp, &lockfile_path);
     }
 
     println!("Update complete. Regenerating loader.lua...");
@@ -1847,12 +1856,18 @@ async fn run_add(
 
     record_changes_or_warn(&cache_root, "add", add_changes);
 
-    if lockfile_dirty && let Err(e) = lockfile.save(&lockfile_path) {
-        eprintln!(
-            "\u{26a0} failed to save {}: {} (lockfile not updated)",
-            lockfile_path.display(),
-            e
-        );
+    if lockfile_dirty {
+        // chezmoi 連携: source 側に書いてから `chezmoi apply` で target に反映。
+        let wp = chezmoi::write_path(config_data.options.chezmoi, &lockfile_path);
+        if let Err(e) = lockfile.save(&wp) {
+            eprintln!(
+                "\u{26a0} failed to save {}: {} (lockfile not updated)",
+                wp.display(),
+                e
+            );
+        } else {
+            chezmoi::apply(&wp, &lockfile_path);
+        }
     }
 
     run_generate().await?;


### PR DESCRIPTION
## Summary

- `rvpm sync` / `update` / `add` were calling `lockfile.save()` directly against the target path, bypassing the `chezmoi::write_path` + `chezmoi::apply` flow that `config.toml` and per-plugin hooks already use.
- With `options.chezmoi = true`, the next `chezmoi apply` would restore the stale lockfile from the chezmoi source — silently rolling back freshly recorded commits.
- Wrap all three `lockfile.save()` call sites the same way the other config-writing paths do: resolve the source path, save, then apply back to the target.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 444 passed
- [x] `cargo make check` (fmt + clippy + test) passes via pre-push hook
- [ ] Manual: with `options.chezmoi = true`, run `rvpm sync` and confirm `chezmoi diff` reports no drift on `rvpm.lock`
- [ ] Manual: same for `rvpm update <name>` and `rvpm add owner/repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional chezmoi integration for managing lockfiles. When enabled, lockfiles are now synchronized through chezmoi's configuration system rather than direct file writes.

* **Documentation**
  * Added documentation explaining how the new chezmoi integration affects lockfile management and configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->