### PR TITLE
fix(on_map): insert replayed key at typeahead start so operator + motion sequences work

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -531,6 +531,13 @@ end
                     Some(d) => format!(", {{ desc = \"{}\" }}", d.replace('"', "\\\"")),
                     None => String::new(),
                 };
+                // feedkeys mode は "im":
+                //   i = typeahead の **先頭** に挿入 (append "m" だと、ユーザーが
+                //       `<lhs><motion>` を素早く打ったとき motion が先に処理されて
+                //       しまう。例: vim-operator-replace で `_i"` を打つと `i` が
+                //       先に評価されて Insert mode に突入する)
+                //   m = remap 許可 (load 後の本物の keymap (e.g. <Plug>) を踏ませる)
+                // lazy.nvim 11+ と同じパターン。
                 body.push_str(&format!(
                     "vim.keymap.set({modes}, \"{lhs}\", function()\n\
                      \x20 local op = vim.v.operator\n\
@@ -540,7 +547,7 @@ end
                      \x20 {load}\n\
                      \x20 local prefix = (reg ~= '\"' and '\"' .. reg or \"\") .. op .. (cnt > 1 and cnt or \"\")\n\
                      \x20 local feed = vim.api.nvim_replace_termcodes(\"<Ignore>\" .. prefix .. \"{lhs}\", true, true, true)\n\
-                     \x20 vim.api.nvim_feedkeys(feed, \"m\", false)\n\
+                     \x20 vim.api.nvim_feedkeys(feed, \"im\", false)\n\
                      end{opts})\n",
                     modes = modes_lua,
                     lhs = lhs,
@@ -1678,6 +1685,31 @@ mod tests {
         assert!(
             lua.contains("<Ignore>"),
             "on_map replay must use <Ignore> prefix (lazy.nvim pattern)"
+        );
+    }
+
+    #[test]
+    fn test_on_map_feedkeys_inserts_at_typeahead_start() {
+        // feedkeys mode は "im" でなければならない:
+        //   - "i" = typeahead の先頭に挿入。append "m" だとユーザーが
+        //     `<lhs><motion>` を素早く打ったとき motion が先に処理され、
+        //     例えば vim-operator-replace の `_i"` で `i` が Insert mode と
+        //     解釈されてしまう (regression test)。
+        //   - "m" = remap 許可 (本物の keymap、典型的には <Plug>... を踏ませる)
+        let mut s = make_lazy_plugin("operator-replace");
+        s.on_map = Some(vec![MapSpec {
+            lhs: "_".to_string(),
+            mode: vec!["n".to_string(), "x".to_string()],
+            desc: None,
+        }]);
+        let lua = gen_loader(Path::new("/merged"), &[s]);
+        assert!(
+            lua.contains("nvim_feedkeys(feed, \"im\""),
+            "on_map replay must insert at typeahead start (mode \"im\") so operator + motion sequences work; got: {lua}"
+        );
+        assert!(
+            !lua.contains("nvim_feedkeys(feed, \"m\""),
+            "on_map must NOT use mode \"m\" alone — that appends to typeahead and breaks `<op><motion>`"
         );
     }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -538,9 +538,20 @@ end
                 //       先に評価されて Insert mode に突入する)
                 //   m = remap 許可 (load 後の本物の keymap (e.g. <Plug>) を踏ませる)
                 // lazy.nvim 11+ と同じパターン。
+                //
+                // v:operator は **operator-pending mode のとき** (`mode(1)` が "no..." 系)
+                // にだけ capture する。`v:operator` は「直前に使ったオペレータ」を
+                // 持続的に保持するので、normal mode から stub を起動した瞬間にそれを
+                // 読むと stale な値 (例: 前回の `dw` から残った "d") を拾ってしまう。
+                // その状態で例えば vim-operator-replace の `_iw` を打つと、replay が
+                // `<Ignore>d_iw` になり `d_` (linewise motion で現在行削除) が走って
+                // しまう (実例: #65 修正後に user が遭遇した「行全体がひかる」症状)。
+                // count / register は「現在の Normal mode コマンド」用にリセットされる
+                // ので mode guard 不要 (e.g. `5_iw` の `5` は今のコマンドの count)。
                 body.push_str(&format!(
                     "vim.keymap.set({modes}, \"{lhs}\", function()\n\
-                     \x20 local op = vim.v.operator\n\
+                     \x20 local _m = vim.fn.mode(1)\n\
+                     \x20 local op = (_m:sub(1, 2) == \"no\") and vim.v.operator or \"\"\n\
                      \x20 local cnt = vim.v.count1\n\
                      \x20 local reg = vim.v.register\n\
                      \x20 vim.keymap.del({modes}, \"{lhs}\")\n\
@@ -1685,6 +1696,38 @@ mod tests {
         assert!(
             lua.contains("<Ignore>"),
             "on_map replay must use <Ignore> prefix (lazy.nvim pattern)"
+        );
+    }
+
+    #[test]
+    fn test_on_map_only_captures_operator_in_op_pending_mode() {
+        // `v:operator` は直前に使ったオペレータを保持し続ける性質があるため、
+        // normal mode から stub を起動した瞬間に無条件で拾うと stale な
+        // operator を replay に prepend してしまう。
+        // 例: 直前に `dw` をしてから lazy load された `_` (vim-operator-replace)
+        // で `_iw` を打つと、stale "d" が混じって `<Ignore>d_iw` を再生し、
+        // `d_` (linewise) で行が消える regression。`mode(1)` で operator-pending
+        // ("no..." prefix) のときだけ capture するように gate する。
+        let mut s = make_lazy_plugin("operator-replace");
+        s.on_map = Some(vec![MapSpec {
+            lhs: "_".to_string(),
+            mode: vec!["n".to_string(), "x".to_string()],
+            desc: None,
+        }]);
+        let lua = gen_loader(Path::new("/merged"), &[s]);
+        // mode guard が入っていること
+        assert!(
+            lua.contains("vim.fn.mode(1)"),
+            "on_map must call vim.fn.mode(1) to detect operator-pending"
+        );
+        assert!(
+            lua.contains("\"no\""),
+            "on_map must compare mode prefix to \"no\" (operator-pending)"
+        );
+        // gate なしの裸 `local op = vim.v.operator` は許さない
+        assert!(
+            !lua.contains("local op = vim.v.operator\n"),
+            "on_map must NOT capture v:operator unconditionally — gate it on mode(1) so stale operators don't leak into replay"
         );
     }
 


### PR DESCRIPTION
## Summary

For a lazy-loaded operator plugin like \`vim-operator-replace\` configured as

\`\`\`toml
[[plugins]]
url = \"https://github.com/kana/vim-operator-replace\"
depends = [\"vim-operator-user\"]
on_map = [{ lhs = \"_\", mode = [\"n\", \"x\"] }]
\`\`\`

with \`after.lua\`

\`\`\`lua
vim.keymap.set({ \"n\", \"x\" }, \"_\", \"<Plug>(operator-replace)\", { silent = true })
\`\`\`

the very first \`_<motion>\` (e.g. \`_iw\` / \`_i\"\`) misbehaved on the trigger invocation. Two related bugs in the \`on_map\` stub were responsible. Both are fixed here; the second invocation already worked because the stub is gone by then.

## Bug 1 — typeahead order (commit 8dff39b)

\`vim.api.nvim_feedkeys(feed, \"m\", false)\` **appends** the replay to the typeahead. When the user types \`_iw\` quickly, the typeahead becomes \`i\" w \<Ignore\> _\` so \`i\` is processed first and Vim enters Insert mode.

Fix: switch to mode \`\"im\"\` (\`i\` = insert at start, \`m\` = remap), matching lazy.nvim 11+.

## Bug 2 — stale \`v:operator\` (commit a90e11c)

Even after Bug 1, \`_iw\` still misbehaved on the very first press: the line briefly highlighted, then deleted, then \`iw\` fell through to Insert mode. \"2 回目は動く\" (2nd attempt works).

Root cause: \`v:operator\` is *the last operator used in Normal mode* and **persists across commands** (\`:h v:operator\` — \"The value remains set until another operator is entered\"). The stub was reading it unconditionally, so a leftover \"d\" from a previous \`dw\` would slip into the replay:

| Step | What happened |
|---|---|
| Earlier | User did \`dw\` → \`v:operator = \"d\"\` (persists) |
| Later | User types \`_iw\` |
| Stub | Captures \`op = \"d\"\` (stale), replay becomes \`<Ignore>d_iw\` |
| Vim | \`d\` (operator pending) → \`_\` (**linewise** motion) → \`d_\` deletes the current line ← \"the line lights up\" |
| Leftover | \`iw\` falls through → \`i\` enters Insert mode, then \`w\` is typed |

Fix: gate the \`v:operator\` capture on \`vim.fn.mode(1):sub(1, 2) == \"no\"\` so we only inherit the operator when the stub was actually triggered from operator-pending mode (legitimate use case: lazy text objects like \`dae\` where the stub fires for \`ae\` while \`d\` is still pending).

\`v:count1\` and \`v:register\` stay unconditional — they are scoped to the current Normal mode command and do not leak across commands.

## Test plan

- [x] New regression tests \`test_on_map_feedkeys_inserts_at_typeahead_start\` and \`test_on_map_only_captures_operator_in_op_pending_mode\` lock in both fixes
- [x] \`cargo make check\` (fmt + clippy + 447 tests) green
- [x] Manual: with the config above, \`_iw\` correctly replaces inside word on first invocation; lazy text objects (\`dae\` etc.) still work because operator-pending capture is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)