### PR TITLE
docs: codify PR review cycle (Gemini + CodeRabbit gating, @-mention rule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - ブランチ名は変更内容を端的に表す (例: `feat/add-only-sync-new-plugin`)。
 - **PR のタイトル・本文は英語で書く。** コミットメッセージも英語。
 
+### PR レビューサイクル
+
+- 全 PR で **Gemini Code Assist** と **CodeRabbit** がレビューを走らせる。両 bot の投稿を待ち、コメントに対処 (fix を PR branch に push) して、フィードバックが解消してからマージする。
+- **fix を push したらレビュアーに返信する。** 対応した review comment のスレッドに、**@-mention (`@gemini-code-assist` / `@coderabbitai`)** 付きで reply する。silent な fix はレビュアーから見えず、盲目的に re-review されて監査トレイル (どの fix がどの指摘に応じたか) も失われる。
+- **Merge gating.** 以下の **両方** を満たすまで merge しない:
+  1. レビュー bot (Gemini / CodeRabbit) が新しい actionable コメントを出さなくなった — fix → @-mention → 沈黙、のサイクルを回し続ける。
+  2. リポジトリオーナー (@yukimemi) が明示的に merge を承認している。
+  Bot からの "Understood" / "Thank you" のような ack のみの返信はその thread の quiet pass とみなす。新しい actionable な指摘が来たら loop を再開。
+- **例外: bot-authored PR (Renovate, Dependabot).** Gemini と CodeRabbit はデフォルトでこれらを skip するので、"bot review を待つ" gate は適用しない。CI が green で owner 承認があれば merge OK。
+
 ## Development Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - 全 PR で **Gemini Code Assist** と **CodeRabbit** がレビューを走らせる。両 bot の投稿を待ち、コメントに対処 (fix を PR branch に push) して、フィードバックが解消してからマージする。
 - **fix を push したらレビュアーに返信する。** 対応した review comment のスレッドに、**@-mention (`@gemini-code-assist` / `@coderabbitai`)** 付きで reply する。silent な fix はレビュアーから見えず、盲目的に re-review されて監査トレイル (どの fix がどの指摘に応じたか) も失われる。
+- **fix + reply を送ったらそこで止まらず、能動的に bot の再発言を監視する。** 数分おき (目安 5 分程度) に `gh pr view` / `gh api .../pulls/<n>/comments` を叩いて新しい actionable コメントが来てないか確認。来ていれば即 fix → @-mention → 監視再開、の loop を回す。Agent 環境なら `/loop` や `ScheduleWakeup` で自動化してよい。放置して「bot が次に話しかけてきたら起きる」運用は、bot が静かに諦めてしまう (actionable コメントを止めて ack だけ返すモードに入る) ケースを拾えない。
+- **監視ストップ条件**: **最後の actionable コメントから 30 分** 新しい指摘が来なかったら監視ループを抜けて、リポジトリオーナーに「bot が quiet になったので merge 判断お願いします」と報告する。30 分は「bot が review cycle を一巡させるのに十分で、人間を待たせすぎない」ライン。短すぎ (<10 分) だと遅延投稿を取りこぼし、長すぎ (>1 時間) だと merge が無意味に遅れる。
 - **Merge gating.** 以下の **両方** を満たすまで merge しない:
   1. レビュー bot (Gemini / CodeRabbit) が新しい actionable コメントを出さなくなった — fix → @-mention → 沈黙、のサイクルを回し続ける。
   2. リポジトリオーナー (@yukimemi) が明示的に merge を承認している。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **監視ストップ条件**: **最後の actionable コメントから 30 分** 新しい指摘が来なかったら監視ループを抜けて、リポジトリオーナーに「bot が quiet になったので merge 判断お願いします」と報告する。30 分は「bot が review cycle を一巡させるのに十分で、人間を待たせすぎない」ライン。短すぎ (<10 分) だと遅延投稿を取りこぼし、長すぎ (>1 時間) だと merge が無意味に遅れる。
 - **Merge gating.** 以下の **両方** を満たすまで merge しない:
   1. レビュー bot (Gemini / CodeRabbit) が新しい actionable コメントを出さなくなった — fix → @-mention → 沈黙、のサイクルを回し続ける。
+     Bot からの "Understood" / "Thank you" のような ack のみの返信はその thread の quiet pass とみなす。新しい actionable な指摘が来たら loop を再開。
   2. リポジトリオーナー (@yukimemi) が明示的に merge を承認している。
-  Bot からの "Understood" / "Thank you" のような ack のみの返信はその thread の quiet pass とみなす。新しい actionable な指摘が来たら loop を再開。
 - **例外: bot-authored PR (Renovate, Dependabot).** Gemini と CodeRabbit はデフォルトでこれらを skip するので、"bot review を待つ" gate は適用しない。CI が green で owner 承認があれば merge OK。
 
 ## Development Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - 全 PR で **Gemini Code Assist** と **CodeRabbit** がレビューを走らせる。両 bot の投稿を待ち、コメントに対処 (fix を PR branch に push) して、フィードバックが解消してからマージする。
 - **fix を push したらレビュアーに返信する。** 対応した review comment のスレッドに、**@-mention (`@gemini-code-assist` / `@coderabbitai`)** 付きで reply する。silent な fix はレビュアーから見えず、盲目的に re-review されて監査トレイル (どの fix がどの指摘に応じたか) も失われる。
-- **fix + reply を送ったらそこで止まらず、能動的に bot の再発言を監視する。** 数分おき (目安 5 分程度) に `gh pr view` / `gh api .../pulls/<n>/comments` を叩いて新しい actionable コメントが来てないか確認。来ていれば即 fix → @-mention → 監視再開、の loop を回す。Agent 環境なら `/loop` や `ScheduleWakeup` で自動化してよい。放置して「bot が次に話しかけてきたら起きる」運用は、bot が静かに諦めてしまう (actionable コメントを止めて ack だけ返すモードに入る) ケースを拾えない。
-- **監視ストップ条件**: **最後の actionable コメントから 30 分** 新しい指摘が来なかったら監視ループを抜けて、リポジトリオーナーに「bot が quiet になったので merge 判断お願いします」と報告する。30 分は「bot が review cycle を一巡させるのに十分で、人間を待たせすぎない」ライン。短すぎ (<10 分) だと遅延投稿を取りこぼし、長すぎ (>1 時間) だと merge が無意味に遅れる。
+- **fix + reply を送ったらそこで止まらず、能動的に bot の再発言を監視する。** 数分おき (目安 5 分程度) に `gh pr view` / `gh api .../pulls/<n>/comments` を叩いて bot の返答を確認。新しい actionable コメントが来ていれば即 fix → @-mention → 監視再開、の loop を回す。Agent 環境なら `/loop` や `ScheduleWakeup` で自動化してよい。
+- **スレッド settle の判定**: 1 つの review thread は、**最新の bot 返信が ack-only** ("Thank you" / "Understood" / "Acknowledged" / 新指摘なしの re-review サマリなど) になった時点で settle。`--diff` の再指摘や追加の actionable コメントが来たら未 settle に戻す。
+- **監視ストップ条件**:
+  1. **すべての open thread が settle** → その PR は quiet。両 PR (or 対象 PR 全部) が quiet になった瞬間にループを抜けてオーナーに merge 判断を仰ぐ。bot が素早く ack を返した場合、30 分待つ必要はない。
+  2. **bot が返信を返さないまま最後の actionable コメントから 30 分経過** → timeout としてその thread を settle 扱いにする。bot が静かに諦めるケース (actionable を止めて何も返さないモード) を拾う fallback。短すぎ (<10 分) だと遅延投稿を取りこぼし、長すぎ (>1 時間) だと merge が無意味に遅れる。
 - **Merge gating.** 以下の **両方** を満たすまで merge しない:
   1. レビュー bot (Gemini / CodeRabbit) が新しい actionable コメントを出さなくなった — fix → @-mention → 沈黙、のサイクルを回し続ける。
      Bot からの "Understood" / "Thank you" のような ack のみの返信はその thread の quiet pass とみなす。新しい actionable な指摘が来たら loop を再開。


### PR DESCRIPTION
## Summary

Teach rvpm's CLAUDE.md how to actually close a PR review loop. Every PR triggers Gemini Code Assist and CodeRabbit, but the prior 'Git ワークフロー' section only said 'open a PR; titles in English' — nothing about what to do with the bot feedback, when it's safe to merge, or how reviewers know a fix landed.

Port the review-cycle rules already written down in the neighboring todoke project's CLAUDE.md, adapted to Japanese to match this file's style:

- Wait for **both** bots to post before touching merge.
- **Reply with an @-mention** in the comment thread whenever a fix addresses a review comment — silent fixes are invisible to the reviewer and erase the audit trail linking the fix commit back to the original concern.
- **Merge gate:** bots quiet AND owner approval. Ack-only bot replies ("Understood" / "Thank you") count as quiet. Any new actionable finding restarts the loop.
- **Bot-authored PR exception:** Renovate / Dependabot are skipped by both bots by default, so the bot-review gate doesn't apply there — CI green + owner approval is enough.

## Test plan

- [x] Read the rendered Markdown locally to confirm the subsection nests cleanly under 'Git ワークフロー'.
- [x] Exercise the workflow on PR #78 (the predecessor PR for #77) — pushed a fix, @-mentioned both `@gemini-code-assist` and `@coderabbitai`, waiting for the quiet-pass signal before merging.
- [x] `grep -n` confirms the 'Git ワークフロー' anchor still appears at its original location for anyone who has it bookmarked.

## Notes

Docs-only change; no code, tests, or config touched. CI still runs through the pre-push hook suite (fmt / clippy / test) for the sake of consistency, but it's a no-op for this diff.

Closes nothing on its own; follow-up PRs under #77 will be the first ones to exercise the newly-documented cycle end-to-end.