### PR TITLE
docs(readme): add rvpm.nvim companion plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,23 @@ cargo test dump_full_sample_loader -- --ignored --nocapture
 rvpm is developed with **TDD**: tests come first, and new behaviors are
 covered by either unit or integration tests before implementation.
 
+## Companion plugin
+
+[**rvpm.nvim**](https://github.com/yukimemi/rvpm.nvim) is a thin
+Neovim Lua layer that exposes `rvpm` as `:Rvpm <sub>` — async
+`vim.system` dispatch for non-interactive commands, a floating
+terminal for the TUIs (`list` / `browse` / `edit` / …), completion
+over `config.toml` plugin names, a BufWritePost auto-generate
+autocmd (with chezmoi re-add routing when `options.chezmoi = true`),
+and `:checkhealth rvpm` on top of `rvpm doctor`.
+
+The CLI remains the source of truth. rvpm.nvim just shortens the
+feedback loop when you'd rather not leave the editor.
+
+```sh
+rvpm add yukimemi/rvpm.nvim
+```
+
 ## Acknowledgments
 
 - **[lazy.nvim](https://github.com/folke/lazy.nvim)** — design inspiration


### PR DESCRIPTION
## Summary

- Adds a short **Companion plugin** section linking to [yukimemi/rvpm.nvim](https://github.com/yukimemi/rvpm.nvim), a thin Neovim Lua layer that exposes `rvpm` as `:Rvpm <sub>`
- Positioned right before Acknowledgments so the ecosystem link lives with related-projects content and does not disrupt the CLI-first framing in the main sections
- Includes the one-liner `rvpm add yukimemi/rvpm.nvim` and briefly summarises what rvpm.nvim provides (async dispatch, floating-terminal TUIs, completion, BufWritePost auto-generate with chezmoi re-add, `:checkhealth rvpm`)
- Explicitly states that the CLI remains the source of truth

## Test plan

- [x] Verified the rendered diff locally — the new section slots in cleanly ahead of Acknowledgments
- [ ] Preview the PR diff on GitHub to confirm rendering of the code fence and bullet list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added companion plugin guide for Neovim integration, documenting editor features including command interface, floating terminals for TUI functionality, configuration file completion, automatic configuration regeneration, and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->