### PR TITLE
feat(profile): embed require tracer, populate [user config].require_trace (#77 PR 2/4)

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -88,7 +88,7 @@ fn lua_str_list(items: &[String]) -> String {
 /// backslash はまず `/` に正規化し (Windows path separator)、
 /// 残った特殊文字 (double quote, backslash, CR/LF, TAB) をエスケープする。
 /// これで generate path に空白や特殊文字が混ざっても安全に emit できる。
-fn lua_quote(s: &str) -> String {
+pub(crate) fn lua_quote(s: &str) -> String {
     let normalized = s.replace('\\', "/");
     let mut out = String::with_capacity(normalized.len() + 2);
     out.push('"');

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -940,8 +940,9 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
             && let Ok(raw) = std::fs::read_to_string(trace_path)
             && let Ok(tree) = parse_require_trace(&raw)
         {
-            let user_stats = stats.entry(GROUP_USER.to_string()).or_insert_with(|| {
-                PluginStats {
+            let user_stats = stats
+                .entry(GROUP_USER.to_string())
+                .or_insert_with(|| PluginStats {
                     name: GROUP_USER.to_string(),
                     total_self_ms: 0.0,
                     total_sourced_ms: 0.0,
@@ -953,8 +954,7 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
                     load_ms: 0.0,
                     trig_ms: 0.0,
                     require_trace: None,
-                }
-            });
+                });
             if user_stats.require_trace.is_none() {
                 user_stats.require_trace = Some(tree);
             }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -904,7 +904,10 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
         let extra_args: Vec<String> = if let Some((tracer_path, _)) = tracer_paths.as_ref() {
             vec![
                 "--cmd".into(),
-                format!("luafile {}", tracer_path.to_string_lossy().replace('\\', "/")),
+                format!(
+                    "luafile {}",
+                    tracer_path.to_string_lossy().replace('\\', "/")
+                ),
             ]
         } else {
             Vec::new()

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -122,11 +122,111 @@ impl RequireNode {
 }
 
 /// instrumented loader.lua が吐いた require trace JSON を `RequireNode` tree に復元。
-#[allow(dead_code)] // wired into run_profile in PR 2 (loader-side tracer hookup)
 pub fn parse_require_trace(json: &str) -> anyhow::Result<RequireNode> {
     let raw: RawRequireNode = serde_json::from_str(json)
         .map_err(|e| anyhow::anyhow!("failed to parse require trace JSON: {}", e))?;
     Ok(RequireNode::from_raw(raw))
+}
+
+/// tracer Lua + 出力先 JSON を `marker_dir` 配下に書き出して (tracer_path, trace_path) を返す。
+///
+/// run ごとに suffix を変える (`tracer_<i>.lua` / `trace_<i>.json`) ので、多 runs で
+/// 前の run の残骸と衝突しない。`nvim --cmd "luafile <tracer_path>"` で使う前提。
+/// 失敗 (ディスクフル等) は呼び出し側で `Err` を捨てて trace なしの通常 profile に fall back。
+pub fn install_require_tracer(
+    marker_dir: &std::path::Path,
+    run_index: usize,
+) -> std::io::Result<(std::path::PathBuf, std::path::PathBuf)> {
+    let tracer_path = marker_dir.join(format!("require_tracer_{}.lua", run_index));
+    let trace_path = marker_dir.join(format!("require_trace_{}.json", run_index));
+    let trace_path_str = normalize_path(&trace_path.to_string_lossy());
+    let script = build_require_tracer_script(&trace_path_str);
+    std::fs::write(&tracer_path, script)?;
+    Ok((tracer_path, trace_path))
+}
+
+/// `rvpm profile` 用 require tracer の Lua スクリプトを組み立てる。
+///
+/// lazy.nvim の [`util.track()`](https://github.com/folke/lazy.nvim/blob/main/lua/lazy/core/util.lua)
+/// と同じ stack-based tracer を `_G.require` にかぶせて、first-time require のみ
+/// 木構造で記録。`VimLeavePre` autocmd で JSON (`vim.json.encode`) に serialize して
+/// `trace_path` に書き出す。
+///
+/// `nvim --cmd "luafile <this script>" ...` として init.lua より前に実行する前提。
+/// そうしないと init.lua の冒頭の `require(...)` を取りこぼす。
+///
+/// 空の `children` は **省略** して emit する — `vim.json.encode({})` は `{}`
+/// (object) を吐くが、Rust 側の `RawRequireNode.children` は `#[serde(default)]`
+/// で missing field に耐える。`children: {}` (object) で送ると parse が失敗するので、
+/// そもそも field を書かない方が安全。
+///
+/// autocmd choice: `VimEnter` は `nvim --headless ... +qa` 構成だと fire されない。
+/// `+qa` で quit コマンドが VimEnter より前に処理されて exit してしまう。`VimLeavePre`
+/// なら `:qa` 処理中に必ず fire するので、どの init 構成でも dump が走る。
+///
+/// resilience: tracer が panic/error しても init.lua 本体の実行を止めない (pcall
+/// で包む)。trace ファイルを開けない (権限なし / ディスクフル) ときは silently skip。
+pub fn build_require_tracer_script(trace_path: &str) -> String {
+    let escaped = crate::loader::lua_quote(trace_path);
+    format!(
+        r#"-- rvpm require tracer (auto-generated; do not edit)
+-- Wraps _G.require with a stack-based timer so the profile TUI can
+-- surface user-init.lua's require chain. Ported from lazy.nvim's
+-- util.track(). Dumps a JSON tree on VimLeavePre.
+local ok_setup, err_setup = pcall(function()
+  local trace_path = {path}
+  local hrtime = (vim.uv or vim.loop).hrtime
+  local root = {{ module = "init.lua", time = hrtime(), children = {{}} }}
+  local stack = {{ root }}
+  local orig_require = _G.require
+  _G.require = function(modname)
+    if package.loaded[modname] ~= nil then
+      return orig_require(modname)
+    end
+    local entry = {{ module = modname, time = hrtime(), children = {{}} }}
+    table.insert(stack[#stack].children, entry)
+    table.insert(stack, entry)
+    local ok, ret = pcall(orig_require, modname)
+    local e = table.remove(stack)
+    e.time = hrtime() - e.time
+    if not ok then error(ret) end
+    return ret
+  end
+  local function to_payload(entry)
+    local out = {{ module = entry.module, time = entry.time }}
+    if #entry.children > 0 then
+      local c = {{}}
+      for i, child in ipairs(entry.children) do
+        c[i] = to_payload(child)
+      end
+      out.children = c
+    end
+    return out
+  end
+  vim.api.nvim_create_autocmd("VimLeavePre", {{
+    once = true,
+    callback = function()
+      root.time = hrtime() - root.time
+      local ok_dump, err_dump = pcall(function()
+        local json = vim.json.encode(to_payload(root))
+        local fh = io.open(trace_path, "w")
+        if fh then
+          fh:write(json)
+          fh:close()
+        end
+      end)
+      if not ok_dump then
+        vim.notify("rvpm require tracer: dump failed: " .. tostring(err_dump), vim.log.levels.WARN)
+      end
+    end,
+  }})
+end)
+if not ok_setup then
+  vim.notify("rvpm require tracer: setup failed: " .. tostring(err_setup), vim.log.levels.WARN)
+end
+"#,
+        path = escaped
+    )
 }
 
 /// 1 フェーズ分の所要時間 (平均値)。
@@ -792,7 +892,26 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
     let mut phase_timelines: Vec<Vec<PhaseTime>> = Vec::new();
 
     for i in 0..cfg.runs {
-        let (content, total) = run_single_startuptime(&[])
+        // require tracer: instrumentation 有効時のみ。marker_dir 配下に
+        // run ごとに別の tracer.lua / trace.json を作り、`--cmd "luafile ..."`
+        // で init.lua より前に読み込ませる。そうしないと init.lua 冒頭の
+        // `require(...)` を取りこぼすため。ファイル I/O 失敗は resilience で
+        // 無視して通常の profile run に進む。
+        let tracer_paths = cfg
+            .marker_dir
+            .as_ref()
+            .and_then(|mdir| install_require_tracer(mdir, i).ok());
+        let extra_args: Vec<String> = if let Some((tracer_path, _)) = tracer_paths.as_ref() {
+            vec![
+                "--cmd".into(),
+                format!("luafile {}", tracer_path.to_string_lossy().replace('\\', "/")),
+            ]
+        } else {
+            Vec::new()
+        };
+        let extra_ref: Vec<&str> = extra_args.iter().map(|s| s.as_str()).collect();
+
+        let (content, total) = run_single_startuptime(&extra_ref)
             .await
             .map_err(|e| anyhow::anyhow!("profile run {}/{} failed: {}", i + 1, cfg.runs, e))?;
         totals.push(total);
@@ -804,6 +923,35 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
             &loader_s,
             user_s.as_slice(),
         );
+
+        // require tracer が trace.json を吐いていれば [user config] に attach。
+        // tracer は VimLeavePre で JSON を書き出すので `+qa` による quit 中に発火する
+        // (VimEnter は headless + +qa 構成だと取りこぼすため採用しない)。
+        if let Some((_, trace_path)) = tracer_paths.as_ref()
+            && let Ok(raw) = std::fs::read_to_string(trace_path)
+            && let Ok(tree) = parse_require_trace(&raw)
+        {
+            stats
+                .entry(GROUP_USER.to_string())
+                .and_modify(|s| {
+                    if s.require_trace.is_none() {
+                        s.require_trace = Some(tree.clone());
+                    }
+                })
+                .or_insert_with(|| PluginStats {
+                    name: GROUP_USER.to_string(),
+                    total_self_ms: 0.0,
+                    total_sourced_ms: 0.0,
+                    file_count: 0,
+                    top_files: Vec::new(),
+                    is_managed: false,
+                    lazy: false,
+                    init_ms: 0.0,
+                    load_ms: 0.0,
+                    trig_ms: 0.0,
+                    require_trace: Some(tree),
+                });
+        }
 
         // eager プラグインの load_ms は instrumentation の有無に関わらず
         // sourcing 合計で近似できるので、marker_s != None 条件の外で先に書く。
@@ -1016,6 +1164,57 @@ mod tests {
         }"#;
         let node = parse_require_trace(json).unwrap();
         assert_eq!(node.self_ms, 0.0);
+    }
+
+    // ── tracer script builder ───────────────────────────────────────────────
+
+    #[test]
+    fn build_tracer_embeds_escaped_output_path() {
+        // Windows の tmp path (スペース含む) が入っても Lua 文字列として安全に
+        // emit されるか。backslash は forward slash に正規化される。
+        let script = build_require_tracer_script(r#"C:\Users\John Doe\AppData\trace.json"#);
+        // 正規化 + 引用後の形
+        assert!(script.contains(r#""C:/Users/John Doe/AppData/trace.json""#));
+        // 未正規化の backslash が残ってないこと
+        assert!(!script.contains(r"C:\Users"));
+    }
+
+    #[test]
+    fn build_tracer_contains_key_hooks() {
+        // tracer の骨格 (require wrap + VimLeavePre dump + package.loaded cache skip
+        // + lazy.nvim 由来の stack-based push/pop) が含まれていること。
+        // VimEnter は headless + +qa で取りこぼすので使わない。
+        let script = build_require_tracer_script("/tmp/trace.json");
+        assert!(script.contains("_G.require = function"));
+        assert!(script.contains("package.loaded[modname]"));
+        assert!(script.contains("VimLeavePre"));
+        assert!(!script.contains("VimEnter"));
+        assert!(script.contains("vim.json.encode"));
+        // hrtime は vim.uv 優先 (0.10+)、fallback で vim.loop
+        assert!(script.contains("vim.uv or vim.loop"));
+    }
+
+    #[test]
+    fn build_tracer_wraps_everything_in_pcall_for_resilience() {
+        // tracer 自身の setup 失敗 / JSON dump 失敗が init.lua の実行を止めない
+        // こと (CLAUDE.md の resilience 原則)。
+        let script = build_require_tracer_script("/tmp/trace.json");
+        // 外側 pcall (setup 全体)
+        assert!(script.contains("ok_setup, err_setup = pcall"));
+        // 内側 pcall (VimEnter dump)
+        assert!(script.contains("ok_dump, err_dump = pcall"));
+        // 失敗時は vim.notify だけで終了
+        assert!(script.contains("vim.notify"));
+    }
+
+    #[test]
+    fn build_tracer_omits_empty_children_to_appease_json_encode() {
+        // vim.json.encode は空 Lua table を `{}` (object) として吐くため、
+        // children が空のノードはフィールド自体を省略する (RawRequireNode の
+        // `#[serde(default)]` で missing 扱いになる)。
+        let script = build_require_tracer_script("/tmp/trace.json");
+        assert!(script.contains("if #entry.children > 0 then"));
+        assert!(script.contains("out.children = c"));
     }
 
     #[test]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -930,18 +930,18 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
         // require tracer が trace.json を吐いていれば [user config] に attach。
         // tracer は VimLeavePre で JSON を書き出すので `+qa` による quit 中に発火する
         // (VimEnter は headless + +qa 構成だと取りこぼすため採用しない)。
+        //
+        // 順序: 先に or_insert_with で空エントリを確定 → post-insert で is_none()
+        // ガードして trace を載せる。and_modify + or_insert_with を併用すると
+        // update 側と insert 側で構造違い (trace のみ / PluginStats 全体) の
+        // 分岐が必要で、`tree.clone()` も強いられるため avoid。average_stats で
+        // 採用した first-populated-wins パターンと同型。
         if let Some((_, trace_path)) = tracer_paths.as_ref()
             && let Ok(raw) = std::fs::read_to_string(trace_path)
             && let Ok(tree) = parse_require_trace(&raw)
         {
-            stats
-                .entry(GROUP_USER.to_string())
-                .and_modify(|s| {
-                    if s.require_trace.is_none() {
-                        s.require_trace = Some(tree.clone());
-                    }
-                })
-                .or_insert_with(|| PluginStats {
+            let user_stats = stats.entry(GROUP_USER.to_string()).or_insert_with(|| {
+                PluginStats {
                     name: GROUP_USER.to_string(),
                     total_self_ms: 0.0,
                     total_sourced_ms: 0.0,
@@ -952,8 +952,12 @@ pub async fn run_profile(cfg: ProfileRunConfig) -> anyhow::Result<ProfileReport>
                     init_ms: 0.0,
                     load_ms: 0.0,
                     trig_ms: 0.0,
-                    require_trace: Some(tree),
-                });
+                    require_trace: None,
+                }
+            });
+            if user_stats.require_trace.is_none() {
+                user_stats.require_trace = Some(tree);
+            }
         }
 
         // eager プラグインの load_ms は instrumentation の有無に関わらず


### PR DESCRIPTION
## Summary

Second PR for #77. [PR #78](https://github.com/yukimemi/rvpm/pull/78) landed the `RequireNode` data model; this one actually fills it in.

- **Tracer Lua script** (`build_require_tracer_script`): lazy.nvim's `util.track()` ported verbatim, wrapped around `_G.require`. Skips cached modules (`package.loaded[modname] ~= nil`), pushes/pops a stack to build the tree, dumps JSON on `VimLeavePre`.
- **Wiring in `run_profile`**: `install_require_tracer(marker_dir, run_index)` writes `require_tracer_<N>.lua` + reserves `require_trace_<N>.json` under the existing phase-marker tempdir. Per-run, the launch args get `--cmd "luafile <tracer.lua>"` so the tracer installs **before init.lua runs** — catching the earliest user `require()` calls. Post-run, the JSON is parsed via `parse_require_trace` (from PR 1) and attached to `[user config]`.
- First-populated semantics for multi-run averages match the `average_stats` regression test introduced in PR 1.

## Why `VimLeavePre`, not `VimEnter`

Initial attempt used `VimEnter`. Manual testing showed the autocmd never fires under `nvim --headless ... +qa` — `+qa` is processed before `VimEnter`, so the process exits without firing it. `VimLeavePre` fires during `:qa` regardless of UI presence. A dedicated test pins this choice so we don't regress back to `VimEnter`.

## Why emit `children` conditionally

`vim.json.encode({})` emits `{}` (JSON object), which `serde_json::from_str::<Vec<_>>` rejects. The Lua side omits the field entirely when the array is empty; the Rust side uses `#[serde(default)]` for `children`, so missing means `Vec::new()`.

## Why everything is pcall'd

CLAUDE.md's resilience rule: a failure in profiling infrastructure must never stop the user's init.lua. Both the setup block and the dump block are wrapped in `pcall`; failures emit `vim.notify(..., WARN)` and nothing else.

## Test plan

- [x] **Unit tests**: 4 new tests on the tracer script itself (path escaping for Windows tempdir-with-spaces, presence of required hooks, pcall resilience, children-omission workaround). 537 total passed (533 from main + 4 new).
- [x] **clippy** `--all-targets -- -D warnings` clean.
- [x] **Manual end-to-end**: `rvpm profile --json --runs 1` against my real Neovim config. `[user config].require_trace` now carries 38 direct requires with multi-level children. For example, `vim.lsp` surfaces as 4.69 ms total with 4 sub-requires (`vim.lsp.log`, `vim.lsp.util`, `vim.lsp._changetracking`, `vim.lsp.rpc`), matching the intuition that `vim.lsp` is an aggregator loading a fan-out.

## Out of scope

- **PR 3** — render the tree in the profile TUI's detail pane when `[user config]` is selected, with `f` (threshold) / `c` (sort toggle) keybindings matching lazy.nvim's Profile view.
- **PR 4** — surface the tree in `--no-tui` plain text and document the JSON schema.

Refs #77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added require-chain tracing to profiling workflow. The profiler now captures module dependencies from initialization startup and exports the require tree as JSON for dependency analysis.

* **Refactor**
  * Adjusted internal function visibility to improve code organization and crate integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->