### PR TITLE
fix(chezmoi): async + 2s timeout for write_path / apply

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,11 @@ commit、それも無ければ default branch の HEAD を pull する。
   `chezmoi::write_path` + `chezmoi::apply` 経由で source 側に書いてから target に
   反映する。これをやらないと chezmoi の「source が truth」原則と衝突して、
   次回 `chezmoi apply` で古い lockfile に巻き戻る。
+- `chezmoi::write_path` / `chezmoi::apply` は **async + 2 秒タイムアウト** で実装
+  (`tokio::process::Command` + `tokio::time::timeout`)。`run_doctor` の外部コマンド
+  probe と同じ思想で、壊れた PATH shim や応答しない subprocess で rvpm 全体が
+  hang するのを防ぐ。タイムアウト時は warn を stderr に流して target 側を返す
+  (resilience)。
 
 ### helptags 自動生成 (`src/helptags.rs`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,8 +276,10 @@ commit、それも無ければ default branch の HEAD を pull する。
 - `chezmoi::write_path` / `chezmoi::apply` は **async + 2 秒タイムアウト** で実装
   (`tokio::process::Command` + `tokio::time::timeout`)。`run_doctor` の外部コマンド
   probe と同じ思想で、壊れた PATH shim や応答しない subprocess で rvpm 全体が
-  hang するのを防ぐ。タイムアウト時は warn を stderr に流して target 側を返す
-  (resilience)。
+  hang するのを防ぐ。`write_path` は `is_chezmoi_available` + 祖先を遡る複数の
+  `chezmoi source-path` 全体に **単一の 2 秒 budget** をかぶせる (個別 timeout が
+  累積して桁違いに膨らむのを防ぐため)。タイムアウト時は warn を stderr に流して
+  target 側を返す (resilience)。
 
 ### helptags 自動生成 (`src/helptags.rs`)
 

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -8,31 +8,34 @@
 //! `.tmpl` (chezmoi テンプレート) は非対応。rvpm 自身が Tera テンプレートを
 //! 持っているため chezmoi のテンプレート機能は不要。
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-/// 外部 `chezmoi` コマンドに許す最大実行時間。これを越えたら諦めて何もしない
-/// (resilience)。`run_doctor` の `VERSION_PROBE_TIMEOUT` と同じ思想で、PATH 上の
-/// 壊れた shim や応答しない subprocess で rvpm 全体が hang するのを防ぐ。
+/// `write_path` / `apply` 1 回あたりに許す全体の wall-clock budget。
+/// `run_doctor` の `VERSION_PROBE_TIMEOUT` と同じ思想で、PATH 上の壊れた shim や
+/// 応答しない subprocess で rvpm 全体が hang するのを防ぐ。
+///
+/// `write_path` では `is_chezmoi_available` + `resolve_source_path` (target 1 回 +
+/// 祖先 N 回) の合計をこの 1 つの budget でカバーする。これにより、深い階層で
+/// 個別 timeout が累積して総待ち時間が桁違いに膨らむことを防ぐ。
 const CHEZMOI_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// target パスに対応する chezmoi source パスを解決する純粋ロジック。
+/// target パスに対応する chezmoi source パスを解決する純粋ロジック。`probe` を
+/// 差し替えることで本番 (`chezmoi source-path` を呼ぶ async 実装) もテスト
+/// (HashMap mock) も同じ関数を共有できる。
 ///
-/// 1. `source_path_probe(target)` が Some を返せばそのまま使う
+/// 1. `probe(target)` が Some を返せばそのまま使う
 /// 2. 返さなければ (新規ファイル等) 祖先を遡り、最初に managed な祖先から
 ///    相対パスを計算して source 側のフルパスを構築する
 /// 3. source パスが `.tmpl` で終わる場合は None (テンプレート非対応)
-///
-/// 本番コードは `resolve_source_path_async` 経由で `chezmoi source-path` を
-/// 呼ぶ (2 秒タイムアウト付き)。この sync 版は `source_path_probe` クロージャに
-/// mock を差し込めるためテストロジック検証専用に残してある。
-#[cfg(test)]
-fn resolve_source_path<F>(target: &Path, mut source_path_probe: F) -> Option<PathBuf>
+async fn resolve_source_path<F, Fut>(target: &Path, mut probe: F) -> Option<PathBuf>
 where
-    F: FnMut(&Path) -> Option<PathBuf>,
+    F: FnMut(PathBuf) -> Fut,
+    Fut: Future<Output = Option<PathBuf>>,
 {
     // target 自体が managed なケース (既存ファイル)
-    if let Some(sp) = source_path_probe(target) {
+    if let Some(sp) = probe(target.to_path_buf()).await {
         if is_tmpl(&sp) {
             eprintln!(
                 "\u{26a0} {} is a chezmoi template (.tmpl). \
@@ -44,9 +47,9 @@ where
         return Some(sp);
     }
     // 新規ファイル: 祖先を遡って managed な ancestor を見つけ、相対パスで join
-    let mut ancestor = target.parent();
+    let mut ancestor = target.parent().map(|p| p.to_path_buf());
     while let Some(a) = ancestor {
-        if let Some(source_ancestor) = source_path_probe(a) {
+        if let Some(source_ancestor) = probe(a.clone()).await {
             if is_tmpl(&source_ancestor) {
                 eprintln!(
                     "\u{26a0} ancestor {} resolves to a chezmoi template (.tmpl). \
@@ -55,10 +58,10 @@ where
                 );
                 return None;
             }
-            let relative = target.strip_prefix(a).ok()?;
+            let relative = target.strip_prefix(&a).ok()?;
             return Some(source_ancestor.join(relative));
         }
-        ancestor = a.parent();
+        ancestor = a.parent().map(|p| p.to_path_buf());
     }
     None
 }
@@ -68,27 +71,21 @@ fn is_tmpl(p: &Path) -> bool {
 }
 
 /// `chezmoi source-path <target>` を実行し、managed なら source パスを返す。
-/// 2 秒のタイムアウト付き — chezmoi が hang しても呼び出し側を巻き込まない。
+/// 個別タイムアウトは持たない — 呼び出し元の `write_path` が全体 budget を
+/// `tokio::time::timeout` でかぶせる前提。
 async fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
-    let fut = tokio::process::Command::new("chezmoi")
+    let output = match tokio::process::Command::new("chezmoi")
         .arg("source-path")
         .arg(target)
-        .output();
-    let output = match tokio::time::timeout(CHEZMOI_TIMEOUT, fut).await {
-        Ok(Ok(o)) => o,
-        Ok(Err(e)) => {
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
             eprintln!(
                 "\u{26a0} chezmoi source-path {} failed: {}",
                 target.display(),
                 e,
-            );
-            return None;
-        }
-        Err(_) => {
-            eprintln!(
-                "\u{26a0} chezmoi source-path {} timed out after {}s",
-                target.display(),
-                CHEZMOI_TIMEOUT.as_secs(),
             );
             return None;
         }
@@ -105,13 +102,16 @@ async fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
     }
 }
 
+/// `chezmoi --version` で chezmoi が PATH 上に存在し起動可能か確認する。
+/// この関数自体はタイムアウトを持たず、呼び出し元の `write_path` の全体 budget で
+/// カバーされる。
 async fn is_chezmoi_available() -> bool {
-    let fut = tokio::process::Command::new("chezmoi")
-        .arg("--version")
-        .output();
     matches!(
-        tokio::time::timeout(CHEZMOI_TIMEOUT, fut).await,
-        Ok(Ok(o)) if o.status.success(),
+        tokio::process::Command::new("chezmoi")
+            .arg("--version")
+            .output()
+            .await,
+        Ok(o) if o.status.success(),
     )
 }
 
@@ -119,65 +119,44 @@ async fn is_chezmoi_available() -> bool {
 /// そうでなければ target そのまま。返り値が target と異なれば source に書いた
 /// ことを意味するので、呼び出し側は `apply()` を呼んで target へ反映する。
 ///
-/// 内部で `chezmoi source-path` を target → 各祖先の順に呼ぶため async。各呼び
-/// 出しに 2 秒の timeout が付くので、chezmoi が応答しなくても全体で hang しない。
+/// 内部で `chezmoi --version` と `chezmoi source-path <target/...>` を順次呼ぶが、
+/// 全体を **単一の 2 秒タイムアウト** でラップする。深い階層を遡る場合でも待ち
+/// 時間が累積せず、`CHEZMOI_TIMEOUT` を超えたら諦めて target をそのまま返す
+/// (resilience)。
 pub async fn write_path(enabled: bool, target: &Path) -> PathBuf {
     if !enabled {
         return target.to_path_buf();
     }
-    if !is_chezmoi_available().await {
-        eprintln!(
-            "\u{26a0} options.chezmoi = true but `chezmoi` is not in PATH. \
-             Writing to target directly (install chezmoi or set chezmoi = false).",
-        );
-        return target.to_path_buf();
-    }
-    resolve_source_path_async(target)
-        .await
-        .unwrap_or_else(|| target.to_path_buf())
-}
-
-/// `resolve_source_path` の async 版。`chezmoi_source_path` を直接呼ぶため
-/// テスト用 mock は差し込めない (純粋なロジック検証は同期版 `resolve_source_path`
-/// で担保する)。
-async fn resolve_source_path_async(target: &Path) -> Option<PathBuf> {
-    if let Some(sp) = chezmoi_source_path(target).await {
-        if is_tmpl(&sp) {
+    let work = async {
+        if !is_chezmoi_available().await {
             eprintln!(
-                "\u{26a0} {} is a chezmoi template (.tmpl). \
-                 chezmoi=true requires plain files — use rvpm's Tera templates instead.",
-                target.display(),
+                "\u{26a0} options.chezmoi = true but `chezmoi` is not in PATH. \
+                 Writing to target directly (install chezmoi or set chezmoi = false).",
             );
             return None;
         }
-        return Some(sp);
-    }
-    let mut ancestor = target.parent();
-    while let Some(a) = ancestor {
-        if let Some(source_ancestor) = chezmoi_source_path(a).await {
-            if is_tmpl(&source_ancestor) {
-                eprintln!(
-                    "\u{26a0} ancestor {} resolves to a chezmoi template (.tmpl). \
-                     chezmoi=true requires plain files — use rvpm's Tera templates instead.",
-                    a.display(),
-                );
-                return None;
-            }
-            let relative = target.strip_prefix(a).ok()?;
-            return Some(source_ancestor.join(relative));
+        resolve_source_path(target, |p| async move { chezmoi_source_path(&p).await }).await
+    };
+    match tokio::time::timeout(CHEZMOI_TIMEOUT, work).await {
+        Ok(Some(sp)) => sp,
+        Ok(None) => target.to_path_buf(),
+        Err(_) => {
+            eprintln!(
+                "\u{26a0} chezmoi resolution for {} timed out after {}s; writing to target directly",
+                target.display(),
+                CHEZMOI_TIMEOUT.as_secs(),
+            );
+            target.to_path_buf()
         }
-        ancestor = a.parent();
     }
-    None
 }
 
 /// source に書いた後、`chezmoi apply <target>` で target へ反映する。
 /// `wrote_to` は実際に書き込んだパス (`write_path` の返り値)。target と
 /// 異なる場合のみ apply が必要 (同一なら直接 target に書いたので不要)。
 ///
-/// async + 2 秒 timeout — `chezmoi apply` が hang しても呼び出し側の async
-/// runtime をブロックしない (例: 並列 sync 中に 1 プラグインの apply が
-/// 詰まっても他の処理は進む)。
+/// 単一の `chezmoi apply` 実行を 2 秒タイムアウトで保護する — apply が hang
+/// しても呼び出し側の async runtime をブロックしない。
 pub async fn apply(wrote_to: &Path, target: &Path) {
     if wrote_to == target {
         return;
@@ -208,57 +187,61 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn mock_probe(managed: HashMap<PathBuf, PathBuf>) -> impl FnMut(&Path) -> Option<PathBuf> {
-        move |p| managed.get(p).cloned()
+    /// HashMap を借用するシンプルな async probe。`resolve_source_path` の
+    /// `FnMut(PathBuf) -> Future` 制約を満たす。
+    fn mock_probe(
+        managed: &HashMap<PathBuf, PathBuf>,
+    ) -> impl FnMut(PathBuf) -> std::future::Ready<Option<PathBuf>> + '_ {
+        move |p| std::future::ready(managed.get(&p).cloned())
     }
 
-    #[test]
-    fn test_resolve_existing_managed_file() {
+    #[tokio::test]
+    async fn test_resolve_existing_managed_file() {
         let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
         let source =
             PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/config.toml");
         let managed = HashMap::from([(target.clone(), source.clone())]);
-        let got = resolve_source_path(&target, mock_probe(managed));
+        let got = resolve_source_path(&target, mock_probe(&managed)).await;
         assert_eq!(got, Some(source));
     }
 
-    #[test]
-    fn test_resolve_new_file_via_managed_ancestor() {
+    #[tokio::test]
+    async fn test_resolve_new_file_via_managed_ancestor() {
         let ancestor_target = PathBuf::from("/home/user/.config/rvpm/nvim/plugins");
         let ancestor_source =
             PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/plugins");
         let target = ancestor_target.join("github.com/foo/bar/init.lua");
         let managed = HashMap::from([(ancestor_target, ancestor_source.clone())]);
-        let got = resolve_source_path(&target, mock_probe(managed));
+        let got = resolve_source_path(&target, mock_probe(&managed)).await;
         assert_eq!(
             got,
             Some(ancestor_source.join("github.com/foo/bar/init.lua"))
         );
     }
 
-    #[test]
-    fn test_resolve_tmpl_returns_none() {
+    #[tokio::test]
+    async fn test_resolve_tmpl_returns_none() {
         let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
         let source =
             PathBuf::from("/home/user/.local/share/chezmoi/dot_config/rvpm/nvim/config.toml.tmpl");
         let managed = HashMap::from([(target.clone(), source)]);
-        let got = resolve_source_path(&target, mock_probe(managed));
+        let got = resolve_source_path(&target, mock_probe(&managed)).await;
         assert_eq!(got, None);
     }
 
-    #[test]
-    fn test_resolve_not_managed_returns_none() {
+    #[tokio::test]
+    async fn test_resolve_not_managed_returns_none() {
         let target = PathBuf::from("/home/user/.config/rvpm/nvim/config.toml");
         let managed = HashMap::new();
-        let got = resolve_source_path(&target, mock_probe(managed));
+        let got = resolve_source_path(&target, mock_probe(&managed)).await;
         assert_eq!(got, None);
     }
 
-    #[test]
-    fn test_resolve_new_file_no_managed_ancestor_returns_none() {
+    #[tokio::test]
+    async fn test_resolve_new_file_no_managed_ancestor_returns_none() {
         let target = PathBuf::from("/home/user/.config/rvpm/nvim/plugins/foo/init.lua");
         let managed = HashMap::new();
-        let got = resolve_source_path(&target, mock_probe(managed));
+        let got = resolve_source_path(&target, mock_probe(&managed)).await;
         assert_eq!(got, None);
     }
 
@@ -271,7 +254,7 @@ mod tests {
 
     /// `write_path(true, ...)` が呼ばれても、CI / 開発機に chezmoi が無ければ
     /// `is_chezmoi_available` が即 false を返して target そのまま、また chezmoi
-    /// があっても 2s timeout で必ず有限時間で帰ってくる。回帰テストの目的は
+    /// があっても全体 2s timeout で必ず有限時間で帰ってくる。回帰テストの目的は
     /// 「無限 hang しない」を担保すること。タイムアウト 2s + spawn コスト分の
     /// 余裕を見て 10s で test 自身を打ち切る。
     #[tokio::test]

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -9,18 +9,25 @@
 //! 持っているため chezmoi のテンプレート機能は不要。
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::time::Duration;
 
-/// target パスに対応する chezmoi source パスを解決する (pure function)。
+/// 外部 `chezmoi` コマンドに許す最大実行時間。これを越えたら諦めて何もしない
+/// (resilience)。`run_doctor` の `VERSION_PROBE_TIMEOUT` と同じ思想で、PATH 上の
+/// 壊れた shim や応答しない subprocess で rvpm 全体が hang するのを防ぐ。
+const CHEZMOI_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// target パスに対応する chezmoi source パスを解決する純粋ロジック。
 ///
 /// 1. `source_path_probe(target)` が Some を返せばそのまま使う
 /// 2. 返さなければ (新規ファイル等) 祖先を遡り、最初に managed な祖先から
 ///    相対パスを計算して source 側のフルパスを構築する
 /// 3. source パスが `.tmpl` で終わる場合は None (テンプレート非対応)
 ///
-/// `source_path_probe` は「`chezmoi source-path <p>` の結果」を返すクロージャ。
-/// テストでは mock を差し込む。
-pub fn resolve_source_path<F>(target: &Path, mut source_path_probe: F) -> Option<PathBuf>
+/// 本番コードは `resolve_source_path_async` 経由で `chezmoi source-path` を
+/// 呼ぶ (2 秒タイムアウト付き)。この sync 版は `source_path_probe` クロージャに
+/// mock を差し込めるためテストロジック検証専用に残してある。
+#[cfg(test)]
+fn resolve_source_path<F>(target: &Path, mut source_path_probe: F) -> Option<PathBuf>
 where
     F: FnMut(&Path) -> Option<PathBuf>,
 {
@@ -61,18 +68,27 @@ fn is_tmpl(p: &Path) -> bool {
 }
 
 /// `chezmoi source-path <target>` を実行し、managed なら source パスを返す。
-fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
-    let output = match Command::new("chezmoi")
+/// 2 秒のタイムアウト付き — chezmoi が hang しても呼び出し側を巻き込まない。
+async fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
+    let fut = tokio::process::Command::new("chezmoi")
         .arg("source-path")
         .arg(target)
-        .output()
-    {
-        Ok(o) => o,
-        Err(e) => {
+        .output();
+    let output = match tokio::time::timeout(CHEZMOI_TIMEOUT, fut).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
             eprintln!(
                 "\u{26a0} chezmoi source-path {} failed: {}",
                 target.display(),
                 e,
+            );
+            return None;
+        }
+        Err(_) => {
+            eprintln!(
+                "\u{26a0} chezmoi source-path {} timed out after {}s",
+                target.display(),
+                CHEZMOI_TIMEOUT.as_secs(),
             );
             return None;
         }
@@ -89,48 +105,101 @@ fn chezmoi_source_path(target: &Path) -> Option<PathBuf> {
     }
 }
 
-fn is_chezmoi_available() -> bool {
-    Command::new("chezmoi")
+async fn is_chezmoi_available() -> bool {
+    let fut = tokio::process::Command::new("chezmoi")
         .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .output();
+    matches!(
+        tokio::time::timeout(CHEZMOI_TIMEOUT, fut).await,
+        Ok(Ok(o)) if o.status.success(),
+    )
 }
 
 /// rvpm が書き込むべきパスを返す。chezmoi 有効かつ managed なら source 側、
 /// そうでなければ target そのまま。返り値が target と異なれば source に書いた
 /// ことを意味するので、呼び出し側は `apply()` を呼んで target へ反映する。
-pub fn write_path(enabled: bool, target: &Path) -> PathBuf {
+///
+/// 内部で `chezmoi source-path` を target → 各祖先の順に呼ぶため async。各呼び
+/// 出しに 2 秒の timeout が付くので、chezmoi が応答しなくても全体で hang しない。
+pub async fn write_path(enabled: bool, target: &Path) -> PathBuf {
     if !enabled {
         return target.to_path_buf();
     }
-    if !is_chezmoi_available() {
+    if !is_chezmoi_available().await {
         eprintln!(
             "\u{26a0} options.chezmoi = true but `chezmoi` is not in PATH. \
              Writing to target directly (install chezmoi or set chezmoi = false).",
         );
         return target.to_path_buf();
     }
-    resolve_source_path(target, chezmoi_source_path).unwrap_or_else(|| target.to_path_buf())
+    resolve_source_path_async(target)
+        .await
+        .unwrap_or_else(|| target.to_path_buf())
+}
+
+/// `resolve_source_path` の async 版。`chezmoi_source_path` を直接呼ぶため
+/// テスト用 mock は差し込めない (純粋なロジック検証は同期版 `resolve_source_path`
+/// で担保する)。
+async fn resolve_source_path_async(target: &Path) -> Option<PathBuf> {
+    if let Some(sp) = chezmoi_source_path(target).await {
+        if is_tmpl(&sp) {
+            eprintln!(
+                "\u{26a0} {} is a chezmoi template (.tmpl). \
+                 chezmoi=true requires plain files — use rvpm's Tera templates instead.",
+                target.display(),
+            );
+            return None;
+        }
+        return Some(sp);
+    }
+    let mut ancestor = target.parent();
+    while let Some(a) = ancestor {
+        if let Some(source_ancestor) = chezmoi_source_path(a).await {
+            if is_tmpl(&source_ancestor) {
+                eprintln!(
+                    "\u{26a0} ancestor {} resolves to a chezmoi template (.tmpl). \
+                     chezmoi=true requires plain files — use rvpm's Tera templates instead.",
+                    a.display(),
+                );
+                return None;
+            }
+            let relative = target.strip_prefix(a).ok()?;
+            return Some(source_ancestor.join(relative));
+        }
+        ancestor = a.parent();
+    }
+    None
 }
 
 /// source に書いた後、`chezmoi apply <target>` で target へ反映する。
 /// `wrote_to` は実際に書き込んだパス (`write_path` の返り値)。target と
 /// 異なる場合のみ apply が必要 (同一なら直接 target に書いたので不要)。
-pub fn apply(wrote_to: &Path, target: &Path) {
+///
+/// async + 2 秒 timeout — `chezmoi apply` が hang しても呼び出し側の async
+/// runtime をブロックしない (例: 並列 sync 中に 1 プラグインの apply が
+/// 詰まっても他の処理は進む)。
+pub async fn apply(wrote_to: &Path, target: &Path) {
     if wrote_to == target {
         return;
     }
-    let mut cmd = Command::new("chezmoi");
-    cmd.arg("apply").arg("--force").arg(target);
-    match cmd.status() {
-        Ok(s) if s.success() => {}
-        Ok(s) => eprintln!(
+    let fut = tokio::process::Command::new("chezmoi")
+        .arg("apply")
+        .arg("--force")
+        .arg(target)
+        .status();
+    match tokio::time::timeout(CHEZMOI_TIMEOUT, fut).await {
+        Ok(Ok(s)) if s.success() => {}
+        Ok(Ok(s)) => eprintln!(
             "\u{26a0} chezmoi apply {} failed (exit {})",
             target.display(),
             s.code().unwrap_or(-1),
         ),
-        Err(e) => eprintln!("\u{26a0} chezmoi apply {} failed: {}", target.display(), e,),
+        Ok(Err(e)) => eprintln!("\u{26a0} chezmoi apply {} failed: {}", target.display(), e),
+        Err(_) => eprintln!(
+            "\u{26a0} chezmoi apply {} timed out after {}s",
+            target.display(),
+            CHEZMOI_TIMEOUT.as_secs(),
+        ),
     }
 }
 
@@ -193,10 +262,26 @@ mod tests {
         assert_eq!(got, None);
     }
 
-    #[test]
-    fn test_write_path_disabled_returns_target() {
+    #[tokio::test]
+    async fn test_write_path_disabled_returns_target() {
         let target = Path::new("/some/target");
-        let got = write_path(false, target);
+        let got = write_path(false, target).await;
         assert_eq!(got, target);
+    }
+
+    /// `write_path(true, ...)` が呼ばれても、CI / 開発機に chezmoi が無ければ
+    /// `is_chezmoi_available` が即 false を返して target そのまま、また chezmoi
+    /// があっても 2s timeout で必ず有限時間で帰ってくる。回帰テストの目的は
+    /// 「無限 hang しない」を担保すること。タイムアウト 2s + spawn コスト分の
+    /// 余裕を見て 10s で test 自身を打ち切る。
+    #[tokio::test]
+    async fn test_write_path_enabled_does_not_hang() {
+        let target = Path::new("/some/target");
+        let fut = write_path(true, target);
+        let res = tokio::time::timeout(Duration::from_secs(10), fut).await;
+        assert!(
+            res.is_ok(),
+            "write_path must return within 10s even when chezmoi is missing or slow"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -900,7 +900,7 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool) -> Result<()> {
             .map(|p| p.display_name())
             .collect();
         lockfile.retain_by_names(&active);
-        let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path);
+        let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path).await;
         if let Err(e) = lockfile.save(&wp) {
             eprintln!(
                 "\u{26a0} failed to save {}: {} (lockfile not updated)",
@@ -908,7 +908,7 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool) -> Result<()> {
                 e
             );
         } else {
-            chezmoi::apply(&wp, &lockfile_path);
+            chezmoi::apply(&wp, &lockfile_path).await;
         }
     }
 
@@ -1683,7 +1683,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
     // ここでは単に新 HEAD を反映した lockfile を atomic write するだけ。
     // (config.toml から外されたプラグインの整理は次の full `rvpm sync` で行う)。
     // chezmoi 連携: source 側に書いてから `chezmoi apply` で target に反映。
-    let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path);
+    let wp = chezmoi::write_path(config.options.chezmoi, &lockfile_path).await;
     if let Err(e) = lockfile.save(&wp) {
         eprintln!(
             "\u{26a0} failed to save {}: {} (lockfile not updated)",
@@ -1691,7 +1691,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
             e
         );
     } else {
-        chezmoi::apply(&wp, &lockfile_path);
+        chezmoi::apply(&wp, &lockfile_path).await;
     }
 
     println!("Update complete. Regenerating loader.lua...");
@@ -1790,9 +1790,9 @@ async fn run_add(
 
     let toml_content = doc.to_string();
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+    let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
     std::fs::write(&wp, &toml_content)?;
-    chezmoi::apply(&wp, &config_path);
+    chezmoi::apply(&wp, &config_path).await;
     println!("Added plugin to config: {}", stored_url);
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
@@ -1858,7 +1858,7 @@ async fn run_add(
 
     if lockfile_dirty {
         // chezmoi 連携: source 側に書いてから `chezmoi apply` で target に反映。
-        let wp = chezmoi::write_path(config_data.options.chezmoi, &lockfile_path);
+        let wp = chezmoi::write_path(config_data.options.chezmoi, &lockfile_path).await;
         if let Err(e) = lockfile.save(&wp) {
             eprintln!(
                 "\u{26a0} failed to save {}: {} (lockfile not updated)",
@@ -1866,7 +1866,7 @@ async fn run_add(
                 e
             );
         } else {
-            chezmoi::apply(&wp, &lockfile_path);
+            chezmoi::apply(&wp, &lockfile_path).await;
         }
     }
 
@@ -1883,10 +1883,10 @@ async fn run_config() -> Result<bool> {
     let config_path = rvpm_config_path();
     ensure_config_exists(&config_path)?;
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let edit_target = chezmoi::write_path(chezmoi_enabled, &config_path);
+    let edit_target = chezmoi::write_path(chezmoi_enabled, &config_path).await;
     println!("Opening {}", edit_target.display());
     open_editor_at_line(&edit_target, 1)?;
-    chezmoi::apply(&edit_target, &config_path);
+    chezmoi::apply(&edit_target, &config_path).await;
     Ok(true)
 }
 
@@ -1905,7 +1905,7 @@ async fn run_init(write: bool) -> Result<()> {
     if write {
         // `config` は既にパース済みなので再読込せずそのまま使う。
         // 親ディレクトリ作成は write_init_lua_snippet が新規作成時に行うので不要。
-        let wp = chezmoi::write_path(config.options.chezmoi, &init_lua_path);
+        let wp = chezmoi::write_path(config.options.chezmoi, &init_lua_path).await;
         let result = write_init_lua_snippet(&wp, &snippet)?;
         match result {
             WriteInitResult::Created => {
@@ -1927,7 +1927,7 @@ async fn run_init(write: bool) -> Result<()> {
         // AlreadyConfigured で apply すると、target 側でユーザーが手で編集した
         // 差分を上書きしてしまう恐れがある。
         if result != WriteInitResult::AlreadyConfigured {
-            chezmoi::apply(&wp, &init_lua_path);
+            chezmoi::apply(&wp, &init_lua_path).await;
         }
     } else {
         println!("-- Add this to your Neovim init.lua:");
@@ -1983,7 +1983,7 @@ async fn run_edit(
 
         let target = config_dir.join(file_name);
         let chezmoi_enabled = read_chezmoi_flag(&config_path);
-        let edit_target = chezmoi::write_path(chezmoi_enabled, &target);
+        let edit_target = chezmoi::write_path(chezmoi_enabled, &target).await;
         if let Some(parent) = edit_target.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -1992,7 +1992,7 @@ async fn run_edit(
         std::process::Command::new(editor)
             .arg(&edit_target)
             .status()?;
-        chezmoi::apply(&edit_target, &target);
+        chezmoi::apply(&edit_target, &target).await;
         return Ok(true);
     }
 
@@ -2095,7 +2095,7 @@ async fn run_edit(
     };
     let target_file = plugin_config_dir.join(file_name);
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let edit_target = chezmoi::write_path(chezmoi_enabled, &target_file);
+    let edit_target = chezmoi::write_path(chezmoi_enabled, &target_file).await;
     if let Some(parent) = edit_target.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -2103,7 +2103,7 @@ async fn run_edit(
     std::process::Command::new(editor)
         .arg(&edit_target)
         .status()?;
-    chezmoi::apply(&edit_target, &target_file);
+    chezmoi::apply(&edit_target, &target_file).await;
     Ok(true)
 }
 
@@ -2240,9 +2240,9 @@ async fn run_set(
                         // 対応 editor なら plugin の url 行にジャンプ
                         let line = find_plugin_line_in_toml(&toml_content, &selected_repo_url);
                         let cz = read_chezmoi_flag(&config_path);
-                        let ep = chezmoi::write_path(cz, &config_path);
+                        let ep = chezmoi::write_path(cz, &config_path).await;
                         open_editor_at_line(&ep, line)?;
-                        chezmoi::apply(&ep, &config_path);
+                        chezmoi::apply(&ep, &config_path).await;
                         // ユーザーが何を編集したか分からないので常に変更ありと見なす
                         return Ok(true);
                     }
@@ -2331,9 +2331,9 @@ async fn run_set(
                                 let line =
                                     find_plugin_line_in_toml(&toml_content, &selected_repo_url);
                                 let cz = read_chezmoi_flag(&config_path);
-                                let ep = chezmoi::write_path(cz, &config_path);
+                                let ep = chezmoi::write_path(cz, &config_path).await;
                                 open_editor_at_line(&ep, line)?;
-                                chezmoi::apply(&ep, &config_path);
+                                chezmoi::apply(&ep, &config_path).await;
                                 return Ok(true);
                             }
                             _ => return Ok(false),
@@ -2392,9 +2392,9 @@ async fn run_set(
 
     if modified {
         let chezmoi_enabled = read_chezmoi_flag(&config_path);
-        let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+        let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
         std::fs::write(&wp, doc.to_string())?;
-        chezmoi::apply(&wp, &config_path);
+        chezmoi::apply(&wp, &config_path).await;
         println!("Updated config for: {}", selected_repo_url);
         return Ok(true);
     }
@@ -2541,9 +2541,9 @@ async fn run_remove(query: Option<String>) -> Result<()> {
     let mut doc = toml_content.parse::<DocumentMut>()?;
     remove_plugin_from_toml(&mut doc, &selected_url)?;
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let wp = chezmoi::write_path(chezmoi_enabled, &config_path);
+    let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
     std::fs::write(&wp, doc.to_string())?;
-    chezmoi::apply(&wp, &config_path);
+    chezmoi::apply(&wp, &config_path).await;
     println!("Removed '{}' from config.", selected_url);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());


### PR DESCRIPTION
## Summary

Addresses [CodeRabbit feedback on #60](https://github.com/yukimemi/rvpm/pull/60#pullrequestreview-PRR_kwDOSAPqjc72hJLm).

`chezmoi::write_path` and `chezmoi::apply` were calling `std::process::Command` with no timeout. From async handlers (`run_sync` / `run_update` / `run_add` / `run_config` / `run_edit` / `run_init` / `run_set` / `run_remove`), a hung \`chezmoi\` subprocess (broken PATH shim, stalled IO) would block the entire Tokio runtime — including parallel git tasks unrelated to chezmoi.

- Switch underlying calls to \`tokio::process::Command\` and wrap each invocation in \`tokio::time::timeout(Duration::from_secs(2), ...)\` — same pattern as the existing \`run_doctor\` external probes.
- On timeout, log warn-and-continue (resilience) like spawn failures already do.
- Make \`write_path\` and \`apply\` \`async fn\`. Update all 24 call sites in \`src/main.rs\` to \`.await\`.
- Keep the pure \`resolve_source_path\` helper as \`#[cfg(test)] fn\` so the mock-driven unit tests for tmpl detection and ancestor walking keep working. Production code goes through the new \`resolve_source_path_async\`.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo make check\` (fmt + clippy + 445 tests) passes via pre-push hook
- [x] New regression test \`test_write_path_enabled_does_not_hang\` — guards that \`write_path(true, ...)\` returns within 10 s wall clock even on a CI machine without chezmoi installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)