### PR TITLE
chore: bump default concurrency from 8 to 13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ nvim_rc = "~/.config/nvim/rc"
 # per-plugin の init/before/after.lua を置くディレクトリの root
 # 未指定なら ~/.config/rvpm/<appname>/plugins
 config_root = "{{ vars.nvim_rc }}/plugins"
-# 並列数上限 (デフォルト 8、GitHub rate limit 回避のため控えめ)
+# 並列数上限 (デフォルト 13、GitHub rate limit 回避のため控えめ)
 concurrency = 10
 # config.toml から外したプラグインディレクトリを sync / generate 完了時に
 # 自動削除 (デフォルト false)。毎回 `sync --prune` を指定する代わり。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ nvim_rc = "~/.config/nvim/rc"
 # 未指定なら ~/.config/rvpm/<appname>/plugins
 config_root = "{{ vars.nvim_rc }}/plugins"
 # 並列数上限 (デフォルト 13、GitHub rate limit 回避のため控えめ)
-concurrency = 10
+concurrency = 16
 # config.toml から外したプラグインディレクトリを sync / generate 完了時に
 # 自動削除 (デフォルト false)。毎回 `sync --prune` を指定する代わり。
 # auto_clean = true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Files end up under `~/.config/rvpm/<appname>/` and
 nvim_rc = "~/.config/nvim/rc"
 
 [options]
-# Parallel git operations limit (default: 8)
+# Parallel git operations limit (default: 13)
 concurrency = 10
 
 # Auto-prune plugin dirs no longer referenced by config.toml on every
@@ -138,7 +138,7 @@ for fully isolated test configs.
 |---|---|---|---|
 | `config_root` | `string` | `~/.config/rvpm/<appname>` | Root for `config.toml`, global hooks, and per-plugin hooks. **Recommended: leave unset** |
 | `cache_root` | `string` | `~/.cache/rvpm/<appname>` | Root for clones, merged rtp, generated loader, and browse cache. **Recommended: leave unset** |
-| `concurrency` | `integer` | `8` | Max parallel git operations during `sync` / `update` |
+| `concurrency` | `integer` | `13` | Max parallel git operations during `sync` / `update` |
 | `chezmoi` | `boolean` | `false` | Route writes through chezmoi source state. See [Advanced → chezmoi integration](#advanced) |
 | `auto_clean` | `boolean` | `false` | `sync` / `generate` auto-delete plugin dirs no longer in `config.toml` (= always `--prune`) |
 | `auto_helptags` | `boolean` | `true` | `sync` / `generate` run `nvim --headless` once at the end to build helptags for every plugin's `doc/`. Skipped with a warning if `nvim` is missing |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ nvim_rc = "~/.config/nvim/rc"
 
 [options]
 # Parallel git operations limit (default: 13)
-concurrency = 10
+concurrency = 16
 
 # Auto-prune plugin dirs no longer referenced by config.toml on every
 # sync / generate. Default: false. Equivalent to always passing --prune.

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub struct Options {
     /// per-plugin init/before/after.lua の置き場。
     /// 未指定なら `~/.config/rvpm/<appname>/plugins`。
     pub config_root: Option<String>,
-    /// git 並列実行数 (default: 8)。
+    /// git 並列実行数 (default: 13)。
     pub concurrency: Option<usize>,
     /// rvpm のキャッシュ root。
     /// 未指定なら `~/.cache/rvpm/<appname>`。

--- a/src/main.rs
+++ b/src/main.rs
@@ -3141,7 +3141,7 @@ fn write_loader_to_path(
 }
 
 /// デフォルト並列数。GitHub の rate limit を避けるため控えめに。
-const DEFAULT_CONCURRENCY: usize = 8;
+const DEFAULT_CONCURRENCY: usize = 13;
 
 fn resolve_concurrency(config_value: Option<usize>) -> usize {
     config_value.unwrap_or(DEFAULT_CONCURRENCY)
@@ -5409,10 +5409,10 @@ url = "owner/repo"
     }
 
     #[test]
-    fn test_resolve_concurrency_defaults_to_8() {
+    fn test_resolve_concurrency_defaults_to_13() {
         let result = resolve_concurrency(None);
         assert_eq!(result, DEFAULT_CONCURRENCY);
-        assert_eq!(result, 8);
+        assert_eq!(result, 13);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Raise `DEFAULT_CONCURRENCY` from `8` to `13` so a fresh install parallelizes more git operations out of the box.
- Stays well below typical GitHub unauthenticated rate-limit thresholds, while better utilizing modern link speeds / CPU for a large plugin set.
- Update `config.rs` doc comment, `README.md` (example + options table), `CLAUDE.md`, and the default-value unit test to match.

## Test plan
- [x] `cargo test resolve_concurrency` — both defaults-to-13 and uses-config-value pass
- [x] pre-push hook (`cargo fmt --check`, `cargo clippy -D warnings`, full `cargo test`) green
- [ ] Manual `rvpm sync` on a real config — exercise the new default in the wild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Default concurrency for parallel operations increased from 8 to 13.
  * Example/default configuration values updated (example concurrency adjusted to 16).
  * Documentation and reference table updated to reflect the new default concurrency limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->