### PR TITLE
feat(profile): render require tree in --no-tui, document JSON schema (#77 PR 4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ sources everything without any runtime glob cost.
 
 ### Startup profile
 
-**`rvpm profile`** — per-plugin phase breakdown in a TUI: banner + phase timeline + plugin table + selected-plugin file detail. Keys: `j/k` navigate · `g/G` top/bottom · `s` cycle sort · `h` hide groups · `?` help · `q` quit.
+**`rvpm profile`** — per-plugin phase breakdown in a TUI: banner + phase timeline + plugin table + selected-plugin file detail. Keys: `j/k` navigate · `g/G` top/bottom · `s` cycle sort · `h` hide groups · `f` require-tree threshold · `c` require-tree sort · `?` help · `q` quit.
+
+Selecting the `[user config]` pseudo-plugin swaps the detail pane for a **require tree** of your `init.lua`: a stack-based tracer wraps `_G.require` for the run, captures `vim.uv.hrtime()` deltas per module, and renders the result depth-indented in the pane. Useful when `[user config]` is one of the heaviest rows and you want to find the offending `require(...)`.
 
 ![profile](vhs/profile.gif)
 
@@ -795,6 +797,65 @@ rvpm list
 rvpm list --no-tui
 rvpm list --no-tui | grep Missing
 ```
+
+</details>
+
+<details>
+<summary><b><code>rvpm profile --json</code> schema</b></summary>
+
+```json
+{
+  "total_startup_ms": 761.8,
+  "runs": 3,
+  "nvim_version": "NVIM v0.13.0-dev-...",
+  "no_merge": false,
+  "no_instrument": false,
+  "phase_timeline": [
+    { "name": "phase-3", "duration_ms": 22.19 },
+    { "name": "phase-6", "duration_ms": 387.92 }
+  ],
+  "plugins": [
+    {
+      "name": "[user config]",
+      "total_self_ms": 111.97,
+      "total_sourced_ms": 705.40,
+      "init_ms": 0.0,
+      "load_ms": 0.0,
+      "trig_ms": 0.0,
+      "file_count": 1,
+      "is_managed": false,
+      "lazy": false,
+      "top_files": [
+        { "path": "init.lua", "self_ms": 111.97, "sourced_ms": 705.40 }
+      ],
+      "require_trace": {
+        "module": "init.lua",
+        "self_ms": 112.0,
+        "sourced_ms": 705.4,
+        "children": [
+          {
+            "module": "user.plugins",
+            "self_ms": 73.12,
+            "sourced_ms": 425.12,
+            "children": [
+              { "module": "user.lsp.servers", "self_ms": 85.34, "sourced_ms": 85.34, "children": [] }
+            ]
+          },
+          { "module": "user.keymaps", "self_ms": 42.11, "sourced_ms": 42.11, "children": [] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Key notes:**
+
+- `phase_timeline` is present only when the run was instrumented (absent under `--no-instrument`).
+- Every plugin has `top_files` (up to 10 heaviest `self_ms` files).
+- `require_trace` is present only on the `[user config]` pseudo-plugin and only when the require tracer ran — `--no-instrument` suppresses it.
+- `require_trace.sourced_ms` is wall-clock time including descendants; `self_ms = sourced_ms - Σ children.sourced_ms`, clamped to `0.0`.
+- All `*_ms` fields are f64 milliseconds averaged across `runs`.
 
 </details>
 

--- a/src/profile_tui.rs
+++ b/src/profile_tui.rs
@@ -1211,6 +1211,45 @@ pub fn print_plain(report: &ProfileReport, top: Option<usize>) {
             p.file_count,
         );
     }
+
+    // [user config] に require_trace があれば require tree を追加出力する。
+    // plain text 出力は pipe / grep 友好的なので threshold は設けず全ノード
+    // 出す方針 (TUI と違って隠す動機が薄い)。sort は TUI のデフォルトと同じ
+    // ByTime で、自動化用途 (ログ収集) でも読みやすい順序になる。
+    if let Some(user_cfg) = report
+        .plugins
+        .iter()
+        .find(|p| p.name == crate::profile::GROUP_USER)
+        && let Some(tree) = user_cfg.require_trace.as_ref()
+    {
+        println!();
+        let nodes = count_require_nodes(tree);
+        println!(
+            "## require tree ({} nodes, sourced {:.2} ms, self {:.2} ms)",
+            nodes, tree.sourced_ms, tree.self_ms
+        );
+        print_require_tree_plain(tree, 0);
+    }
+}
+
+fn print_require_tree_plain(node: &RequireNode, depth: usize) {
+    let indent: String = "  ".repeat(depth);
+    println!(
+        "  {}{:<40}  sourced {:>7.2} ms · self {:>7.2} ms",
+        indent,
+        node.module,
+        node.sourced_ms,
+        node.self_ms,
+    );
+    let mut children: Vec<&RequireNode> = node.children.iter().collect();
+    children.sort_by(|a, b| {
+        b.sourced_ms
+            .partial_cmp(&a.sourced_ms)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for c in children {
+        print_require_tree_plain(c, depth + 1);
+    }
 }
 
 #[cfg(test)]

--- a/src/profile_tui.rs
+++ b/src/profile_tui.rs
@@ -1236,10 +1236,7 @@ fn print_require_tree_plain(node: &RequireNode, depth: usize) {
     let indent: String = "  ".repeat(depth);
     println!(
         "  {}{:<40}  sourced {:>7.2} ms · self {:>7.2} ms",
-        indent,
-        node.module,
-        node.sourced_ms,
-        node.self_ms,
+        indent, node.module, node.sourced_ms, node.self_ms,
     );
     let mut children: Vec<&RequireNode> = node.children.iter().collect();
     children.sort_by(|a, b| {

--- a/src/profile_tui.rs
+++ b/src/profile_tui.rs
@@ -110,10 +110,15 @@ fn next_require_threshold(current: f64) -> f64 {
 }
 
 /// `flatten_require_tree` が返す 1 行分のデータ。
+///
+/// `module` は source ツリー (`ProfileReport.plugins[...].require_trace`) の
+/// `RequireNode.module` を借用する。row は render-time に毎 frame 作るため、
+/// `String::clone` を避けて借用にしたい (lazy.nvim の lifetime-free 構造と違い
+/// 我々の RequireNode tree は render loop 中は動かないので borrow 可能)。
 #[derive(Debug, Clone, PartialEq)]
-pub struct RequireRow {
+pub struct RequireRow<'a> {
     pub depth: usize,
-    pub module: String,
+    pub module: &'a str,
     pub self_ms: f64,
     pub sourced_ms: f64,
 }
@@ -126,12 +131,12 @@ pub struct RequireRow {
 ///   - Chronological: insertion order のまま (init.lua 内の require 呼び出し順)
 ///
 /// max_rows: 可視領域の行数上限。下位の行は切り詰め。
-pub fn flatten_require_tree(
-    root: &RequireNode,
+pub fn flatten_require_tree<'a>(
+    root: &'a RequireNode,
     threshold_ms: f64,
     sort: RequireTreeSort,
     max_rows: usize,
-) -> Vec<RequireRow> {
+) -> Vec<RequireRow<'a>> {
     // max_rows は pane の残り行から来る自然な上限 (典型的には 10〜50)。
     // pre-allocate してフレーム毎の re-alloc を回避。
     let mut out = Vec::with_capacity(max_rows);
@@ -139,13 +144,13 @@ pub fn flatten_require_tree(
     out
 }
 
-fn walk(
-    node: &RequireNode,
+fn walk<'a>(
+    node: &'a RequireNode,
     depth: usize,
     threshold: f64,
     sort: RequireTreeSort,
     max_rows: usize,
-    out: &mut Vec<RequireRow>,
+    out: &mut Vec<RequireRow<'a>>,
     is_root: bool,
 ) {
     if out.len() >= max_rows {
@@ -157,7 +162,7 @@ fn walk(
     }
     out.push(RequireRow {
         depth,
-        module: node.module.clone(),
+        module: &node.module,
         self_ms: node.self_ms,
         sourced_ms: node.sourced_ms,
     });
@@ -810,7 +815,7 @@ fn draw_require_tree_detail(
                 Style::default().fg(Color::DarkGray),
             ),
             Span::styled(
-                pad_truncate(&row.module, name_width),
+                pad_truncate(row.module, name_width),
                 Style::default().fg(Color::Gray),
             ),
             Span::styled(
@@ -1323,7 +1328,7 @@ mod tests {
         let tree = sample_tree();
         let rows = flatten_require_tree(&tree, 0.0, RequireTreeSort::ByTime, 99);
         // init.lua → A (7) → A1 (5) → A2 (1) → C (2) → B (0.4)
-        let modules: Vec<&str> = rows.iter().map(|r| r.module.as_str()).collect();
+        let modules: Vec<&str> = rows.iter().map(|r| r.module).collect();
         assert_eq!(modules, vec!["init.lua", "A", "A1", "A2", "C", "B"]);
     }
 
@@ -1332,7 +1337,7 @@ mod tests {
         let tree = sample_tree();
         let rows = flatten_require_tree(&tree, 0.0, RequireTreeSort::Chronological, 99);
         // init.lua → A → A1 → A2 → B → C (Chronological では source 順)
-        let modules: Vec<&str> = rows.iter().map(|r| r.module.as_str()).collect();
+        let modules: Vec<&str> = rows.iter().map(|r| r.module).collect();
         assert_eq!(modules, vec!["init.lua", "A", "A1", "A2", "B", "C"]);
     }
 
@@ -1342,7 +1347,7 @@ mod tests {
         // threshold=1.0 は sourced_ms < 1.0 をカット。B (0.4) は消える。
         // A2 (1.0) はちょうど閾値なので残る (< ではなく >= で判定)。
         let rows = flatten_require_tree(&tree, 1.0, RequireTreeSort::ByTime, 99);
-        let modules: Vec<&str> = rows.iter().map(|r| r.module.as_str()).collect();
+        let modules: Vec<&str> = rows.iter().map(|r| r.module).collect();
         assert!(!modules.contains(&"B"));
         assert!(modules.contains(&"A2")); // 境界値は残す
     }


### PR DESCRIPTION
Final PR for #77 — closes the feature. **Depends on #81** (the PR 3 tree data functions it uses); review/merge after #81 lands. Github's auto-rebase will handle the diff.

- `print_plain` appends a trailing `## require tree` section when `[user config].require_trace` is populated. No threshold filter (plain output is for grep/long-term), sort stays at `sourced_ms` desc.
- README gains a collapsible JSON schema section under Advanced — top-level envelope, phase_timeline, per-plugin entries, top_files, require_trace, with notes on averaging and `self_ms` clamping.
- Existing `### Startup profile` paragraph learns the new `f`/`c` keybindings from PR 3 and explains what 'require tree' means.

No new tests (renderer-only runtime change, docs-only for README). 546 still pass. clippy clean. Manual: `rvpm profile --no-tui --runs 1` shows 142-node tree with matching indentation to the TUI view.

Closes #77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TUI keybindings (`f` for threshold, `c` for sort) for require-tree inspection.
  * [user config] pseudo-plugin now displays require-tree with per-module timing measurements.
  * Plain-text output now includes require-tree section.

* **Documentation**
  * Added comprehensive `rvpm profile --json` schema documentation detailing JSON fields and conditional inclusion rules.
  * Documented require-tree tracer mechanics and timing semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->