### PR TITLE
fix(profile): focus feedback on both panes, honest require-tree root label

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,7 @@ rvpm list --no-tui | grep Missing
 - Every plugin has `top_files` (up to 10 heaviest `self_ms` files).
 - `require_trace` is present only on the `[user config]` pseudo-plugin and only when the require tracer ran — `--no-instrument` suppresses it.
 - `require_trace.sourced_ms` is wall-clock time including descendants; `self_ms = sourced_ms - Σ children.sourced_ms`, clamped to `0.0`.
-- `require_trace.module == "(startup)"` at the root — the tracer is installed via `--cmd luafile`, so the root covers the whole span from Neovim process start to `VimLeavePre`, not just user `init.lua`. Plugin-table `total` for `[user config]` is a different scope (just the `sourcing init.lua` entry from `--startuptime`), so the two numbers won't match and that's expected.
+- `require_trace.module == "(startup)"` at the root — the tracer is installed via `--cmd luafile`, so the root covers the whole span from Neovim process start to `VimLeavePre`, not just user `init.lua`. Plugin-table `total` for `[user config]` is a different scope (the sum of `--startuptime` `sourcing` entries for every file rvpm attributes to the config roots, typically `init.lua` plus the global `before.lua` / `after.lua` hooks), so the two numbers won't match and that's expected.
 - All `*_ms` fields are f64 milliseconds averaged across `runs`.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ rvpm list --no-tui | grep Missing
         { "path": "init.lua", "self_ms": 111.97, "sourced_ms": 705.40 }
       ],
       "require_trace": {
-        "module": "init.lua",
+        "module": "(startup)",
         "self_ms": 112.0,
         "sourced_ms": 705.4,
         "children": [
@@ -855,6 +855,7 @@ rvpm list --no-tui | grep Missing
 - Every plugin has `top_files` (up to 10 heaviest `self_ms` files).
 - `require_trace` is present only on the `[user config]` pseudo-plugin and only when the require tracer ran — `--no-instrument` suppresses it.
 - `require_trace.sourced_ms` is wall-clock time including descendants; `self_ms = sourced_ms - Σ children.sourced_ms`, clamped to `0.0`.
+- `require_trace.module == "(startup)"` at the root — the tracer is installed via `--cmd luafile`, so the root covers the whole span from Neovim process start to `VimLeavePre`, not just user `init.lua`. Plugin-table `total` for `[user config]` is a different scope (just the `sourcing init.lua` entry from `--startuptime`), so the two numbers won't match and that's expected.
 - All `*_ms` fields are f64 milliseconds averaged across `runs`.
 
 </details>

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -176,7 +176,11 @@ pub fn build_require_tracer_script(trace_path: &str) -> String {
 local ok_setup, err_setup = pcall(function()
   local trace_path = {path}
   local hrtime = (vim.uv or vim.loop).hrtime
-  local root = {{ module = "init.lua", time = hrtime(), children = {{}} }}
+  -- "(startup)" で測定スコープの広さ (`--cmd luafile` ロード時点から
+  -- `VimLeavePre` まで、nvim runtime の pre-init.lua 分も含む) を明示する。
+  -- 以前は "init.lua" というラベルだったが、startuptime の init.lua sourcing 行
+  -- (ユーザ init.lua 自体の self 経過時間) と値が噛み合わず混乱を招いた。
+  local root = {{ module = "(startup)", time = hrtime(), children = {{}} }}
   local stack = {{ root }}
   local orig_require = _G.require
   _G.require = function(modname)

--- a/src/profile_tui.rs
+++ b/src/profile_tui.rs
@@ -841,7 +841,11 @@ fn draw_plugin_table(f: &mut Frame, area: Rect, state: &mut ProfileTuiState) {
             .title(title)
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::DarkGray)),
+            .border_style(Style::default().fg(if state.focus == Focus::Table {
+                Color::Magenta
+            } else {
+                Color::DarkGray
+            })),
     )
     .row_highlight_style(
         Style::default()
@@ -1027,8 +1031,12 @@ fn draw_require_tree_detail(
         ]));
     }
 
+    // tree の self/sourced は tracer スコープ (--cmd luafile から VimLeavePre まで
+    // の全期間) の値、init.lua は startuptime が報告する init.lua ファイル自身の
+    // self_ms (Lua require の内訳は含まない)。スコープが違うので並べて表示する
+    // 際は「何を指した数字か」を明示する。
     let summary = format!(
-        "  self {:.2}  sourced {:.2}  /  total {:.2} ms",
+        "  tree self {:.2} ms · sourced {:.2} ms · init.lua file {:.2} ms",
         tree.self_ms, tree.sourced_ms, plugin.total_self_ms
     );
     let title = Line::from(vec![
@@ -1169,12 +1177,19 @@ fn draw_detail(f: &mut Frame, area: Rect, state: &ProfileTuiState) {
         ),
         Span::styled(summary, Style::default().fg(Color::Gray)),
     ]);
+    // Tab で focus が Detail に来たとき、[user config] 以外の plugin でも枠色で
+    // フィードバックする。そうしないと「Tab 押したのに何も起きてない」に見える。
+    let border_color = if state.focus == Focus::Detail {
+        Color::Magenta
+    } else {
+        Color::DarkGray
+    };
     let widget = Paragraph::new(lines).block(
         Block::default()
             .title(title)
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::DarkGray)),
+            .border_style(Style::default().fg(border_color)),
     );
     f.render_widget(widget, area);
 }

--- a/src/profile_tui.rs
+++ b/src/profile_tui.rs
@@ -1032,11 +1032,13 @@ fn draw_require_tree_detail(
     }
 
     // tree の self/sourced は tracer スコープ (--cmd luafile から VimLeavePre まで
-    // の全期間) の値、init.lua は startuptime が報告する init.lua ファイル自身の
-    // self_ms (Lua require の内訳は含まない)。スコープが違うので並べて表示する
-    // 際は「何を指した数字か」を明示する。
+    // の全期間) の値。config self は `aggregate_single_run` が [user config]
+    // 擬似プラグインに振り分けた全ファイル (init.lua + global before.lua +
+    // global after.lua など) の startuptime self_ms の合計で、Lua require の
+    // 内訳は含まない。スコープが違うので並べて表示する際は「何を指した数字か」
+    // を明示する。
     let summary = format!(
-        "  tree self {:.2} ms · sourced {:.2} ms · init.lua file {:.2} ms",
+        "  tree self {:.2} ms · sourced {:.2} ms · config self {:.2} ms",
         tree.self_ms, tree.sourced_ms, plugin.total_self_ms
     );
     let title = Line::from(vec![


### PR DESCRIPTION
Follow-up on PR #83 after real-config testing surfaced three UX issues.

## 1. Tab felt frozen on non-[user config] plugins
Only the [user config] detail pane changed border color on focus switch. Every other plugin's pane stayed DarkGray → Tab toggled focus internally but looked like it was lost, and j/k did nothing because those plugins have no require_tree.

Fix: both `draw_plugin_table` and the non-tree `draw_detail` branch now paint their border Magenta when focused. j/k staying no-op on a static top_files list is fine once the border color signals "you're here".

## 2. Tree root "init.lua" was misleading
The tracer is installed via `--cmd luafile`, so its root span is "tracer install → VimLeavePre" — that includes all Neovim runtime loading before user init.lua starts. Labeling the whole span "init.lua" suggested the user's init.lua took 400+ ms when really it's ~70ms and the rest is pre-init.lua runtime work.

Rename to `"(startup)"` — matches the actual scope, parenthesized form also flags it as synthetic vs. real module names.

## 3. Banner mixed two incompatible scopes
`self A  sourced B  /  total C` stuck tracer-scope (A, B) and startuptime-scope (C) together, inviting "these should add up". They shouldn't — they measure different things.

Rebuilt as: `tree self X ms · sourced Y ms · init.lua file Z ms`. The three labels now make the scope difference obvious.

## README

JSON schema example now shows `"module": "(startup)"`, and a note in the schema keys explains why `require_trace` root totals won't match the plugin-table `total` for `[user config]` — expected scope difference, not a bug.

## Test plan

- 549 still pass (root module name is fixture in parser tests, not load-bearing).
- clippy clean.
- Manual: `rvpm profile --no-tui` prints `## require tree (70 nodes, sourced 393.90 ms, self 369.22 ms)` with `(startup)` at the root.

Addresses user feedback after #83 merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin table and detail panel borders now highlight when in focus for improved visual feedback.

* **Improvements**
  * Root node of require trace now correctly labeled as "(startup)" instead of "init.lua".
  * Detail panel summary text now explicitly labels components (tree self, sourced, config self).

* **Documentation**
  * Updated require trace example with corrected root module label and added tracer scope explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->