### PR TITLE
feat(sync): surface plugins held back by lockfile pin in the summary

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -74,6 +74,26 @@ impl<'a> Repo<'a> {
             .await
             .map_err(|e| anyhow::anyhow!("head_commit task panicked: {}", e))?
     }
+
+    /// fetch 後の remote tracking branch の tip commit を返す。HEAD は動かさない。
+    ///
+    /// lockfile pin (rev なしで lockfile commit に寄せられているケース) が remote の
+    /// 最新から乖離しているかを run_sync 側で判定するためのヘルパー。
+    /// HEAD を読むわけではないので `head_commit()` と組み合わせて使う:
+    /// `head != remote_head` なら「held back」。
+    ///
+    /// 解決順 (`gix_reset_to_remote` と同じロジック):
+    /// 1. `refs/remotes/<remote>/<current_branch>`
+    /// 2. `refs/remotes/<remote>/HEAD` (detached HEAD 時の fallback)
+    ///
+    /// どちらも解決できない場合は `None` (malformed repo、未 fetch 等)。
+    /// caller は `None` を「判定不能」として扱い held-back 分類から除外する。
+    pub async fn remote_head(&self) -> Result<Option<String>> {
+        let dst = self.dst.to_path_buf();
+        tokio::task::spawn_blocking(move || read_remote_head(&dst))
+            .await
+            .map_err(|e| anyhow::anyhow!("remote_head task panicked: {}", e))?
+    }
 }
 
 /// owner/repo 形式のショートハンドを GitHub URL に変換。
@@ -153,6 +173,32 @@ fn read_head(dst: &Path) -> Result<String> {
     let repo = gix::open(dst)?;
     let head = repo.head_commit()?;
     Ok(head.id().to_string())
+}
+
+/// remote tracking branch の tip を読み取る。HEAD は動かさない。
+/// tracking branch (`refs/remotes/<remote>/<branch>`) が見つからなければ
+/// `refs/remotes/<remote>/HEAD` に fallback。それも無ければ `Ok(None)`。
+fn read_remote_head(dst: &Path) -> Result<Option<String>> {
+    let repo = gix::open(dst)?;
+    let remote_name = repo
+        .find_default_remote(gix::remote::Direction::Fetch)
+        .and_then(|r| r.ok())
+        .and_then(|r| r.name().map(|n| n.as_bstr().to_string()))
+        .unwrap_or_else(|| "origin".to_string());
+
+    if let Some(head_name) = repo.head_name()? {
+        let branch = head_name.as_bstr().to_string();
+        let tracking = branch.replace("refs/heads/", &format!("refs/remotes/{}/", remote_name));
+        if let Ok(mut tr) = repo.find_reference(&tracking) {
+            return Ok(Some(tr.peel_to_id()?.detach().to_string()));
+        }
+    }
+
+    let remote_head_ref = format!("refs/remotes/{}/HEAD", remote_name);
+    if let Ok(mut r) = repo.find_reference(&remote_head_ref) {
+        return Ok(Some(r.peel_to_id()?.detach().to_string()));
+    }
+    Ok(None)
 }
 
 /// before/after の HEAD から `GitChange` を組み立てる。
@@ -694,6 +740,75 @@ mod tests {
         let change = repo.sync().await.unwrap().expect("HEAD moved");
         assert_eq!(change.breaking_subjects.len(), 1, "{:?}", change);
         assert!(change.breaking_subjects[0].contains("feat!: redesign"));
+    }
+
+    async fn git_head(dir: &Path) -> String {
+        let out = git_cmd(dir)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .await
+            .unwrap();
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    #[tokio::test]
+    async fn test_remote_head_reports_tracking_branch_tip() {
+        // Mirrors the "held back by lockfile pin" scenario: pin to an old
+        // commit, advance the remote, verify that remote_head reflects the
+        // new remote tip while HEAD stays at the pin.
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("a.txt"), "v1").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let initial = git_head(&src).await;
+
+        // Fresh clone → local HEAD == remote tip.
+        let repo = Repo::new(src.to_str().unwrap(), &dst, None);
+        repo.sync().await.unwrap();
+        assert_eq!(
+            repo.remote_head().await.unwrap().as_deref(),
+            Some(initial.as_str()),
+            "fresh clone: remote_head should match HEAD"
+        );
+
+        // Advance the remote by one commit.
+        fs::write(src.join("a.txt"), "v2").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "advance"])
+            .output()
+            .await
+            .unwrap();
+        let new_tip = git_head(&src).await;
+        assert_ne!(new_tip, initial, "remote tip must have moved");
+
+        // Re-sync with the pinned rev: fetch brings the new ref in, but
+        // HEAD stays at `initial`.
+        let pinned = Repo::new(src.to_str().unwrap(), &dst, Some(initial.as_str()));
+        pinned.sync().await.unwrap();
+        assert_eq!(
+            pinned.head_commit().await.unwrap(),
+            initial,
+            "pinned sync must keep HEAD at the requested rev"
+        );
+
+        // remote_head must return the NEW tip, signalling the held-back state.
+        let rh = pinned.remote_head().await.unwrap();
+        assert_eq!(
+            rh.as_deref(),
+            Some(new_tip.as_str()),
+            "remote_head must report the fetched remote tip, not HEAD"
+        );
+        assert_ne!(rh.as_deref(), Some(initial.as_str()));
     }
 
     #[tokio::test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -186,17 +186,24 @@ fn read_remote_head(dst: &Path) -> Result<Option<String>> {
         .and_then(|r| r.name().map(|n| n.as_bstr().to_string()))
         .unwrap_or_else(|| "origin".to_string());
 
+    // tracking ref が見つかっても peel 失敗時は `Ok(None)` に落とす (resilience:
+    // malformed ref や stale packed-refs で held-back 判定全体が止まるのを避け、
+    // 代わりにそのプラグインを「判定不能」として分類から除外する)。
     if let Some(head_name) = repo.head_name()? {
         let branch = head_name.as_bstr().to_string();
         let tracking = branch.replace("refs/heads/", &format!("refs/remotes/{}/", remote_name));
-        if let Ok(mut tr) = repo.find_reference(&tracking) {
-            return Ok(Some(tr.peel_to_id()?.detach().to_string()));
+        if let Ok(mut tr) = repo.find_reference(&tracking)
+            && let Ok(id) = tr.peel_to_id()
+        {
+            return Ok(Some(id.detach().to_string()));
         }
     }
 
     let remote_head_ref = format!("refs/remotes/{}/HEAD", remote_name);
-    if let Ok(mut r) = repo.find_reference(&remote_head_ref) {
-        return Ok(Some(r.peel_to_id()?.detach().to_string()));
+    if let Ok(mut r) = repo.find_reference(&remote_head_ref)
+        && let Ok(id) = r.peel_to_id()
+    {
+        return Ok(Some(id.detach().to_string()));
     }
     Ok(None)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,7 +709,13 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
                     // held-back 判定用に remote tracking tip を読む (HEAD は動かさない)。
                     // 失敗時は None → classify_held_back 側で「判定不能」扱いになり、
                     // 結果として held_back リストには積まれない (resilience)。
-                    let remote_head = repo.remote_head().await.ok().flatten();
+                    // 分類が None 確定の前提条件 (explicit rev / lockfile 寄与なし) では
+                    // gix open 自体をスキップして 200+ プラグイン構成の I/O を減らす。
+                    let remote_head = if plugin.rev.is_none() && effective_rev.is_some() {
+                        repo.remote_head().await.ok().flatten()
+                    } else {
+                        None
+                    };
                     let held_back = classify_held_back(
                         plugin.rev.as_deref(),
                         effective_rev.as_deref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,11 +525,6 @@ fn classify_held_back(
     }
 }
 
-/// Shorten a commit hash for user-facing display (7 chars, git-style).
-fn short_sha(sha: &str) -> String {
-    sha.chars().take(7).collect()
-}
-
 async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Result<()> {
     // `--frozen` は lockfile に依存した strict check、`--no-lock` は lockfile を
     // 完全無視する escape hatch。両方立つと「strict のつもりが silently latest を
@@ -909,8 +904,8 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
             eprintln!(
                 "  -> {}  {} -> {}",
                 pin.name,
-                short_sha(&pin.pinned),
-                short_sha(&pin.remote),
+                crate::update_log::short_hash(&pin.pinned),
+                crate::update_log::short_hash(&pin.remote),
             );
         }
     }
@@ -4469,14 +4464,6 @@ mod tests {
         // Same resilience argument in the other direction.
         let got = classify_held_back(None, Some("abc"), None, Some("def"));
         assert_eq!(got, None);
-    }
-
-    #[test]
-    fn test_short_sha_takes_first_seven_chars() {
-        assert_eq!(short_sha("abcdef1234567890"), "abcdef1");
-        // Shorter input: don't pad or error, just return what we've got.
-        assert_eq!(short_sha("abc"), "abc");
-        assert_eq!(short_sha(""), "");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,53 @@ async fn execute_build_command(
     }
 }
 
+/// A plugin that sync left at a lockfile-pinned commit while its remote
+/// has advanced. Reported in the sync summary so users know `rvpm update`
+/// would actually change something.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HeldBackPin {
+    name: String,
+    pinned: String,
+    remote: String,
+}
+
+/// Decide whether a just-synced plugin is being "held back" by a lockfile
+/// pin. Returns `Some((pinned_commit, remote_tip))` when:
+///
+/// - the plugin has **no explicit `rev`** (not the user's choice),
+/// - the **lockfile contributed** an effective rev (pin came from the lockfile),
+/// - and the pinned HEAD is **behind the remote tracking tip**.
+///
+/// Returns `None` otherwise — explicit `rev`, no lockfile contribution,
+/// already at remote tip, or either commit unknown (treat unknowns as
+/// "not held back" to avoid false positives).
+///
+/// This is the pure classification step; the caller is responsible for
+/// composing the plugin display name and emitting the summary line.
+fn classify_held_back(
+    plugin_rev: Option<&str>,
+    effective_rev: Option<&str>,
+    head_commit: Option<&str>,
+    remote_head: Option<&str>,
+) -> Option<(String, String)> {
+    if plugin_rev.is_some() {
+        return None;
+    }
+    effective_rev?;
+    let head = head_commit?;
+    let remote = remote_head?;
+    if head != remote {
+        Some((head.to_string(), remote.to_string()))
+    } else {
+        None
+    }
+}
+
+/// Shorten a commit hash for user-facing display (7 chars, git-style).
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
 async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Result<()> {
     // `--frozen` は lockfile に依存した strict check、`--no-lock` は lockfile を
     // 完全無視する escape hatch。両方立つと「strict のつもりが silently latest を
@@ -664,8 +711,23 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
                     // lockfile エントリが新規作成できるよう別途取得する。
                     // 失敗しても sync 本体の成否には影響させない (resilience)。
                     let head_commit = repo.head_commit().await.ok();
+                    // held-back 判定用に remote tracking tip を読む (HEAD は動かさない)。
+                    // 失敗時は None → classify_held_back 側で「判定不能」扱いになり、
+                    // 結果として held_back リストには積まれない (resilience)。
+                    let remote_head = repo.remote_head().await.ok().flatten();
+                    let held_back = classify_held_back(
+                        plugin.rev.as_deref(),
+                        effective_rev.as_deref(),
+                        head_commit.as_deref(),
+                        remote_head.as_deref(),
+                    )
+                    .map(|(pinned, remote)| HeldBackPin {
+                        name: plugin.display_name(),
+                        pinned,
+                        remote,
+                    });
                     let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
-                    Ok((plugin, dst_path, build_warn, change, head_commit))
+                    Ok((plugin, dst_path, build_warn, change, head_commit, held_back))
                 }
                 Err(e) => {
                     let _ = tx
@@ -706,6 +768,9 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
 
     let mut build_warnings: Vec<(String, String)> = Vec::new();
     let mut sync_changes: Vec<crate::update_log::ChangeRecord> = Vec::new();
+    // lockfile pin で最新から置いてけぼりになっているプラグインを集めて、sync 末尾に
+    // まとめて「`rvpm update` で進めて」と案内する (罠の緩和)。
+    let mut held_back: Vec<HeldBackPin> = Vec::new();
     let mut finished_tasks = 0;
     let dev_count = config.plugins.iter().filter(|p| p.dev).count();
     let total_tasks = config.plugins.len() - dev_count;
@@ -724,12 +789,15 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
             Some((url, status)) = rx.recv() => { tui_state.update_status(&url, status); }
             Some(res) = set.join_next() => {
                 finished_tasks += 1;
-                if let Ok(Ok((plugin, dst_path, build_warn, git_change, head_commit))) = res {
+                if let Ok(Ok((plugin, dst_path, build_warn, git_change, head_commit, pin))) = res {
                     if let Some(warn) = build_warn {
                         build_warnings.push((plugin.url.clone(), warn));
                     }
                     if let Some(change) = git_change {
                         sync_changes.push(change_record_from(&plugin, change));
+                    }
+                    if let Some(p) = pin {
+                        held_back.push(p);
                     }
                     // lockfile 更新: sync 完了後の現 HEAD を pin として記録。
                     // `--no-lock` 時もこの in-memory 更新は行うが、terminal save は飛ばすので
@@ -826,6 +894,24 @@ async fn run_sync(prune: bool, frozen: bool, no_lock: bool, rebuild: bool) -> Re
         eprintln!("\n{} plugin(s) promoted lazy -> eager:", promoted.len());
         for name in &sorted_promoted {
             eprintln!("  -> {}", name);
+        }
+    }
+    // lockfile pin で最新から置いてけぼりのプラグインを案内する。`rvpm sync` は
+    // pin を尊重する (= update しない) 設計なので、rev を設定していないユーザーが
+    // 「sync したのに古いまま」と感じる罠を緩和する目的。
+    if !held_back.is_empty() {
+        held_back.sort_by(|a, b| a.name.cmp(&b.name));
+        eprintln!(
+            "\n{} plugin(s) held at lockfile pin (no `rev` set). Run `rvpm update` to advance:",
+            held_back.len()
+        );
+        for pin in &held_back {
+            eprintln!(
+                "  -> {}  {} -> {}",
+                pin.name,
+                short_sha(&pin.pinned),
+                short_sha(&pin.remote),
+            );
         }
     }
     println!("Generating loader.lua...");
@@ -4323,6 +4409,74 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(path, content).unwrap();
+    }
+
+    // ─── classify_held_back ──────────────────────────────────────────────
+    // Pure classification of "this plugin is being held back by a lockfile
+    // pin". The integration path is covered by the git::remote_head test
+    // on the git.rs side; these tests nail down the decision table only.
+
+    #[test]
+    fn test_classify_held_back_reports_pin_behind_remote() {
+        // No rev set, lockfile contributed a commit, and HEAD (= pin)
+        // lags behind remote → this is the case users hit.
+        let got = classify_held_back(
+            None,
+            Some("lockcommit"),
+            Some("lockcommit"),
+            Some("newcommit"),
+        );
+        assert_eq!(
+            got,
+            Some(("lockcommit".to_string(), "newcommit".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_classify_held_back_silent_when_explicit_rev_set() {
+        // If the user pinned via `rev`, the lag is intentional — not our
+        // call to flag.
+        let got = classify_held_back(Some("v1.0.0"), Some("v1.0.0"), Some("abc"), Some("def"));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_classify_held_back_silent_without_lockfile_contribution() {
+        // No lockfile entry → sync already reset to remote; there's no pin
+        // holding us back.
+        let got = classify_held_back(None, None, Some("abc"), Some("abc"));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_classify_held_back_silent_when_pin_matches_remote() {
+        // Lockfile pin and remote happen to line up — everyone's up to
+        // date, no reason to nag.
+        let got = classify_held_back(None, Some("abc"), Some("abc"), Some("abc"));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_classify_held_back_silent_when_remote_head_unknown() {
+        // Can't prove the pin is behind if we can't resolve the remote tip.
+        // Prefer silence over a false positive (resilience).
+        let got = classify_held_back(None, Some("abc"), Some("abc"), None);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_classify_held_back_silent_when_head_unknown() {
+        // Same resilience argument in the other direction.
+        let got = classify_held_back(None, Some("abc"), None, Some("def"));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_short_sha_takes_first_seven_chars() {
+        assert_eq!(short_sha("abcdef1234567890"), "abcdef1");
+        // Shorter input: don't pad or error, just return what we've got.
+        assert_eq!(short_sha("abc"), "abc");
+        assert_eq!(short_sha(""), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`rvpm sync` intentionally respects the lockfile — plugins without an explicit `rev` stay pinned at the lockfile commit rather than being pulled to latest. This matches lazy.nvim's reproducibility model and is the right default, but it trips users who read `sync` as "bring everything up to date":

> I ran `rvpm sync` and my plugin is still old.

This PR keeps the sync semantics unchanged and just closes the UX gap with a **summary at the end of sync**. Any plugin whose lockfile-supplied pin is behind its remote tip is listed with short shas and a hint to run `rvpm update`:

```
3 plugin(s) held at lockfile pin (no ``rev`` set). Run ``rvpm update`` to advance:
  -> yukimemi/rvpm.nvim  4e52964 -> b8077bb
  -> folke/snacks.nvim   abc1234 -> def5678
  -> nvim-telescope/telescope.nvim  111aaaa -> 222bbbb
```

Silent when nothing is held back: plugins with an explicit `rev`, plugins whose pin already matches remote, and plugins with no lockfile contribution (first sync / `--no-lock`) don't appear.

## Implementation

- **`Repo::remote_head()`** reads the tracked remote branch tip (`refs/remotes/<remote>/<branch>`, falling back to `refs/remotes/<remote>/HEAD` for detached HEAD) without moving local HEAD. Returns `Option<String>` so malformed / un-fetched cases degrade to "undecidable" rather than producing false positives.
- **`classify_held_back()`** is a pure decision function over four inputs (plugin rev, effective rev, head, remote head). Explicit `rev` or missing lockfile contribution → `None`; pin matches remote → `None`; pin differs from remote → `Some((pin, remote_tip))`.
- The sync task tuple now carries an `Option<HeldBackPin>`. The join loop collects them; the end-of-sync reporter sorts by name and prints right after the existing "promoted lazy -> eager" block.

## Tests

- `git::tests::test_remote_head_reports_tracking_branch_tip` — fresh clone reports remote == HEAD, then pin the rev and advance the remote; `remote_head` reflects the new tip while HEAD stays at the pin.
- `tests::test_classify_held_back_*` — six cases covering the full decision table (reports / silent on explicit rev / silent on no lockfile / silent on match / silent on unknown remote / silent on unknown head).
- `tests::test_short_sha_takes_first_seven_chars` — display helper.

All 457 tests pass. ``cargo fmt --all -- --check`` and ``cargo clippy --all-targets -- -D warnings`` clean.

## Test plan

- [x] ``cargo test`` — 457 passed
- [x] ``cargo fmt --all -- --check``
- [x] ``cargo clippy --all-targets -- -D warnings``
- [ ] Manual smoke: sync a config with a pinned plugin whose remote has advanced → confirm summary appears
- [ ] Manual smoke: sync a config where everything is at remote tip → confirm summary stays silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync now detects plugins that are pinned locally but have newer remote tips and reports them after sync, with short hashes and a recommendation to run `rvpm update`.
* **Tests**
  * Added unit and integration tests covering detection and reporting of held-back plugins and edge cases (explicit revisions, non-lockfile cases, unknown commits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->