### PR TITLE
feat(add): AI-powered config via claude / gemini / codex CLI (closes #93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,15 @@ concurrency = 16
 #   "always"        — scan 結果を無条件採用 (スクリプト用)
 #   "never"         — scan skip、eager add
 # auto_lazy = "ask"
+# `rvpm add` を AI CLI に委譲する場合のバックエンド (#93)。
+#   "off" (default) — 静的 scan + auto_lazy フローを使う
+#   "claude" / "gemini" / "codex" — 該当 CLI を subprocess で起動
+# CLI が未インストールならエラー。`auto_lazy` は無視される。
+# CLI flag `--ai claude` / `--no-ai` で per-call 上書き可能。
+# ai = "claude"
+# AI 出力の自然言語 (explanation 本文 + chat 応答)。default "en"。
+# XML tag 構造そのものは英語固定 (parse 安定性のため)。
+# ai_language = "ja"
 
 [options.browse]
 # README 表示を外部コマンドに委譲する (browse TUI 専用)。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
  "unicode-width",
  "wait-timeout",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -4825,6 +4826,15 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ regex = "1"
 toml = "1.1"
 toml_edit = "0.25"
 
+# CLI subprocess discovery (`claude` / `gemini` / `codex` on PATH for AI add #93).
+which = "8"
+
 # Markdown rendering (for store TUI README preview).
 # `highlight-code` brings in syntect + ansi-to-tui (~4 MB of syntax / theme
 # data) but is the only way to make fenced code blocks readable — without it

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ for fully isolated test configs.
 | `auto_helptags` | `boolean` | `true` | `sync` / `generate` run `nvim --headless` once at the end to build helptags for every plugin's `doc/`. Skipped with a warning if `nvim` is missing |
 | `url_style` | `"short"` \| `"full"` | `"short"` | How `rvpm add` writes GitHub plugin URLs. Duplicate detection normalizes between styles |
 | `fetch_interval` | duration string (`"6h"`, `"30m"`, `"45s"`, `"1d"`, `"0"`) | `"6h"` | Per-plugin fetch cache window. `sync` skips `git fetch` for plugins pulled within the last *fetch_interval*. Accepted units: `s` / `m` / `h` / `d`. Set to `"0"` to disable caching (pre-v3.19 behavior). Override per-run with `rvpm sync --refresh` / `--no-refresh` |
-| `auto_lazy` | `"ask"` \| `"always"` \| `"never"` | `"ask"` | How `rvpm add` (and `rvpm browse → Enter`) handles the post-clone scan that looks for `nvim_create_user_command` / keymaps in the plugin's `plugin/` + `ftplugin/` + `after/plugin/` + `lua/` dirs. `"ask"` (default) prompts interactively on TTY and skips silently on non-TTY. `"always"` accepts the suggestion unconditionally. `"never"` skips the scan entirely. Per-call override via `--auto-lazy` / `--no-lazy` on `rvpm add`. Accepted suggestions cluster commands by 3-char LCP (3+ char shared prefix becomes `/^Prefix/` regex so future commands in that family auto-load) and enumerate keymaps (maps don't LCP well) |
+| `auto_lazy` | `"ask"` \| `"always"` \| `"never"` | `"ask"` | How `rvpm add` (and `rvpm browse → Enter`) handles the post-clone scan that looks for `nvim_create_user_command` / keymaps in the plugin's `plugin/` + `ftplugin/` + `after/plugin/` + `lua/` dirs. `"ask"` (default) prompts interactively on TTY and skips silently on non-TTY. `"always"` accepts the suggestion unconditionally. `"never"` skips the scan entirely. Per-call override via `--auto-lazy` / `--no-lazy` on `rvpm add`. Accepted suggestions cluster commands by 3-char LCP (3+ char shared prefix becomes `/^Prefix/` regex so future commands in that family auto-load) and enumerate keymaps (maps don't LCP well). **Ignored when `ai != "off"`** — the AI handles the design end-to-end |
+| `ai` | `"off"` \| `"claude"` \| `"gemini"` \| `"codex"` | `"off"` | Use an AI CLI to design the full `[[plugins]]` block (plus per-plugin hook files) on `rvpm add`. The chosen CLI must already be installed and authenticated (`claude login`, `gemini auth`, etc.) — rvpm doesn't manage API keys. When set, the static-scan + auto-lazy path is skipped entirely. After the AI proposes, you can apply, refine via chat, hand off to the native CLI for free-form follow-up, or skip. Per-call override via `--ai <backend>` / `--no-ai` on `rvpm add` |
+| `ai_language` | string | `"en"` | Natural language for the AI's `<rvpm:explanation>` body and chat replies. The XML tag structure itself is always English so parsing stays predictable. Accepts BCP-47-ish codes (`"en"`, `"ja"`, `"zh"`, `"de"`) or free-form names |
 
 > **💡 Leave `config_root` / `cache_root` unset.** Defaults are already
 > `<appname>`-aware. Setting a literal path (e.g. `cache_root = "~/dotfiles/rvpm"`)
@@ -287,6 +289,60 @@ on_map = [
 | `lhs` | `string` | **(required)** | Key sequence that triggers loading |
 | `mode` | `string \| string[]` | `"n"` | Vim mode(s) for the keymap (`"n"`, `"x"`, `"i"`, etc.) |
 | `desc` | `string` | none | Description shown in `:map` / which-key **before** the plugin is loaded |
+
+</details>
+
+<details>
+<summary><b>AI-powered <code>rvpm add</code> (claude / gemini / codex)</b></summary>
+
+Set `options.ai` to a CLI you have installed and authenticated, and `rvpm add`
+delegates the design of the `[[plugins]]` entry to the AI:
+
+```toml
+[options]
+ai = "claude"           # "off" (default) | "claude" | "gemini" | "codex"
+ai_language = "en"      # explanation language; structural output stays English
+```
+
+Or per-call: `rvpm add owner/repo --ai claude`. The flag overrides the config
+value for that one invocation; `--no-ai` forces the static-scan path.
+
+What it does:
+
+1. Clones the plugin (same as the regular path).
+2. Builds a prompt from rvpm's TOML schema, the plugin's `README` + `doc/`,
+   and your current `config.toml` + `plugins/` tree.
+3. Invokes the chosen CLI one-shot (`claude -p` / `gemini -p` / `codex exec`).
+4. Parses the response (XML tags `<rvpm:plugin_entry>`, `<rvpm:init_lua>`,
+   `<rvpm:before_lua>`, `<rvpm:after_lua>`, `<rvpm:explanation>`).
+5. Shows you the proposal and asks: **Apply / Chat / Hand off / Skip**.
+
+**Apply** writes the proposed entry to `config.toml` and creates the proposed
+hook files under `{config_root}/plugins/<host>/<owner>/<repo>/`. Existing
+hook files are never overwritten.
+
+**Chat** lets you give one-line feedback ("also add depends on plenary",
+"actually, I want this eager"); rvpm rebuilds the prompt with your message
+and the previous proposal, fetches an updated proposal, and re-prompts.
+
+**Hand off** spawns the chosen CLI in interactive mode with the same prompt
+preloaded. **rvpm exits at this point** — your subsequent conversation is
+between you and the CLI, and the CLI's own file-editing tools (Edit / Write
+in claude-code, etc.) are responsible for any further changes to
+`config.toml` or hook files. rvpm does not re-import the result.
+
+**Skip** discards the proposal but leaves the stub `[[plugins]]` entry that
+was written before the AI was invoked, so you can edit it manually.
+
+Requirements:
+
+- The chosen CLI must be on `PATH`.
+- It must be authenticated (rvpm doesn't manage API keys — it uses your
+  existing CLI session).
+- Network access for the CLI to talk to its provider.
+
+When AI mode is active, the `auto_lazy` setting and the `--auto-lazy` /
+`--no-lazy` flags are ignored — the AI handles trigger selection.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -325,11 +325,20 @@ hook files are never overwritten.
 "actually, I want this eager"); rvpm rebuilds the prompt with your message
 and the previous proposal, fetches an updated proposal, and re-prompts.
 
-**Hand off** spawns the chosen CLI in interactive mode with the same prompt
-preloaded. **rvpm exits at this point** — your subsequent conversation is
-between you and the CLI, and the CLI's own file-editing tools (Edit / Write
-in claude-code, etc.) are responsible for any further changes to
-`config.toml` or hook files. rvpm does not re-import the result.
+**Hand off** saves the latest prompt (initial + any chat refinements you
+made) to a temp file, announces the path, and spawns the chosen CLI in
+interactive mode with stdio inherited from your terminal. **rvpm hands
+control over to the CLI** — load the saved prompt with the CLI's own
+file-reading mechanism (e.g. `cat <path>` in claude-code, or copy-paste).
+Your subsequent conversation is between you and the CLI, and its own
+file-editing tools (Edit / Write in claude-code, etc.) are responsible
+for any further changes to `config.toml` or hook files. rvpm does not
+re-import the result.
+
+> **Why a saved file instead of stdin pipe?** Tools like `claude-code`
+> exit immediately when stdin closes, so a piped prompt can't keep the
+> session interactive. The temp-file approach gives you the full prompt
+> *and* an interactive session.
 
 **Skip** discards the proposal but leaves the stub `[[plugins]]` entry that
 was written before the AI was invoked, so you can edit it manually.

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -72,7 +72,7 @@ pub async fn run_ai_add(
     let mut proposal = parse_and_validate(&prior_response)?;
 
     loop {
-        print_proposal_preview(&proposal);
+        print_proposal_preview(&proposal, plugin_config_dir, user_config_toml_path);
 
         match prompt_chat_action().await? {
             ChatAction::Apply => {
@@ -178,49 +178,65 @@ fn parse_and_validate(response: &str) -> Result<Proposal> {
     Ok(proposal)
 }
 
-fn print_proposal_preview(p: &Proposal) {
+fn print_proposal_preview(p: &Proposal, plugin_config_dir: &Path, config_toml_path: &Path) {
+    let rule = "\u{2500}".repeat(60);
     eprintln!();
-    eprintln!("\u{1f4dd} Proposed [[plugins]] entry:");
     eprintln!(
-        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+        "\u{1f4dd} [[plugins]] entry to merge into {}:",
+        config_toml_path.display()
     );
+    eprintln!("{rule}");
     for line in p.plugin_entry_toml.lines() {
         eprintln!("  {line}");
     }
-    if let Some(init) = &p.init_lua {
-        eprintln!();
-        eprintln!("\u{1f4c4} Will create init.lua:");
-        for line in init.lines().take(20) {
-            eprintln!("  {line}");
-        }
-        if init.lines().count() > 20 {
-            eprintln!("  ...");
-        }
-    }
-    if let Some(before) = &p.before_lua {
-        eprintln!();
-        eprintln!("\u{1f4c4} Will create before.lua:");
-        for line in before.lines().take(20) {
-            eprintln!("  {line}");
-        }
-        if before.lines().count() > 20 {
-            eprintln!("  ...");
-        }
-    }
-    if let Some(after) = &p.after_lua {
-        eprintln!();
-        eprintln!("\u{1f4c4} Will create after.lua:");
-        for line in after.lines().take(20) {
-            eprintln!("  {line}");
-        }
-        if after.lines().count() > 20 {
-            eprintln!("  ...");
-        }
-    }
+
+    print_hook_section(p.init_lua.as_deref(), plugin_config_dir, "init.lua", &rule);
+    print_hook_section(
+        p.before_lua.as_deref(),
+        plugin_config_dir,
+        "before.lua",
+        &rule,
+    );
+    print_hook_section(
+        p.after_lua.as_deref(),
+        plugin_config_dir,
+        "after.lua",
+        &rule,
+    );
+
     eprintln!();
     eprintln!("\u{1f4ad} AI explanation:");
     for line in p.explanation.lines() {
         eprintln!("  {line}");
     }
     eprintln!();
+}
+
+fn print_hook_section(body: Option<&str>, plugin_dir: &Path, name: &str, rule: &str) {
+    let Some(body) = body else { return };
+    let path = plugin_dir.join(name);
+    let exists = path.exists();
+    let line_count = body.lines().count();
+
+    eprintln!();
+    if exists {
+        eprintln!(
+            "\u{1f4c4} {} already exists ({} line proposal will be skipped to preserve your edits):",
+            path.display(),
+            line_count,
+        );
+    } else {
+        eprintln!(
+            "\u{1f4c4} Will create {} ({} lines):",
+            path.display(),
+            line_count
+        );
+    }
+    eprintln!("{rule}");
+    for line in body.lines().take(20) {
+        eprintln!("  {line}");
+    }
+    if line_count > 20 {
+        eprintln!("  ... ({} more lines)", line_count - 20);
+    }
 }

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -1,0 +1,207 @@
+// AI add の interactive chat loop (Mode A) と applied 提案の preview/apply UI。
+//
+// Mode B (handoff) は `mod.rs` の `run_handoff` に分離。
+
+use crate::ai::prompt::{build_followup_prompt, build_initial_prompt, collect_plugins_tree};
+use crate::ai::{
+    Backend, Proposal, ensure_cli_installed, invoke_oneshot, parse_proposal, run_handoff,
+    validate_proposal_toml, write_hook_files,
+};
+use anyhow::{Context, Result};
+use dialoguer::{Input, Select, theme::ColorfulTheme};
+use std::path::{Path, PathBuf};
+
+/// chat loop の終了アクション。
+pub enum ChatOutcome {
+    /// user が apply を選択。AI 提案を config.toml + hook ファイルに反映済み。
+    Applied { written_hooks: Vec<PathBuf> },
+    /// user が skip を選択。何も反映しない。
+    Skipped,
+    /// user が handoff を選択。CLI ツールを直接起動済み (rvpm 側の処理は終了)。
+    HandedOff,
+}
+
+/// AI mode の add 全体エントリ。
+///
+/// 引数:
+///   - `backend`: 使う CLI (`Claude` / `Gemini` / `Codex`)
+///   - `plugin_url`: user が `rvpm add` で渡した URL (config 書き込み時の同定用)
+///   - `plugin_root`: clone 済みプラグインの実パス (README/doc 抽出元)
+///   - `config_root`: per-plugin hook を書く先のルート
+///   - `user_config_toml_path`: user の `config.toml` (read-only に渡す参考情報、書き込みは呼び出し側)
+///   - `ai_language`: explanation/chat の言語 (`"en"` / `"ja"` 等)
+///
+/// 戻り値:
+///   - `Ok(ChatOutcome::Applied { plugin_entry_toml, written_hooks })` —
+///     呼び出し側 (`run_add`) が `plugin_entry_toml` を `config.toml` に append。
+///   - `Ok(ChatOutcome::Skipped)` — user 取り消し。
+///   - `Ok(ChatOutcome::HandedOff)` — Mode B エスケープ済み。
+///   - `Err(_)` — CLI 不在 / network / parse 不能 等。
+pub async fn run_ai_add(
+    backend: Backend,
+    plugin_url: &str,
+    plugin_root: &Path,
+    config_root: &Path,
+    user_config_toml_path: &Path,
+    ai_language: &str,
+) -> Result<AiAddOutcome> {
+    ensure_cli_installed(backend)?;
+
+    let user_config_toml = std::fs::read_to_string(user_config_toml_path)
+        .with_context(|| format!("failed to read {}", user_config_toml_path.display()))?;
+    let user_plugins_tree = collect_plugins_tree(config_root);
+
+    let initial_prompt = build_initial_prompt(
+        plugin_url,
+        plugin_root,
+        &user_config_toml,
+        &user_plugins_tree,
+        ai_language,
+    )?;
+
+    eprintln!(
+        "\u{1f916} Asking {} about {} (this may take a moment)...",
+        backend.label(),
+        plugin_url
+    );
+
+    // 最初の turn
+    let mut prior_response = invoke_oneshot(backend, &initial_prompt).await?;
+    let mut proposal = parse_and_validate(&prior_response)?;
+
+    loop {
+        print_proposal_preview(&proposal);
+
+        let action = match prompt_chat_action()? {
+            ChatAction::Apply => {
+                let written = write_hook_files(config_root, plugin_url, &proposal)?;
+                return Ok(AiAddOutcome {
+                    outcome: ChatOutcome::Applied {
+                        written_hooks: written,
+                    },
+                    proposal: Some(proposal),
+                });
+            }
+            ChatAction::Skip => {
+                return Ok(AiAddOutcome {
+                    outcome: ChatOutcome::Skipped,
+                    proposal: None,
+                });
+            }
+            ChatAction::HandOff => {
+                run_handoff(backend, &initial_prompt)?;
+                return Ok(AiAddOutcome {
+                    outcome: ChatOutcome::HandedOff,
+                    proposal: None,
+                });
+            }
+            ChatAction::Chat => ChatAction::Chat,
+        };
+
+        // chat — user の追加要求を 1 行受けて follow-up prompt 構築
+        let _ = action;
+        let followup: String = Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Your feedback for the AI")
+            .interact_text()?;
+        if followup.trim().is_empty() {
+            eprintln!("(empty feedback, returning to action menu)");
+            continue;
+        }
+
+        let next_prompt = build_followup_prompt(&initial_prompt, &prior_response, &followup);
+        eprintln!(
+            "\u{1f916} Asking {} for an updated proposal...",
+            backend.label()
+        );
+        prior_response = invoke_oneshot(backend, &next_prompt).await?;
+        proposal = parse_and_validate(&prior_response)?;
+    }
+}
+
+/// `run_ai_add` の戻り値。Applied 時は `proposal` から `plugin_entry_toml` を取り出して
+/// config.toml に書き込むのが呼び出し側 (`run_add`) の責務。
+pub struct AiAddOutcome {
+    pub outcome: ChatOutcome,
+    pub proposal: Option<Proposal>,
+}
+
+#[derive(Clone, Copy)]
+enum ChatAction {
+    Apply,
+    Chat,
+    HandOff,
+    Skip,
+}
+
+fn prompt_chat_action() -> Result<ChatAction> {
+    let choices = [
+        "Apply (write to config.toml + create hook files)",
+        "Chat (refine with feedback)",
+        "Hand off to native CLI (rvpm exits, AI continues directly)",
+        "Skip (discard proposal, no changes)",
+    ];
+    let sel = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("How should we proceed?")
+        .items(choices.as_slice())
+        .default(0)
+        .interact()?;
+    Ok(match sel {
+        0 => ChatAction::Apply,
+        1 => ChatAction::Chat,
+        2 => ChatAction::HandOff,
+        _ => ChatAction::Skip,
+    })
+}
+
+fn parse_and_validate(response: &str) -> Result<Proposal> {
+    let proposal = parse_proposal(response)?;
+    validate_proposal_toml(&proposal.plugin_entry_toml)?;
+    Ok(proposal)
+}
+
+fn print_proposal_preview(p: &Proposal) {
+    eprintln!();
+    eprintln!("\u{1f4dd} Proposed [[plugins]] entry:");
+    eprintln!(
+        "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}"
+    );
+    for line in p.plugin_entry_toml.lines() {
+        eprintln!("  {line}");
+    }
+    if let Some(init) = &p.init_lua {
+        eprintln!();
+        eprintln!("\u{1f4c4} Will create init.lua:");
+        for line in init.lines().take(20) {
+            eprintln!("  {line}");
+        }
+        if init.lines().count() > 20 {
+            eprintln!("  ...");
+        }
+    }
+    if let Some(before) = &p.before_lua {
+        eprintln!();
+        eprintln!("\u{1f4c4} Will create before.lua:");
+        for line in before.lines().take(20) {
+            eprintln!("  {line}");
+        }
+        if before.lines().count() > 20 {
+            eprintln!("  ...");
+        }
+    }
+    if let Some(after) = &p.after_lua {
+        eprintln!();
+        eprintln!("\u{1f4c4} Will create after.lua:");
+        for line in after.lines().take(20) {
+            eprintln!("  {line}");
+        }
+        if after.lines().count() > 20 {
+            eprintln!("  ...");
+        }
+    }
+    eprintln!();
+    eprintln!("\u{1f4ad} AI explanation:");
+    for line in p.explanation.lines() {
+        eprintln!("  {line}");
+    }
+    eprintln!();
+}

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -165,17 +165,31 @@ async fn prompt_chat_action() -> Result<ChatAction> {
     })
 }
 
-/// follow-up テキスト入力も同様に worker thread で待つ。
+/// follow-up テキスト入力。`dialoguer::Input::interact_text` を使うと CJK や
+/// 絵文字 (Japanese / Chinese / 全角記号 等) の **display width** が code-point
+/// count と一致しないため、Backspace で内部 buffer は減ってもターミナル上に
+/// 残骸が残る (display は char width で消すべきだが dialoguer は code-point
+/// 単位)。
+///
+/// 解決: `stdin().read_line()` で **terminal の cooked mode に任せる**。OS の
+/// terminal driver は CJK Backspace の幅処理を正しくやるので問題が解消する。
+/// 副作用として ColorfulTheme の装飾 prompt は失うが、free-text 入力に theme は
+/// 不要 (Select の方は単キー入力なので dialoguer のままで OK)。
 async fn ask_followup() -> Result<String> {
-    use dialoguer::{Input, theme::ColorfulTheme};
-    tokio::task::spawn_blocking(|| {
-        Input::<String>::with_theme(&ColorfulTheme::default())
-            .with_prompt("Your feedback for the AI")
-            .interact_text()
+    use std::io::{self, BufRead, Write};
+    tokio::task::spawn_blocking(|| -> Result<String> {
+        // ColorfulTheme の `?` prompt prefix を可能な限り再現 (色は付けない)。
+        eprint!("? Your feedback for the AI: ");
+        io::stderr().flush().ok();
+        let mut buf = String::new();
+        io::stdin()
+            .lock()
+            .read_line(&mut buf)
+            .context("failed to read user input")?;
+        Ok(buf.trim_end_matches(['\r', '\n']).to_string())
     })
     .await
-    .context("failed to join blocking dialoguer task")?
-    .map_err(|e| anyhow::anyhow!("dialoguer input failed: {e}"))
+    .context("failed to join blocking input task")?
 }
 
 fn parse_and_validate(response: &str) -> Result<Proposal> {

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -36,6 +36,10 @@ pub enum ChatOutcome {
 ///   - `Ok(ChatOutcome::Skipped)` — user 取り消し。
 ///   - `Ok(ChatOutcome::HandedOff)` — Mode B エスケープ済み。
 ///   - `Err(_)` — CLI 不在 / network / parse 不能 等。
+// 引数数が clippy too_many_arguments の閾値超だが、各 path / flag は
+// caller (`run_add`) 文脈で意味が明確 (struct でまとめると逆に指示性が下がる)
+// なので個別 param で受ける。
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ai_add(
     backend: Backend,
     plugin_url: &str,
@@ -44,6 +48,7 @@ pub async fn run_ai_add(
     config_root: &Path,
     user_config_toml_path: &Path,
     ai_language: &str,
+    chezmoi_enabled: bool,
 ) -> Result<AiAddOutcome> {
     ensure_cli_installed(backend)?;
 
@@ -76,7 +81,8 @@ pub async fn run_ai_add(
 
         match prompt_chat_action().await? {
             ChatAction::Apply => {
-                let written = write_hook_files(plugin_config_dir, &proposal)?;
+                let written =
+                    write_hook_files(plugin_config_dir, &proposal, chezmoi_enabled).await?;
                 return Ok(AiAddOutcome {
                     outcome: ChatOutcome::Applied {
                         written_hooks: written,

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -196,18 +196,31 @@ fn print_proposal_preview(p: &Proposal, plugin_config_dir: &Path, config_toml_pa
         eprintln!("  {line}");
     }
 
-    print_hook_section(p.init_lua.as_deref(), plugin_config_dir, "init.lua", &rule);
+    // 各 hook の skip 対象を集めて、最後にサマリブロックを出す。
+    // 単発の "already exists" 行を見落として Apply されると AI 提案が無視されたまま
+    // になる UX 事故 (Gemini / CodeRabbit 共通指摘) を防ぐため、メニュー直前に
+    // 強調表示する。
+    let mut skipped: Vec<String> = Vec::new();
+    print_hook_section(
+        p.init_lua.as_deref(),
+        plugin_config_dir,
+        "init.lua",
+        &rule,
+        &mut skipped,
+    );
     print_hook_section(
         p.before_lua.as_deref(),
         plugin_config_dir,
         "before.lua",
         &rule,
+        &mut skipped,
     );
     print_hook_section(
         p.after_lua.as_deref(),
         plugin_config_dir,
         "after.lua",
         &rule,
+        &mut skipped,
     );
 
     eprintln!();
@@ -215,10 +228,31 @@ fn print_proposal_preview(p: &Proposal, plugin_config_dir: &Path, config_toml_pa
     for line in p.explanation.lines() {
         eprintln!("  {line}");
     }
+
+    if !skipped.is_empty() {
+        eprintln!();
+        eprintln!("{rule}");
+        eprintln!(
+            "\u{26a0}\u{fe0f}  HEADS UP — Apply will SKIP {} existing hook file(s):",
+            skipped.len()
+        );
+        for path in &skipped {
+            eprintln!("    [SKIPPED] {path}");
+        }
+        eprintln!("    Your existing edits are preserved. To apply the AI proposal,");
+        eprintln!("    delete the file first or merge manually.");
+        eprintln!("{rule}");
+    }
     eprintln!();
 }
 
-fn print_hook_section(body: Option<&str>, plugin_dir: &Path, name: &str, rule: &str) {
+fn print_hook_section(
+    body: Option<&str>,
+    plugin_dir: &Path,
+    name: &str,
+    rule: &str,
+    skipped: &mut Vec<String>,
+) {
     let Some(body) = body else { return };
     let path = plugin_dir.join(name);
     let exists = path.exists();
@@ -227,13 +261,14 @@ fn print_hook_section(body: Option<&str>, plugin_dir: &Path, name: &str, rule: &
     eprintln!();
     if exists {
         eprintln!(
-            "\u{1f4c4} {} already exists ({} line proposal will be skipped to preserve your edits):",
+            "\u{26a0}\u{fe0f}  [SKIPPED] {} already exists ({} line proposal preserved for reference):",
             path.display(),
             line_count,
         );
+        skipped.push(path.display().to_string());
     } else {
         eprintln!(
-            "\u{1f4c4} Will create {} ({} lines):",
+            "\u{1f195} Will create {} ({} lines):",
             path.display(),
             line_count
         );

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -8,7 +8,6 @@ use crate::ai::{
     validate_proposal_toml, write_hook_files,
 };
 use anyhow::{Context, Result};
-use dialoguer::{Input, Select, theme::ColorfulTheme};
 use std::path::{Path, PathBuf};
 
 /// chat loop の終了アクション。
@@ -41,6 +40,7 @@ pub async fn run_ai_add(
     backend: Backend,
     plugin_url: &str,
     plugin_root: &Path,
+    plugin_config_dir: &Path,
     config_root: &Path,
     user_config_toml_path: &Path,
     ai_language: &str,
@@ -65,16 +65,18 @@ pub async fn run_ai_add(
         plugin_url
     );
 
-    // 最初の turn
+    // chat 履歴を反映して handoff に渡せるよう、最後に AI に投げた prompt を覚えておく。
+    // 1 turn 目は initial_prompt そのもの、follow-up が走ったらそれで上書き。
+    let mut last_prompt = initial_prompt.clone();
     let mut prior_response = invoke_oneshot(backend, &initial_prompt).await?;
     let mut proposal = parse_and_validate(&prior_response)?;
 
     loop {
         print_proposal_preview(&proposal);
 
-        let action = match prompt_chat_action()? {
+        match prompt_chat_action().await? {
             ChatAction::Apply => {
-                let written = write_hook_files(config_root, plugin_url, &proposal)?;
+                let written = write_hook_files(plugin_config_dir, &proposal)?;
                 return Ok(AiAddOutcome {
                     outcome: ChatOutcome::Applied {
                         written_hooks: written,
@@ -89,32 +91,29 @@ pub async fn run_ai_add(
                 });
             }
             ChatAction::HandOff => {
-                run_handoff(backend, &initial_prompt)?;
+                // refine 済み文脈を維持: 最後に投げた prompt をそのまま handoff に渡す。
+                run_handoff(backend, &last_prompt).await?;
                 return Ok(AiAddOutcome {
                     outcome: ChatOutcome::HandedOff,
                     proposal: None,
                 });
             }
-            ChatAction::Chat => ChatAction::Chat,
-        };
-
-        // chat — user の追加要求を 1 行受けて follow-up prompt 構築
-        let _ = action;
-        let followup: String = Input::with_theme(&ColorfulTheme::default())
-            .with_prompt("Your feedback for the AI")
-            .interact_text()?;
-        if followup.trim().is_empty() {
-            eprintln!("(empty feedback, returning to action menu)");
-            continue;
+            ChatAction::Chat => {
+                // chat — user の追加要求を 1 行受けて follow-up prompt 構築
+                let followup = ask_followup().await?;
+                if followup.trim().is_empty() {
+                    eprintln!("(empty feedback, returning to action menu)");
+                    continue;
+                }
+                last_prompt = build_followup_prompt(&initial_prompt, &prior_response, &followup);
+                eprintln!(
+                    "\u{1f916} Asking {} for an updated proposal...",
+                    backend.label()
+                );
+                prior_response = invoke_oneshot(backend, &last_prompt).await?;
+                proposal = parse_and_validate(&prior_response)?;
+            }
         }
-
-        let next_prompt = build_followup_prompt(&initial_prompt, &prior_response, &followup);
-        eprintln!(
-            "\u{1f916} Asking {} for an updated proposal...",
-            backend.label()
-        );
-        prior_response = invoke_oneshot(backend, &next_prompt).await?;
-        proposal = parse_and_validate(&prior_response)?;
     }
 }
 
@@ -133,24 +132,44 @@ enum ChatAction {
     Skip,
 }
 
-fn prompt_chat_action() -> Result<ChatAction> {
-    let choices = [
-        "Apply (write to config.toml + create hook files)",
-        "Chat (refine with feedback)",
-        "Hand off to native CLI (rvpm exits, AI continues directly)",
-        "Skip (discard proposal, no changes)",
-    ];
-    let sel = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("How should we proceed?")
-        .items(choices.as_slice())
-        .default(0)
-        .interact()?;
-    Ok(match sel {
+/// dialoguer は同期 API なので `spawn_blocking` で worker thread に逃がす。
+/// async fn 内で `.interact()` を直呼びすると Tokio executor を塞ぐ。
+async fn prompt_chat_action() -> Result<ChatAction> {
+    use dialoguer::{Select, theme::ColorfulTheme};
+    let result = tokio::task::spawn_blocking(|| {
+        let choices = [
+            "Apply (write to config.toml + create hook files)",
+            "Chat (refine with feedback)",
+            "Hand off to native CLI (rvpm exits, AI continues directly)",
+            "Skip (discard proposal, no changes)",
+        ];
+        Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("How should we proceed?")
+            .items(choices.as_slice())
+            .default(0)
+            .interact()
+    })
+    .await
+    .context("failed to join blocking dialoguer task")??;
+    Ok(match result {
         0 => ChatAction::Apply,
         1 => ChatAction::Chat,
         2 => ChatAction::HandOff,
         _ => ChatAction::Skip,
     })
+}
+
+/// follow-up テキスト入力も同様に worker thread で待つ。
+async fn ask_followup() -> Result<String> {
+    use dialoguer::{Input, theme::ColorfulTheme};
+    tokio::task::spawn_blocking(|| {
+        Input::<String>::with_theme(&ColorfulTheme::default())
+            .with_prompt("Your feedback for the AI")
+            .interact_text()
+    })
+    .await
+    .context("failed to join blocking dialoguer task")?
+    .map_err(|e| anyhow::anyhow!("dialoguer input failed: {e}"))
 }
 
 fn parse_and_validate(response: &str) -> Result<Proposal> {

--- a/src/ai/chat.rs
+++ b/src/ai/chat.rs
@@ -73,8 +73,11 @@ pub async fn run_ai_add(
     // chat 履歴を反映して handoff に渡せるよう、最後に AI に投げた prompt を覚えておく。
     // 1 turn 目は initial_prompt そのもの、follow-up が走ったらそれで上書き。
     let mut last_prompt = initial_prompt.clone();
-    let mut prior_response = invoke_oneshot(backend, &initial_prompt).await?;
-    let mut proposal = parse_and_validate(&prior_response)?;
+    let first_response = invoke_oneshot(backend, &initial_prompt).await?;
+    let mut proposal = parse_and_validate(&first_response)?;
+    // raw response (preamble 込み) は使わない — follow-up では parsed `Proposal`
+    // から compact XML を再構築して投入する (token 圧縮のため)。
+    drop(first_response);
 
     loop {
         print_proposal_preview(&proposal, plugin_config_dir, user_config_toml_path);
@@ -105,19 +108,29 @@ pub async fn run_ai_add(
                 });
             }
             ChatAction::Chat => {
-                // chat — user の追加要求を 1 行受けて follow-up prompt 構築
+                // chat — user の追加要求を 1 行受けて follow-up prompt 構築。
+                //
+                // **prior 圧縮**: AI が返した raw response (preamble の "I'll propose..."
+                // などのプロセ含む) ではなく、parsed `Proposal` から `<rvpm:*>` tag だけを
+                // 再構築して投入する (CodeRabbit suggestion #95)。
+                //   - raw は 5-15KB / turn の preamble 込みになり得る
+                //   - 再構築 XML は ~1KB 程度 (TOML + lua bodies + explanation のみ)
+                //   - AI が次 turn で必要な context は構造化された `<rvpm:*>` だけなので
+                //     preamble を削っても reasoning chain を損なわない
+                //   - long chat で context window を圧迫しなくなる + token コスト減
                 let followup = ask_followup().await?;
                 if followup.trim().is_empty() {
                     eprintln!("(empty feedback, returning to action menu)");
                     continue;
                 }
-                last_prompt = build_followup_prompt(&initial_prompt, &prior_response, &followup);
+                let prior_xml = proposal_to_xml(&proposal);
+                last_prompt = build_followup_prompt(&initial_prompt, &prior_xml, &followup);
                 eprintln!(
                     "\u{1f916} Asking {} for an updated proposal...",
                     backend.label()
                 );
-                prior_response = invoke_oneshot(backend, &last_prompt).await?;
-                proposal = parse_and_validate(&prior_response)?;
+                let next_response = invoke_oneshot(backend, &last_prompt).await?;
+                proposal = parse_and_validate(&next_response)?;
             }
         }
     }
@@ -196,6 +209,36 @@ fn parse_and_validate(response: &str) -> Result<Proposal> {
     let proposal = parse_proposal(response)?;
     validate_proposal_toml(&proposal.plugin_entry_toml)?;
     Ok(proposal)
+}
+
+/// `Proposal` から `<rvpm:*>` tag だけの compact XML を再構築する。
+///
+/// follow-up turn の prompt 投入時に **AI の生 response (preamble 込み)** を
+/// そのまま re-inject する代わりにこれを使うと、preamble (例: "Sure, I'll
+/// propose...", "Based on the README..." 等の prose 混じり) を削れる。
+///
+/// AI が次 turn で reasoning に必要な情報は `<rvpm:*>` の中身に過不足なく
+/// 含まれている (TOML / hook bodies / explanation) ので情報損失ゼロ。
+/// 5-15KB / turn 削減され、長 chat の context window 圧迫と token コストを抑える。
+fn proposal_to_xml(p: &Proposal) -> String {
+    let mut out = String::with_capacity(p.plugin_entry_toml.len() + p.explanation.len() + 256);
+    out.push_str("<rvpm:plugin_entry>\n");
+    out.push_str(&p.plugin_entry_toml);
+    out.push_str("\n</rvpm:plugin_entry>\n");
+    for (tag, body) in [
+        ("init_lua", p.init_lua.as_deref()),
+        ("before_lua", p.before_lua.as_deref()),
+        ("after_lua", p.after_lua.as_deref()),
+    ] {
+        out.push_str(&format!(
+            "<rvpm:{tag}>\n{}\n</rvpm:{tag}>\n",
+            body.unwrap_or("(none)")
+        ));
+    }
+    out.push_str("<rvpm:explanation>\n");
+    out.push_str(&p.explanation);
+    out.push_str("\n</rvpm:explanation>\n");
+    out
 }
 
 fn print_proposal_preview(p: &Proposal, plugin_config_dir: &Path, config_toml_path: &Path) {
@@ -293,5 +336,74 @@ fn print_hook_section(
     }
     if line_count > 20 {
         eprintln!("  ... ({} more lines)", line_count - 20);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposal_to_xml_emits_all_tags_with_present_lua() {
+        let p = Proposal {
+            plugin_entry_toml: "[[plugins]]\nurl = \"o/r\"".to_string(),
+            init_lua: Some("vim.g.x = 1".to_string()),
+            before_lua: None,
+            after_lua: Some("require('o').setup({})".to_string()),
+            explanation: "two sentence explanation here.".to_string(),
+        };
+        let xml = proposal_to_xml(&p);
+        // すべての tag が含まれる
+        assert!(xml.contains("<rvpm:plugin_entry>"));
+        assert!(xml.contains("</rvpm:plugin_entry>"));
+        assert!(xml.contains("<rvpm:init_lua>"));
+        assert!(xml.contains("vim.g.x = 1"));
+        // None の Lua は (none) marker で出力する
+        assert!(xml.contains("<rvpm:before_lua>\n(none)\n</rvpm:before_lua>"));
+        assert!(xml.contains("require('o').setup"));
+        assert!(xml.contains("two sentence explanation here."));
+    }
+
+    #[test]
+    fn proposal_to_xml_round_trips_through_parse_proposal() {
+        // 再構築した XML が元の Proposal にパースし戻せる (next turn の AI が
+        // 前 turn の構造化出力を「自分の前の reply」として読める保証)。
+        let original = Proposal {
+            plugin_entry_toml: "[[plugins]]\nurl = \"a/b\"\non_cmd = [\"X\"]".to_string(),
+            init_lua: Some("a = 1".to_string()),
+            before_lua: None,
+            after_lua: None,
+            explanation: "expl".to_string(),
+        };
+        let xml = proposal_to_xml(&original);
+        let reparsed = crate::ai::parse_proposal(&xml).unwrap();
+        assert_eq!(
+            reparsed.plugin_entry_toml.trim(),
+            original.plugin_entry_toml
+        );
+        assert_eq!(reparsed.init_lua, original.init_lua);
+        assert_eq!(reparsed.before_lua, None); // (none) → None
+        assert_eq!(reparsed.after_lua, None);
+        assert_eq!(reparsed.explanation, original.explanation);
+    }
+
+    #[test]
+    fn proposal_to_xml_is_smaller_than_typical_raw_response() {
+        // Raw AI response は preamble + tags + 余分な改行/コードフェンスで膨らむ。
+        // proposal_to_xml は構造のみなので大幅に小さくなる (代表的に 5-10x)。
+        let p = Proposal {
+            plugin_entry_toml: "[[plugins]]\nurl = \"o/r\"".to_string(),
+            init_lua: None,
+            before_lua: None,
+            after_lua: None,
+            explanation: "Brief".to_string(),
+        };
+        let compact = proposal_to_xml(&p);
+        // Compact 表現は 1KB 未満に収まるべき (簡素な proposal なら)。
+        assert!(
+            compact.len() < 1024,
+            "compact xml unexpectedly large: {} bytes",
+            compact.len()
+        );
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,0 +1,440 @@
+// AI-assisted `rvpm add` (#93).
+//
+// このモジュールは静的 scan (#90, plugin_scan.rs) の代わりに外部 AI CLI
+// (claude / gemini / codex) を呼んで `[[plugins]]` 全体 + 必要な hook ファイル
+// を提案させる。設計トレードオフ:
+//
+//   - **CLI subprocess 経由**: API key 管理を user の `claude login` / `gemini auth`
+//     に委ねる。SDK 直叩きより薄く保ち、3 ツール統一インターフェース。
+//   - **構造化出力**: AI 出力は `<rvpm:plugin_entry>` 等の XML tag で囲ませ、
+//     code fence や前置きが混ざっても robust に regex 抽出する。
+//   - **Mode A (内蔵 chat loop)** がメイン路: rvpm が会話履歴を保持し毎ターン
+//     `claude -p "..."` を一発投げ直す。長期会話は token 食うが TOML 抽出が
+//     確実 + 3 ツール挙動統一。
+//   - **Mode B (handoff)** は user に CLI を直接渡す逃げ道: 初期 prompt を
+//     最初の turn として用意して `claude` (interactive) を spawn → rvpm 退出。
+//     CLI ツール側のファイル編集機能で config.toml / hook 直接書かせる。
+//     **rvpm 側は結果を re-import しない** (README に明記)。
+
+use anyhow::{Context, Result, anyhow};
+use std::path::{Path, PathBuf};
+
+mod chat;
+mod prompt;
+
+pub use chat::{ChatOutcome, run_ai_add};
+
+/// 利用可能な AI CLI ツール。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Backend {
+    Claude,
+    Gemini,
+    Codex,
+}
+
+impl Backend {
+    /// CLI 実行ファイル名 (PATH 上にあるべきもの)。
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Backend::Claude => "claude",
+            Backend::Gemini => "gemini",
+            Backend::Codex => "codex",
+        }
+    }
+
+    /// `cli_name()` が PATH 上に見つかるかを返す。
+    pub fn is_available(self) -> bool {
+        which::which(self.cli_name()).is_ok()
+    }
+
+    /// バックエンド共通のラベル。
+    pub fn label(self) -> &'static str {
+        match self {
+            Backend::Claude => "Claude",
+            Backend::Gemini => "Gemini",
+            Backend::Codex => "Codex",
+        }
+    }
+}
+
+/// AI が出力する 1 ターン分の提案。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Proposal {
+    /// `[[plugins]]` block (TOML として valid であることを呼び出し側で検証)。
+    pub plugin_entry_toml: String,
+    /// per-plugin init.lua 内容。`None` なら作らない。
+    pub init_lua: Option<String>,
+    pub before_lua: Option<String>,
+    pub after_lua: Option<String>,
+    /// 2-3 文の根拠説明 (preview 表示用)。
+    pub explanation: String,
+}
+
+/// AI CLI が PATH に無いときのエラー (install hint 込み)。
+pub fn ensure_cli_installed(backend: Backend) -> Result<()> {
+    if backend.is_available() {
+        return Ok(());
+    }
+    let cli = backend.cli_name();
+    let hint = match backend {
+        Backend::Claude => "https://docs.claude.com/claude-code",
+        Backend::Gemini => "https://ai.google.dev/gemini-api/docs/cli",
+        Backend::Codex => "https://github.com/openai/codex",
+    };
+    Err(anyhow!(
+        "AI backend `{cli}` is not on PATH. Install it first ({hint}) or pass a different `--ai` flag."
+    ))
+}
+
+/// CLI を一発呼び出しモードで起動して prompt を投げ、応答を文字列で返す。
+/// stdin で prompt を渡す (shell escape & 長文対策)。timeout 90 秒。
+pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<String> {
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+    use tokio::time::{Duration, timeout};
+
+    ensure_cli_installed(backend)?;
+
+    // 各 CLI のフラグは「stdin から prompt を読み、結果を stdout に」のモードを選ぶ:
+    //   - claude: `claude -p` で one-shot non-interactive、stdin で prompt
+    //   - gemini: `gemini -p` 同様
+    //   - codex:  `codex exec`  (or `codex -p`、ver 依存)
+    // どれも stdin 受け付けるはず。安全側に prompt を stdin で渡す。
+    let mut cmd = Command::new(backend.cli_name());
+    match backend {
+        Backend::Claude | Backend::Gemini => {
+            cmd.arg("-p").arg("-");
+        }
+        Backend::Codex => {
+            cmd.arg("exec").arg("-");
+        }
+    }
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().with_context(|| {
+        format!(
+            "failed to spawn AI CLI `{}` (is it installed and on PATH?)",
+            backend.cli_name()
+        )
+    })?;
+
+    // stdin に prompt を書き込んで close (EOF を AI に伝える)。
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt_text.as_bytes())
+            .await
+            .context("failed to write prompt to AI CLI stdin")?;
+        // explicit drop → close stdin → AI が EOF 受け取って応答開始
+    }
+
+    // 最大 90 秒で打ち切り (network 遅延 + thinking time の余裕)。
+    let output = timeout(Duration::from_secs(90), child.wait_with_output())
+        .await
+        .map_err(|_| anyhow!("AI CLI `{}` timed out after 90s", backend.cli_name()))?
+        .with_context(|| format!("AI CLI `{}` failed to produce output", backend.cli_name()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "AI CLI `{}` exited with status {}: {}",
+            backend.cli_name(),
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// AI 応答から `<rvpm:plugin_entry>` 等の XML tag を抜き取る。
+pub fn parse_proposal(response: &str) -> Result<Proposal> {
+    let entry = extract_tag(response, "plugin_entry")
+        .ok_or_else(|| anyhow!("AI response missing required <rvpm:plugin_entry> tag"))?;
+    let init = extract_optional_lua(response, "init_lua");
+    let before = extract_optional_lua(response, "before_lua");
+    let after = extract_optional_lua(response, "after_lua");
+    let explanation =
+        extract_tag(response, "explanation").unwrap_or_else(|| "(no explanation given)".into());
+    Ok(Proposal {
+        plugin_entry_toml: entry.trim().to_string(),
+        init_lua: init,
+        before_lua: before,
+        after_lua: after,
+        explanation: explanation.trim().to_string(),
+    })
+}
+
+/// `<rvpm:NAME>...</rvpm:NAME>` の中身を返す (前後 whitespace つき)。
+/// 見つからなければ `None`。
+fn extract_tag(text: &str, name: &str) -> Option<String> {
+    let open = format!("<rvpm:{name}>");
+    let close = format!("</rvpm:{name}>");
+    let start = text.find(&open)? + open.len();
+    let end = text[start..].find(&close)? + start;
+    Some(text[start..end].to_string())
+}
+
+/// Lua 系 tag の中身を `Option<String>` で返す。`(none)` (大文字小文字無視) は `None`。
+fn extract_optional_lua(text: &str, name: &str) -> Option<String> {
+    let body = extract_tag(text, name)?;
+    let trimmed = body.trim();
+    if trimmed.eq_ignore_ascii_case("(none)") || trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// AI 提案 TOML が valid であることを軽く verify (parse できるか + `[[plugins]]`
+/// が 1 件あるか)。
+pub fn validate_proposal_toml(toml_src: &str) -> Result<()> {
+    let value: toml::Value =
+        toml::from_str(toml_src).context("AI-proposed TOML failed to parse")?;
+    let plugins = value
+        .get("plugins")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("AI proposal missing `[[plugins]]` array"))?;
+    if plugins.is_empty() {
+        return Err(anyhow!("AI proposal contains 0 plugin entries"));
+    }
+    if plugins.len() > 1 {
+        return Err(anyhow!(
+            "AI proposed {} plugin entries; expected exactly 1 for `rvpm add`",
+            plugins.len()
+        ));
+    }
+    Ok(())
+}
+
+/// Mode B のハンドオフ: 初期 prompt を **最初の user turn として渡しつつ** CLI を
+/// interactive 起動する。rvpm はそのまま親プロセスを引き継ぐ (exec 相当)。
+/// 戻り値の Result は spawn 失敗のみで、CLI 終了は user 任せ。
+///
+/// **重要**: ここから先は rvpm は介入しない。CLI ツール側のファイル編集機能で
+/// `config.toml` や hook を user が直接書かせる前提 (README に明記)。
+pub fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
+    use std::io::Write;
+
+    ensure_cli_installed(backend)?;
+
+    // どの CLI も interactive モードでは prompt を引数 / stdin から取れる。
+    // 安全側に「対話起動 + stdin で prompt 流し込み」を選ぶ。CLI が EOF を
+    // 受け取った後も interactive 継続するか否かは ツール依存。実用上は
+    // user がそこから対話可能なので問題ない (handoff した瞬間 rvpm は退場)。
+    let mut child = std::process::Command::new(backend.cli_name())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("failed to spawn AI CLI `{}`", backend.cli_name()))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(prompt_text.as_bytes());
+        let _ = stdin.write_all(b"\n");
+    }
+
+    // user が CLI を終了するまで待つ。
+    let _ = child.wait();
+    Ok(())
+}
+
+/// AI mode で生成された hook 内容を user の config_root 配下に書き込む。
+/// `<host>/<owner>/<repo>/{init,before,after}.lua` の規約に従う。
+pub fn write_hook_files(
+    config_root: &Path,
+    plugin_url: &str,
+    proposal: &Proposal,
+) -> Result<Vec<PathBuf>> {
+    let plugin_dir = compute_plugin_config_dir(config_root, plugin_url)?;
+    std::fs::create_dir_all(&plugin_dir).with_context(|| {
+        format!(
+            "failed to create plugin config dir {}",
+            plugin_dir.display()
+        )
+    })?;
+
+    let mut written = Vec::new();
+    for (name, body) in [
+        ("init.lua", proposal.init_lua.as_deref()),
+        ("before.lua", proposal.before_lua.as_deref()),
+        ("after.lua", proposal.after_lua.as_deref()),
+    ] {
+        let Some(body) = body else { continue };
+        let path = plugin_dir.join(name);
+        // 既存ファイルは上書きしない (user の手書き編集を尊重)。
+        if path.exists() {
+            eprintln!(
+                "\u{26a0} {} already exists, skipping AI-generated content. Apply manually if desired.",
+                path.display()
+            );
+            continue;
+        }
+        std::fs::write(&path, format!("{}\n", body.trim_end()))
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        written.push(path);
+    }
+    Ok(written)
+}
+
+/// `<host>/<owner>/<repo>/` 形式に展開。GitHub URL のみ対応。
+fn compute_plugin_config_dir(config_root: &Path, plugin_url: &str) -> Result<PathBuf> {
+    let trimmed = plugin_url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+    let owner_repo = if let Some(stripped) = trimmed.strip_prefix("https://github.com/") {
+        stripped.to_string()
+    } else if let Some(stripped) = trimmed.strip_prefix("git@github.com:") {
+        stripped.to_string()
+    } else if trimmed.contains('/') && !trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        return Err(anyhow!(
+            "cannot derive owner/repo from plugin URL `{plugin_url}`"
+        ));
+    };
+    let parts: Vec<&str> = owner_repo.split('/').collect();
+    if parts.len() != 2 {
+        return Err(anyhow!(
+            "plugin URL `{plugin_url}` does not match owner/repo"
+        ));
+    }
+    Ok(config_root.join("github.com").join(parts[0]).join(parts[1]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_proposal_extracts_required_tags() {
+        let response = r#"
+some preamble that should be ignored
+
+<rvpm:plugin_entry>
+[[plugins]]
+url = "owner/repo"
+on_cmd = ["Foo"]
+</rvpm:plugin_entry>
+
+<rvpm:init_lua>
+vim.g.foo = 1
+</rvpm:init_lua>
+
+<rvpm:before_lua>(none)</rvpm:before_lua>
+<rvpm:after_lua>
+require('foo').setup({})
+</rvpm:after_lua>
+
+<rvpm:explanation>
+README shows :Foo as the entry command.
+</rvpm:explanation>
+"#;
+        let p = parse_proposal(response).unwrap();
+        assert!(p.plugin_entry_toml.contains("[[plugins]]"));
+        assert!(p.plugin_entry_toml.contains(r#"url = "owner/repo""#));
+        assert_eq!(p.init_lua.as_deref(), Some("vim.g.foo = 1"));
+        assert_eq!(p.before_lua, None, "(none) must collapse to None");
+        assert_eq!(p.after_lua.as_deref(), Some("require('foo').setup({})"));
+        assert!(p.explanation.contains("README shows"));
+    }
+
+    #[test]
+    fn parse_proposal_missing_plugin_entry_errors() {
+        let response = "<rvpm:explanation>nothing else</rvpm:explanation>";
+        assert!(parse_proposal(response).is_err());
+    }
+
+    #[test]
+    fn parse_proposal_extracts_when_wrapped_in_markdown_fences() {
+        // 一部 CLI は ``` fence を勝手に付ける可能性。tag 抽出は中身さえあれば OK。
+        let response = r#"
+```
+<rvpm:plugin_entry>
+[[plugins]]
+url = "x/y"
+</rvpm:plugin_entry>
+<rvpm:init_lua>(none)</rvpm:init_lua>
+<rvpm:before_lua>(none)</rvpm:before_lua>
+<rvpm:after_lua>(none)</rvpm:after_lua>
+<rvpm:explanation>ok</rvpm:explanation>
+```
+"#;
+        let p = parse_proposal(response).unwrap();
+        assert!(p.plugin_entry_toml.contains(r#"url = "x/y""#));
+        assert_eq!(p.init_lua, None);
+    }
+
+    #[test]
+    fn validate_proposal_toml_accepts_single_plugin_entry() {
+        let toml_src = r#"
+[[plugins]]
+url = "owner/repo"
+on_cmd = ["Foo"]
+"#;
+        validate_proposal_toml(toml_src).unwrap();
+    }
+
+    #[test]
+    fn validate_proposal_toml_rejects_multiple_plugin_entries() {
+        let toml_src = r#"
+[[plugins]]
+url = "a/b"
+
+[[plugins]]
+url = "c/d"
+"#;
+        assert!(validate_proposal_toml(toml_src).is_err());
+    }
+
+    #[test]
+    fn validate_proposal_toml_rejects_invalid_syntax() {
+        let toml_src = "[[plugins]\nurl = ";
+        assert!(validate_proposal_toml(toml_src).is_err());
+    }
+
+    #[test]
+    fn validate_proposal_toml_rejects_no_plugins_array() {
+        let toml_src = r#"name = "ignored""#;
+        assert!(validate_proposal_toml(toml_src).is_err());
+    }
+
+    #[test]
+    fn compute_plugin_config_dir_handles_short_form() {
+        let root = std::path::Path::new("/cfg");
+        let p = compute_plugin_config_dir(root, "owner/repo").unwrap();
+        assert_eq!(
+            p,
+            std::path::Path::new("/cfg/github.com/owner/repo").to_path_buf()
+        );
+    }
+
+    #[test]
+    fn compute_plugin_config_dir_handles_https_form() {
+        let root = std::path::Path::new("/cfg");
+        let p = compute_plugin_config_dir(root, "https://github.com/owner/repo.git").unwrap();
+        assert_eq!(
+            p,
+            std::path::Path::new("/cfg/github.com/owner/repo").to_path_buf()
+        );
+    }
+
+    #[test]
+    fn extract_optional_lua_collapses_none_marker() {
+        let resp = "<rvpm:init_lua>  (none)  </rvpm:init_lua>";
+        assert_eq!(extract_optional_lua(resp, "init_lua"), None);
+    }
+
+    #[test]
+    fn extract_optional_lua_keeps_real_content() {
+        let resp = "<rvpm:init_lua>vim.g.x = 1</rvpm:init_lua>";
+        assert_eq!(
+            extract_optional_lua(resp, "init_lua").as_deref(),
+            Some("vim.g.x = 1")
+        );
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -11,10 +11,12 @@
 //   - **Mode A (内蔵 chat loop)** がメイン路: rvpm が会話履歴を保持し毎ターン
 //     `claude -p "..."` を一発投げ直す。長期会話は token 食うが TOML 抽出が
 //     確実 + 3 ツール挙動統一。
-//   - **Mode B (handoff)** は user に CLI を直接渡す逃げ道: 初期 prompt を
-//     最初の turn として用意して `claude` (interactive) を spawn → rvpm 退出。
-//     CLI ツール側のファイル編集機能で config.toml / hook 直接書かせる。
-//     **rvpm 側は結果を re-import しない** (README に明記)。
+//   - **Mode B (handoff)** は user に CLI を直接渡す逃げ道: prompt をテンポラリ
+//     ファイルに保存してパスを announce、`claude` (interactive) を inherit-stdio
+//     で spawn する。**stdin 事前注入はしない** (claude-code は EOF で即 exit する
+//     ため interactive にならない)。user が CLI 内で prompt ファイルを読めば
+//     refine 済み文脈が手に入る。CLI ツール側のファイル編集機能で config.toml /
+//     hook 直接書かせる。**rvpm 側は結果を re-import しない** (README に明記)。
 
 use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
@@ -112,7 +114,10 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
     }
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+        .stderr(std::process::Stdio::piped())
+        // tokio Command の `kill_on_drop` は default false。timeout で future が
+        // drop されたとき子プロセスを残さないように true にする (CodeRabbit Critical)。
+        .kill_on_drop(true);
 
     let mut child = cmd.spawn().with_context(|| {
         format!(
@@ -169,12 +174,16 @@ pub fn parse_proposal(response: &str) -> Result<Proposal> {
 
 /// `<rvpm:NAME>...</rvpm:NAME>` の中身を返す (前後 whitespace つき)。
 /// 見つからなければ `None`。
+///
+/// AI の preamble に `<rvpm:plugin_entry>` という単語が混じる false positive を避けるため、
+/// **最後の occurrence** を起点に matching する: 構造化出力は応答末尾に来るのが
+/// 通常だし、preamble の言及で偶発的に block を切り出す事故が起きにくい。
 fn extract_tag(text: &str, name: &str) -> Option<String> {
     let open = format!("<rvpm:{name}>");
     let close = format!("</rvpm:{name}>");
-    let start = text.find(&open)? + open.len();
-    let end = text[start..].find(&close)? + start;
-    Some(text[start..end].to_string())
+    let start_off = text.rfind(&open)? + open.len();
+    let close_off = text[start_off..].find(&close)? + start_off;
+    Some(text[start_off..close_off].to_string())
 }
 
 /// Lua 系 tag の中身を `Option<String>` で返す。`(none)` (大文字小文字無視) は `None`。
@@ -209,47 +218,65 @@ pub fn validate_proposal_toml(toml_src: &str) -> Result<()> {
     Ok(())
 }
 
-/// Mode B のハンドオフ: 初期 prompt を **最初の user turn として渡しつつ** CLI を
-/// interactive 起動する。rvpm はそのまま親プロセスを引き継ぐ (exec 相当)。
-/// 戻り値の Result は spawn 失敗のみで、CLI 終了は user 任せ。
+/// Mode B のハンドオフ: prompt をテンポラリファイルに書き出し、CLI を
+/// **interactive モードで** 起動する (stdin / stdout / stderr とも親 TTY を継承)。
+/// rvpm は CLI 終了まで `wait` するだけで、それ以降の状態は CLI 側に委譲する。
 ///
-/// **重要**: ここから先は rvpm は介入しない。CLI ツール側のファイル編集機能で
-/// `config.toml` や hook を user が直接書かせる前提 (README に明記)。
-pub fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
-    use std::io::Write;
-
+/// **prompt の事前注入は意図的に行わない**: stdin pipe + drop すると claude-code
+/// などは EOF を受けて即座に exit するため、interactive にならない (Gemini High)。
+/// 代わりに prompt をテンポラリ MD ファイルに保存してパスを announce する。
+/// user は CLI 内で `/file <path>` (claude-code) や `cat <path>` を使って
+/// 読み込めばよい。
+///
+/// CLI 終了まで blocking wait するが、`spawn_blocking` で別 thread に逃がして
+/// Tokio executor は塞がない。
+pub async fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
     ensure_cli_installed(backend)?;
 
-    // どの CLI も interactive モードでは prompt を引数 / stdin から取れる。
-    // 安全側に「対話起動 + stdin で prompt 流し込み」を選ぶ。CLI が EOF を
-    // 受け取った後も interactive 継続するか否かは ツール依存。実用上は
-    // user がそこから対話可能なので問題ない (handoff した瞬間 rvpm は退場)。
-    let mut child = std::process::Command::new(backend.cli_name())
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .spawn()
-        .with_context(|| format!("failed to spawn AI CLI `{}`", backend.cli_name()))?;
+    // prompt をテンポラリファイルに保存
+    let mut tmp_path = std::env::temp_dir();
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    tmp_path.push(format!("rvpm-ai-prompt-{stamp}.md"));
+    std::fs::write(&tmp_path, prompt_text)
+        .with_context(|| format!("failed to write prompt to {}", tmp_path.display()))?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        let _ = stdin.write_all(prompt_text.as_bytes());
-        let _ = stdin.write_all(b"\n");
-    }
+    eprintln!();
+    eprintln!(
+        "\u{1f4dd} Prompt saved to: {}\n\
+         Starting `{}` interactively. Paste the prompt or load it via your CLI's file-reading mechanism.\n",
+        tmp_path.display(),
+        backend.cli_name()
+    );
 
-    // user が CLI を終了するまで待つ。
-    let _ = child.wait();
+    // 子プロセスを spawn_blocking 内で起動 + wait (std::process は async に乗らないため)。
+    let cli_name = backend.cli_name().to_string();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let status = std::process::Command::new(&cli_name)
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status()
+            .with_context(|| format!("failed to spawn AI CLI `{cli_name}`"))?;
+        let _ = status; // exit status は無視 (user 操作なのでエラーじゃない)
+        Ok(())
+    })
+    .await
+    .context("failed to join blocking handoff task")??;
+
     Ok(())
 }
 
-/// AI mode で生成された hook 内容を user の config_root 配下に書き込む。
-/// `<host>/<owner>/<repo>/{init,before,after}.lua` の規約に従う。
-pub fn write_hook_files(
-    config_root: &Path,
-    plugin_url: &str,
-    proposal: &Proposal,
-) -> Result<Vec<PathBuf>> {
-    let plugin_dir = compute_plugin_config_dir(config_root, plugin_url)?;
-    std::fs::create_dir_all(&plugin_dir).with_context(|| {
+/// AI mode で生成された hook 内容を、呼び出し側で resolve 済みの per-plugin
+/// config dir (`<config_root>/plugins/<host>/<owner>/<repo>/`) に書き込む。
+///
+/// path 解決は呼び出し側 (`run_add`) が `resolve_plugin_config_dir` 経由で行う。
+/// ここでホスト名や url 形式を再パースしないことで、GitLab / 他 host や
+/// `Plugin::canonical_path` の形式変更にも自動追従する。
+pub fn write_hook_files(plugin_dir: &Path, proposal: &Proposal) -> Result<Vec<PathBuf>> {
+    std::fs::create_dir_all(plugin_dir).with_context(|| {
         format!(
             "failed to create plugin config dir {}",
             plugin_dir.display()
@@ -277,33 +304,6 @@ pub fn write_hook_files(
         written.push(path);
     }
     Ok(written)
-}
-
-/// `<host>/<owner>/<repo>/` 形式に展開。GitHub URL のみ対応。
-fn compute_plugin_config_dir(config_root: &Path, plugin_url: &str) -> Result<PathBuf> {
-    let trimmed = plugin_url
-        .trim()
-        .trim_end_matches('/')
-        .trim_end_matches(".git")
-        .trim_end_matches('/');
-    let owner_repo = if let Some(stripped) = trimmed.strip_prefix("https://github.com/") {
-        stripped.to_string()
-    } else if let Some(stripped) = trimmed.strip_prefix("git@github.com:") {
-        stripped.to_string()
-    } else if trimmed.contains('/') && !trimmed.contains("://") {
-        trimmed.to_string()
-    } else {
-        return Err(anyhow!(
-            "cannot derive owner/repo from plugin URL `{plugin_url}`"
-        ));
-    };
-    let parts: Vec<&str> = owner_repo.split('/').collect();
-    if parts.len() != 2 {
-        return Err(anyhow!(
-            "plugin URL `{plugin_url}` does not match owner/repo"
-        ));
-    }
-    Ok(config_root.join("github.com").join(parts[0]).join(parts[1]))
 }
 
 #[cfg(test)]
@@ -347,6 +347,27 @@ README shows :Foo as the entry command.
     fn parse_proposal_missing_plugin_entry_errors() {
         let response = "<rvpm:explanation>nothing else</rvpm:explanation>";
         assert!(parse_proposal(response).is_err());
+    }
+
+    #[test]
+    fn parse_proposal_ignores_tag_name_in_preamble() {
+        // AI が "I will use the <rvpm:plugin_entry> tag below..." のように preamble で
+        // tag 名を言及するケース。最後の occurrence を起点にすれば誤切り出しを回避できる。
+        let response = r#"
+I will populate the <rvpm:plugin_entry> tag below with the proposal.
+
+<rvpm:plugin_entry>
+[[plugins]]
+url = "real/entry"
+</rvpm:plugin_entry>
+<rvpm:init_lua>(none)</rvpm:init_lua>
+<rvpm:before_lua>(none)</rvpm:before_lua>
+<rvpm:after_lua>(none)</rvpm:after_lua>
+<rvpm:explanation>ok</rvpm:explanation>
+"#;
+        let p = parse_proposal(response).unwrap();
+        assert!(p.plugin_entry_toml.contains("real/entry"));
+        assert!(!p.plugin_entry_toml.contains("populate"));
     }
 
     #[test]
@@ -404,23 +425,29 @@ url = "c/d"
     }
 
     #[test]
-    fn compute_plugin_config_dir_handles_short_form() {
-        let root = std::path::Path::new("/cfg");
-        let p = compute_plugin_config_dir(root, "owner/repo").unwrap();
-        assert_eq!(
-            p,
-            std::path::Path::new("/cfg/github.com/owner/repo").to_path_buf()
-        );
-    }
-
-    #[test]
-    fn compute_plugin_config_dir_handles_https_form() {
-        let root = std::path::Path::new("/cfg");
-        let p = compute_plugin_config_dir(root, "https://github.com/owner/repo.git").unwrap();
-        assert_eq!(
-            p,
-            std::path::Path::new("/cfg/github.com/owner/repo").to_path_buf()
-        );
+    fn write_hook_files_writes_only_present_lua_blocks() {
+        // 呼び出し側 (`run_add`) が plugin_dir を resolve 済みで渡す前提を確認。
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_dir = tmp
+            .path()
+            .join("plugins")
+            .join("github.com")
+            .join("o")
+            .join("r");
+        let p = Proposal {
+            plugin_entry_toml: r#"[[plugins]]
+url = "o/r""#
+                .to_string(),
+            init_lua: Some("vim.g.x = 1".to_string()),
+            before_lua: None,
+            after_lua: Some("require('o').setup({})".to_string()),
+            explanation: "test".to_string(),
+        };
+        let written = write_hook_files(&plugin_dir, &p).unwrap();
+        assert_eq!(written.len(), 2);
+        assert!(plugin_dir.join("init.lua").exists());
+        assert!(!plugin_dir.join("before.lua").exists());
+        assert!(plugin_dir.join("after.lua").exists());
     }
 
     #[test]

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -167,7 +167,14 @@ pub fn ensure_cli_installed(backend: Backend) -> Result<()> {
 }
 
 /// CLI を一発呼び出しモードで起動して prompt を投げ、応答を文字列で返す。
-/// stdin で prompt を渡す (shell escape & 長文対策)。timeout 90 秒。
+/// stdin で prompt を渡す (shell escape & 長文対策)。
+///
+/// **timeout**: 5 分 (300 秒)。当初 90 秒だったが、chat 2 turn 目以降は
+/// `build_followup_prompt` で `initial + prior_response + feedback` を全部
+/// 再投入するので prompt が 50-100KB クラスに膨らみ、Gemini が 90 秒では
+/// 収まらないケース報告あり。300 秒なら現実的に余裕がある。
+/// `RVPM_AI_TIMEOUT_SECS` 環境変数で per-call 上書き可能 (ネットワーク遅延が
+/// 強い環境向け)。
 pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<String> {
     use tokio::io::AsyncWriteExt;
     use tokio::process::Command;
@@ -176,6 +183,13 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
     ensure_cli_installed(backend)?;
     let resolved = resolve_cli(backend.cli_name())
         .ok_or_else(|| anyhow!("AI CLI `{}` is not on PATH", backend.cli_name()))?;
+
+    // prompt サイズを表示 (timeout 原因の透明性 + sanity check)。
+    eprintln!(
+        "  (prompt size: {} bytes / {} lines)",
+        prompt_text.len(),
+        prompt_text.lines().count()
+    );
 
     // 各 CLI のフラグは「stdin から prompt を読み、結果を stdout に」のモードを選ぶ:
     //   - claude: `claude -p` で one-shot non-interactive、stdin で prompt
@@ -215,10 +229,21 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
         // explicit drop → close stdin → AI が EOF 受け取って応答開始
     }
 
-    // 最大 90 秒で打ち切り (network 遅延 + thinking time の余裕)。
-    let output = timeout(Duration::from_secs(90), child.wait_with_output())
+    // timeout は default 300 秒、`RVPM_AI_TIMEOUT_SECS` で上書き可能。
+    let timeout_secs = std::env::var("RVPM_AI_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(300);
+    let output = timeout(Duration::from_secs(timeout_secs), child.wait_with_output())
         .await
-        .map_err(|_| anyhow!("AI CLI `{}` timed out after 90s", backend.cli_name()))?
+        .map_err(|_| {
+            anyhow!(
+                "AI CLI `{}` timed out after {timeout_secs}s. \
+                 The chat follow-up prompt grows with conversation history; \
+                 set RVPM_AI_TIMEOUT_SECS=600 or longer if your network is slow.",
+                backend.cli_name()
+            )
+        })?
         .with_context(|| format!("AI CLI `{}` failed to produce output", backend.cli_name()))?;
 
     if !output.status.success() {

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -45,9 +45,11 @@ impl Backend {
         }
     }
 
-    /// `cli_name()` が PATH 上に見つかるかを返す。
+    /// `cli_name()` が PATH 上に見つかるかを返す。Windows では `.ps1` 等の
+    /// non-default PATHEXT も探すので、pnpm 等が `.ps1` wrapper のみ install した
+    /// ケースでも検出できる。
     pub fn is_available(self) -> bool {
-        which::which(self.cli_name()).is_ok()
+        resolve_cli(self.cli_name()).is_some()
     }
 
     /// バックエンド共通のラベル。
@@ -56,6 +58,68 @@ impl Backend {
             Backend::Claude => "Claude",
             Backend::Gemini => "Gemini",
             Backend::Codex => "Codex",
+        }
+    }
+}
+
+/// 解決された CLI の起動情報。
+#[derive(Debug, Clone)]
+pub struct ResolvedCli {
+    /// `Command::new` に渡すプログラム (`.exe` 直、もしくは `powershell.exe`)。
+    pub program: PathBuf,
+    /// プログラムの最初に付ける引数 (PowerShell 経由時は `-File <path>` 等)。
+    pub prefix_args: Vec<String>,
+}
+
+/// `name` を PATH から解決する (Windows の `.ps1` 対応込み)。
+///
+/// 探索順:
+///   1. `which(name)` — Unix なら直接、Windows なら PATHEXT デフォルト (`.exe`/`.cmd`/`.bat` 等)。
+///      解決パスが `.ps1` だった場合は PowerShell 起動命令として包む。
+///   2. (Windows のみ) `which("name.ps1")` — pnpm 等が `.ps1` のみ install した
+///      ケースの fallback。PATHEXT に `.ps1` が無くても拾える。
+///
+/// `.ps1` を実行するには Windows の `CreateProcess` 単体では不可なので、
+/// `powershell.exe -NoProfile -ExecutionPolicy Bypass -File <full path>` で wrap する。
+pub fn resolve_cli(name: &str) -> Option<ResolvedCli> {
+    if let Ok(p) = which::which(name) {
+        return Some(wrap_if_powershell(p));
+    }
+    #[cfg(windows)]
+    {
+        for ext in ["ps1", "cmd", "bat", "exe"] {
+            if let Ok(p) = which::which(format!("{name}.{ext}")) {
+                return Some(wrap_if_powershell(p));
+            }
+        }
+    }
+    None
+}
+
+fn wrap_if_powershell(path: PathBuf) -> ResolvedCli {
+    let is_ps1 = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("ps1"))
+        .unwrap_or(false);
+    if is_ps1 {
+        // Windows 標準の powershell.exe で `.ps1` を起動。-NoProfile で user の
+        // $PROFILE をスキップ (起動高速化 + side effect 排除)、-ExecutionPolicy Bypass
+        // で署名要求を無効化 (pnpm の wrapper は署名されない)。
+        ResolvedCli {
+            program: PathBuf::from("powershell.exe"),
+            prefix_args: vec![
+                "-NoProfile".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string(),
+                "-File".to_string(),
+                path.to_string_lossy().into_owned(),
+            ],
+        }
+    } else {
+        ResolvedCli {
+            program: path,
+            prefix_args: Vec::new(),
         }
     }
 }
@@ -97,13 +161,16 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
     use tokio::time::{Duration, timeout};
 
     ensure_cli_installed(backend)?;
+    let resolved = resolve_cli(backend.cli_name())
+        .ok_or_else(|| anyhow!("AI CLI `{}` is not on PATH", backend.cli_name()))?;
 
     // 各 CLI のフラグは「stdin から prompt を読み、結果を stdout に」のモードを選ぶ:
     //   - claude: `claude -p` で one-shot non-interactive、stdin で prompt
     //   - gemini: `gemini -p` 同様
     //   - codex:  `codex exec`  (or `codex -p`、ver 依存)
     // どれも stdin 受け付けるはず。安全側に prompt を stdin で渡す。
-    let mut cmd = Command::new(backend.cli_name());
+    let mut cmd = Command::new(&resolved.program);
+    cmd.args(&resolved.prefix_args);
     match backend {
         Backend::Claude | Backend::Gemini => {
             cmd.arg("-p").arg("-");
@@ -232,6 +299,8 @@ pub fn validate_proposal_toml(toml_src: &str) -> Result<()> {
 /// Tokio executor は塞がない。
 pub async fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
     ensure_cli_installed(backend)?;
+    let resolved = resolve_cli(backend.cli_name())
+        .ok_or_else(|| anyhow!("AI CLI `{}` is not on PATH", backend.cli_name()))?;
 
     // prompt をテンポラリファイルに保存
     let mut tmp_path = std::env::temp_dir();
@@ -252,14 +321,15 @@ pub async fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
     );
 
     // 子プロセスを spawn_blocking 内で起動 + wait (std::process は async に乗らないため)。
-    let cli_name = backend.cli_name().to_string();
+    let label = backend.cli_name().to_string();
     tokio::task::spawn_blocking(move || -> Result<()> {
-        let status = std::process::Command::new(&cli_name)
+        let status = std::process::Command::new(&resolved.program)
+            .args(&resolved.prefix_args)
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())
             .status()
-            .with_context(|| format!("failed to spawn AI CLI `{cli_name}`"))?;
+            .with_context(|| format!("failed to spawn AI CLI `{label}`"))?;
         let _ = status; // exit status は無視 (user 操作なのでエラーじゃない)
         Ok(())
     })
@@ -432,6 +502,36 @@ url = "c/d"
     fn validate_proposal_toml_rejects_no_plugins_array() {
         let toml_src = r#"name = "ignored""#;
         assert!(validate_proposal_toml(toml_src).is_err());
+    }
+
+    #[test]
+    fn wrap_if_powershell_wraps_ps1_path() {
+        // .ps1 ファイルは powershell.exe で起動するよう変換される。
+        let p = std::path::PathBuf::from("C:/foo/gemini.ps1");
+        let r = wrap_if_powershell(p);
+        assert_eq!(r.program, std::path::PathBuf::from("powershell.exe"));
+        assert!(r.prefix_args.iter().any(|a| a == "-File"));
+        assert!(r.prefix_args.iter().any(|a| a.contains("gemini.ps1")));
+        // ExecutionPolicy Bypass で署名要求を無効化する
+        assert!(r.prefix_args.iter().any(|a| a == "Bypass"));
+    }
+
+    #[test]
+    fn wrap_if_powershell_passes_exe_through() {
+        // .exe は直接起動 (prefix_args 空)。
+        let p = std::path::PathBuf::from("C:/foo/claude.exe");
+        let r = wrap_if_powershell(p.clone());
+        assert_eq!(r.program, p);
+        assert!(r.prefix_args.is_empty());
+    }
+
+    #[test]
+    fn wrap_if_powershell_passes_unix_path_through() {
+        // 拡張子無し (Unix の典型的な executable) も直接起動。
+        let p = std::path::PathBuf::from("/usr/local/bin/codex");
+        let r = wrap_if_powershell(p.clone());
+        assert_eq!(r.program, p);
+        assert!(r.prefix_args.is_empty());
     }
 
     #[tokio::test]

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -272,10 +272,19 @@ pub async fn run_handoff(backend: Backend, prompt_text: &str) -> Result<()> {
 /// AI mode で生成された hook 内容を、呼び出し側で resolve 済みの per-plugin
 /// config dir (`<config_root>/plugins/<host>/<owner>/<repo>/`) に書き込む。
 ///
+/// `chezmoi_enabled` (`options.chezmoi`) が true のとき、書き込みは `chezmoi::write_path`
+/// 経由で source state に行い、`chezmoi::apply` で target に反映する。
+/// raw `fs::write` で target に直書きすると次の `chezmoi apply` で削除/drift 扱いになるため、
+/// `rvpm edit` 等の他コマンドと同じ規約に揃える。
+///
 /// path 解決は呼び出し側 (`run_add`) が `resolve_plugin_config_dir` 経由で行う。
 /// ここでホスト名や url 形式を再パースしないことで、GitLab / 他 host や
 /// `Plugin::canonical_path` の形式変更にも自動追従する。
-pub fn write_hook_files(plugin_dir: &Path, proposal: &Proposal) -> Result<Vec<PathBuf>> {
+pub async fn write_hook_files(
+    plugin_dir: &Path,
+    proposal: &Proposal,
+    chezmoi_enabled: bool,
+) -> Result<Vec<PathBuf>> {
     std::fs::create_dir_all(plugin_dir).with_context(|| {
         format!(
             "failed to create plugin config dir {}",
@@ -290,18 +299,19 @@ pub fn write_hook_files(plugin_dir: &Path, proposal: &Proposal) -> Result<Vec<Pa
         ("after.lua", proposal.after_lua.as_deref()),
     ] {
         let Some(body) = body else { continue };
-        let path = plugin_dir.join(name);
+        let target = plugin_dir.join(name);
         // 既存ファイルは上書きしない (user の手書き編集を尊重)。
-        if path.exists() {
+        if target.exists() {
             eprintln!(
                 "\u{26a0} {} already exists, skipping AI-generated content. Apply manually if desired.",
-                path.display()
+                target.display()
             );
             continue;
         }
-        std::fs::write(&path, format!("{}\n", body.trim_end()))
-            .with_context(|| format!("failed to write {}", path.display()))?;
-        written.push(path);
+        crate::chezmoi::write_routed(chezmoi_enabled, &target, format!("{}\n", body.trim_end()))
+            .await
+            .with_context(|| format!("failed to write {}", target.display()))?;
+        written.push(target);
     }
     Ok(written)
 }
@@ -424,9 +434,10 @@ url = "c/d"
         assert!(validate_proposal_toml(toml_src).is_err());
     }
 
-    #[test]
-    fn write_hook_files_writes_only_present_lua_blocks() {
+    #[tokio::test]
+    async fn write_hook_files_writes_only_present_lua_blocks() {
         // 呼び出し側 (`run_add`) が plugin_dir を resolve 済みで渡す前提を確認。
+        // chezmoi_enabled=false で従来 path (raw fs::write 相当) と挙動一致するか。
         let tmp = tempfile::tempdir().unwrap();
         let plugin_dir = tmp
             .path()
@@ -443,7 +454,7 @@ url = "o/r""#
             after_lua: Some("require('o').setup({})".to_string()),
             explanation: "test".to_string(),
         };
-        let written = write_hook_files(&plugin_dir, &p).unwrap();
+        let written = write_hook_files(&plugin_dir, &p, false).await.unwrap();
         assert_eq!(written.len(), 2);
         assert!(plugin_dir.join("init.lua").exists());
         assert!(!plugin_dir.join("before.lua").exists());

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -103,11 +103,24 @@ fn wrap_if_powershell(path: PathBuf) -> ResolvedCli {
         .map(|e| e.eq_ignore_ascii_case("ps1"))
         .unwrap_or(false);
     if is_ps1 {
-        // Windows 標準の powershell.exe で `.ps1` を起動。-NoProfile で user の
-        // $PROFILE をスキップ (起動高速化 + side effect 排除)、-ExecutionPolicy Bypass
-        // で署名要求を無効化 (pnpm の wrapper は署名されない)。
+        // PowerShell 7 (`pwsh.exe`) を優先、無ければ Windows PowerShell 5.1
+        // (`powershell.exe`、Windows 標準同梱) に fallback。
+        //   - pnpm 利用層は modern toolchain に偏るので PS7 入りが大多数。
+        //   - pnpm の wrapper script は単純な PATH/exec 操作のみで、PS5.1 / 7
+        //     どちらでも同じ挙動 (silent fallback の behavioral risk が無い)。
+        //   - PS5.1 を primary にすると PS7 のみ user で odd ハマる可能性。
+        //
+        // `-NoProfile` で user の $PROFILE をスキップ (起動高速化 + side effect 排除)、
+        // `-ExecutionPolicy Bypass` で署名要求と zone-prompt の両方を無効化
+        // (Unrestricted は MOTW タグ付き script で interactive prompt を出すので、
+        // subprocess 起動時に hang する可能性がある)。
+        let ps_exe = if which::which("pwsh").is_ok() {
+            "pwsh.exe"
+        } else {
+            "powershell.exe"
+        };
         ResolvedCli {
-            program: PathBuf::from("powershell.exe"),
+            program: PathBuf::from(ps_exe),
             prefix_args: vec![
                 "-NoProfile".to_string(),
                 "-ExecutionPolicy".to_string(),
@@ -506,14 +519,21 @@ url = "c/d"
 
     #[test]
     fn wrap_if_powershell_wraps_ps1_path() {
-        // .ps1 ファイルは powershell.exe で起動するよう変換される。
+        // .ps1 ファイルは pwsh.exe (PS7 入りなら) または powershell.exe で起動。
+        // どちらが選ばれるかは test 実行環境に依存するので exact 比較しない。
         let p = std::path::PathBuf::from("C:/foo/gemini.ps1");
         let r = wrap_if_powershell(p);
-        assert_eq!(r.program, std::path::PathBuf::from("powershell.exe"));
+        let prog = r.program.to_string_lossy().to_ascii_lowercase();
+        assert!(
+            prog == "pwsh.exe" || prog == "powershell.exe",
+            "expected pwsh.exe or powershell.exe, got {prog}"
+        );
         assert!(r.prefix_args.iter().any(|a| a == "-File"));
         assert!(r.prefix_args.iter().any(|a| a.contains("gemini.ps1")));
-        // ExecutionPolicy Bypass で署名要求を無効化する
+        // ExecutionPolicy Bypass で署名要求 + zone prompt を無効化する
         assert!(r.prefix_args.iter().any(|a| a == "Bypass"));
+        // -NoProfile で user $PROFILE スキップ
+        assert!(r.prefix_args.iter().any(|a| a == "-NoProfile"));
     }
 
     #[test]

--- a/src/ai/prompt.rs
+++ b/src/ai/prompt.rs
@@ -1,0 +1,308 @@
+// AI add 用 prompt builder。
+//
+// 設計指針:
+//   - **schema は英語固定** — `<rvpm:plugin_entry>` 等の tag 構造を AI に確実に守らせる
+//     ためには指示そのものは英語が安全 (混在で取りこぼす AI がいる)。
+//   - **explanation / chat は user の言語** — `options.ai_language` を prompt に
+//     差し込んで「この言語で説明して」と頼む。デフォルト "en"。
+//   - **token cap** — plugin README + doc/ で巨大な repo (>200KB) もあるので
+//     ハード上限 50KB を超えたら trim + 注記を入れる。
+
+use anyhow::Result;
+use std::path::Path;
+
+/// rvpm の TOML schema brief (生成時に compile-time に取り込む)。
+const SCHEMA: &str = include_str!("schema_prompt.md");
+
+/// AI add の最初の turn で投げる prompt を組み立てる。
+///
+/// 構成 (ブロック順):
+///   1. 役割と出力フォーマット仕様 (schema_prompt.md の英語版)
+///   2. 言語ヒント — `<rvpm:explanation>` 内 と chat 応答の言語指示
+///   3. 対象プラグイン情報 (URL / README / doc/)
+///   4. user の現状 config (config.toml 全文 + plugins/ ツリー一覧)
+///   5. 最終インストラクション
+pub fn build_initial_prompt(
+    plugin_url: &str,
+    plugin_root: &Path,
+    user_config_toml: &str,
+    user_plugins_tree: &str,
+    ai_language: &str,
+) -> Result<String> {
+    let plugin_readme = read_plugin_readme(plugin_root);
+    let plugin_doc = read_plugin_doc(plugin_root);
+
+    let mut out = String::new();
+    out.push_str(SCHEMA);
+    out.push_str("\n\n---\n\n");
+
+    // 言語ヒント — schema 構造は英語固定だが explanation は user 言語
+    if !ai_language.eq_ignore_ascii_case("en") {
+        out.push_str(&format!(
+            "## Language\n\n\
+             Respond in **{ai_language}** for natural-language portions: the \
+             `<rvpm:explanation>` body and any chat replies after this turn. \
+             Keep XML tag names, TOML, and Lua code in their original form (no translation).\n\n",
+        ));
+    }
+
+    out.push_str("---\n\n");
+    out.push_str("# Plugin to add\n\n");
+    out.push_str(&format!("URL: `{plugin_url}`\n\n"));
+    if let Some(readme) = plugin_readme {
+        out.push_str("## README\n\n");
+        out.push_str(&trim_to_cap(&readme, 30_000));
+        out.push_str("\n\n");
+    }
+    if let Some(doc) = plugin_doc {
+        out.push_str("## Vim help (doc/)\n\n");
+        out.push_str(&trim_to_cap(&doc, 15_000));
+        out.push_str("\n\n");
+    }
+
+    out.push_str("---\n\n");
+    out.push_str("# User context\n\n");
+    out.push_str("## Current config.toml\n\n");
+    out.push_str("```toml\n");
+    out.push_str(&trim_to_cap(user_config_toml, 30_000));
+    out.push_str("\n```\n\n");
+
+    out.push_str("## Existing plugins/ directory tree\n\n");
+    out.push_str("```\n");
+    out.push_str(user_plugins_tree.trim_end());
+    out.push_str("\n```\n\n");
+
+    out.push_str("---\n\n");
+    out.push_str(
+        "Now propose the optimal `[[plugins]]` block for the plugin above, plus any \
+         hook files. Output exactly the XML tag structure shown earlier — no markdown \
+         code fences around the tags, no preamble text outside the tags.\n",
+    );
+
+    Ok(out)
+}
+
+/// 後続 turn (user follow-up) 用の prompt を組み立てる。
+/// 直前の AI 応答 + user の追加要求を渡し、提案を更新させる。
+pub fn build_followup_prompt(
+    initial_prompt: &str,
+    prior_response: &str,
+    user_followup: &str,
+) -> String {
+    format!(
+        "{initial_prompt}\n\n---\n\n\
+         # Previous proposal (your last reply)\n\n\
+         {prior_response}\n\n---\n\n\
+         # User feedback\n\n\
+         {user_followup}\n\n\
+         Update the proposal to address this feedback. Return the same XML tag structure.\n"
+    )
+}
+
+/// プラグイン root から README を読む (大文字小文字違い + 拡張子違いに対応)。
+fn read_plugin_readme(plugin_root: &Path) -> Option<String> {
+    let candidates = [
+        "README.md",
+        "README",
+        "README.rst",
+        "Readme.md",
+        "readme.md",
+    ];
+    for name in candidates {
+        let path = plugin_root.join(name);
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// プラグイン doc/ 配下の `*.txt` を結合して返す (Vim help)。50KB 超は trim。
+fn read_plugin_doc(plugin_root: &Path) -> Option<String> {
+    let doc_dir = plugin_root.join("doc");
+    if !doc_dir.is_dir() {
+        return None;
+    }
+    let mut combined = String::new();
+    let entries = std::fs::read_dir(&doc_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("txt") {
+            continue;
+        }
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            combined.push_str(&format!("\n\n=== doc/{name} ===\n\n"));
+            combined.push_str(&content);
+        }
+    }
+    if combined.is_empty() {
+        None
+    } else {
+        Some(combined)
+    }
+}
+
+/// `cap` バイト超なら切って "...(truncated)" を付ける。マルチバイト境界を尊重。
+fn trim_to_cap(text: &str, cap: usize) -> String {
+    if text.len() <= cap {
+        return text.to_string();
+    }
+    // char boundary を尊重して cap 以下に収める
+    let mut end = cap;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n\n...(truncated, {} bytes total, showing first {} bytes)",
+        &text[..end],
+        text.len(),
+        end
+    )
+}
+
+/// user の `<config_root>/plugins/` ディレクトリツリーを文字列化 (depth 3 まで)。
+/// 「どんな per-plugin hook を持ってるか」を AI に把握させて duplicate 提案を防ぐ。
+pub fn collect_plugins_tree(plugins_root: &Path) -> String {
+    let mut out = String::new();
+    let _ = walk_tree(plugins_root, plugins_root, 0, 3, &mut out);
+    if out.is_empty() {
+        "(no plugins/ directory yet)".to_string()
+    } else {
+        out
+    }
+}
+
+fn walk_tree(
+    root: &Path,
+    cur: &Path,
+    depth: usize,
+    max_depth: usize,
+    out: &mut String,
+) -> std::io::Result<()> {
+    if depth > max_depth {
+        return Ok(());
+    }
+    let mut entries: Vec<_> = std::fs::read_dir(cur)?.flatten().collect();
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if path.is_dir() {
+            out.push_str(&format!("{rel}/\n"));
+            let _ = walk_tree(root, &path, depth + 1, max_depth, out);
+        } else {
+            out.push_str(&format!("{rel}\n"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_initial_prompt_includes_schema_and_inputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_root = tmp.path().join("plugin");
+        std::fs::create_dir_all(&plugin_root).unwrap();
+        std::fs::write(
+            plugin_root.join("README.md"),
+            "# my-plugin\n\nUse :Foo to start.",
+        )
+        .unwrap();
+
+        let prompt = build_initial_prompt(
+            "owner/repo",
+            &plugin_root,
+            "[[plugins]]\nurl = \"existing/dep\"\n",
+            "github.com/existing/dep/\n",
+            "en",
+        )
+        .unwrap();
+
+        assert!(prompt.contains("rvpm — TOML schema brief"));
+        assert!(prompt.contains("owner/repo"));
+        assert!(prompt.contains("Use :Foo to start"));
+        assert!(prompt.contains("existing/dep"));
+        // 英語デフォルトでは Language ヒントは挿入しない
+        assert!(!prompt.contains("Respond in"));
+    }
+
+    #[test]
+    fn build_initial_prompt_inserts_language_hint_when_non_english() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_root = tmp.path().join("plugin");
+        std::fs::create_dir_all(&plugin_root).unwrap();
+        std::fs::write(plugin_root.join("README.md"), "x").unwrap();
+
+        let prompt = build_initial_prompt("owner/repo", &plugin_root, "", "(empty)", "ja").unwrap();
+        assert!(prompt.contains("Respond in **ja**"));
+    }
+
+    #[test]
+    fn build_followup_prompt_includes_prior_response_and_feedback() {
+        let p = build_followup_prompt(
+            "INITIAL",
+            "<rvpm:plugin_entry>...</rvpm:plugin_entry>",
+            "Add depends = telescope.nvim",
+        );
+        assert!(p.contains("INITIAL"));
+        assert!(p.contains("Previous proposal"));
+        assert!(p.contains("<rvpm:plugin_entry>...</rvpm:plugin_entry>"));
+        assert!(p.contains("Add depends = telescope.nvim"));
+    }
+
+    #[test]
+    fn trim_to_cap_truncates_oversized_text() {
+        let text = "a".repeat(100);
+        let trimmed = trim_to_cap(&text, 30);
+        assert!(trimmed.starts_with(&"a".repeat(30)));
+        assert!(trimmed.contains("(truncated"));
+        assert!(trimmed.contains("100 bytes total"));
+    }
+
+    #[test]
+    fn trim_to_cap_passes_through_when_under_cap() {
+        let text = "short";
+        assert_eq!(trim_to_cap(text, 100), "short");
+    }
+
+    #[test]
+    fn read_plugin_readme_handles_uppercase_and_md_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("README.md"), "hello").unwrap();
+        assert_eq!(read_plugin_readme(tmp.path()).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn read_plugin_doc_concatenates_txt_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let doc = tmp.path().join("doc");
+        std::fs::create_dir_all(&doc).unwrap();
+        std::fs::write(doc.join("a.txt"), "AAA").unwrap();
+        std::fs::write(doc.join("b.txt"), "BBB").unwrap();
+        // 非 txt は無視
+        std::fs::write(doc.join("ignored.md"), "MMM").unwrap();
+        let combined = read_plugin_doc(tmp.path()).unwrap();
+        assert!(combined.contains("AAA"));
+        assert!(combined.contains("BBB"));
+        assert!(!combined.contains("MMM"));
+    }
+
+    #[test]
+    fn collect_plugins_tree_lists_files_and_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("github.com").join("owner").join("repo");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("init.lua"), "").unwrap();
+        let tree = collect_plugins_tree(tmp.path());
+        assert!(tree.contains("github.com/"));
+        assert!(tree.contains("github.com/owner/repo/init.lua"));
+    }
+}

--- a/src/ai/schema_prompt.md
+++ b/src/ai/schema_prompt.md
@@ -1,0 +1,85 @@
+# rvpm — TOML schema brief (for AI assistants)
+
+You are configuring **rvpm**, a Rust-based Neovim plugin manager. Generate
+the optimal `[[plugins]]` TOML block for the plugin the user is adding,
+plus optional `init.lua` / `before.lua` / `after.lua` hook files.
+
+## Plugin entry schema
+
+```toml
+[[plugins]]
+name = "..."          # display name. defaults to repo name if omitted.
+url  = "owner/repo"   # GitHub short form OR https://github.com/owner/repo (match the user's existing url_style — see "User context" below)
+rev  = "v1.2.3"       # optional pin: branch / tag / commit SHA
+merge   = true        # optional, default true. set false to keep plugin's runtimepath isolated when it conflicts with others
+depends = ["other-plugin"]  # optional. ONLY list plugins already present in the user's config.
+
+# Lazy triggers (any one fires loading). Setting any of these auto-promotes the plugin to lazy.
+on_cmd   = ["Foo", "/^Bar/"]                # exact :command names OR /regex/ (regex expanded against the plugin's statically-defined command names)
+on_ft    = ["rust", "toml"]                 # filetype names
+on_event = ["BufReadPre", "User LazyDone", "/^User Foo/"]  # standard or User events. /regex/ matches "User <name>" synthesized strings
+on_path  = ["*.rs", "Cargo.toml"]           # BufRead/BufNewFile glob
+on_source = ["plenary.nvim"]                # load when another plugin's "rvpm_loaded_<name>" User autocmd fires
+# on_map: simple LHS string OR { lhs, mode, desc } table. Mix freely.
+# /regex/ for lhs expands against the plugin's <Plug>(...) mappings. mode/desc are inherited per expanded entry.
+on_map = [
+  "<leader>f",
+  { lhs = "<leader>v", mode = ["n", "x"] },
+  { lhs = "/^<Plug>\\(Chezmoi/", mode = ["n"] },
+]
+
+cond = "vim.fn.has('win32') == 1"   # optional Lua expression; load only when truthy
+```
+
+## Hook file conventions
+
+- `init.lua` — runs **before** RTP append. Use for `vim.g.<plugin>_setting = ...` global config.
+- `before.lua` — runs **after** RTP append, before `plugin/*` source. Use for `require('foo').setup(...)`.
+- `after.lua` — runs **after** `plugin/*` source. Use for keymaps and post-setup tweaks.
+
+If the plugin needs no special hook, output `(none)` for that section. Don't invent hooks "just in case."
+
+## Lazy trigger guidance
+
+- If the plugin exposes commands that match a clear prefix (`FooOpen`, `FooClose`, `FooToggle`) prefer `on_cmd = ["/^Foo/"]` over enumerating each.
+- If it's a `<Plug>`-based plugin (vim-commentary, vim-surround, vim-unimpaired) prefer `on_map = [{ lhs = "/^<Plug>\\(Foo/", mode = [...] }]`.
+- If it fires User events as a "ready" signal (`PluginLoaded` etc.), other plugins can hook via `on_event = ["User PluginLoaded"]`.
+- If it's a colorscheme plugin (`colors/foo.{vim,lua}`), it'll be auto-handled by rvpm's ColorSchemePre — no trigger needed (just leave eager or use any trigger).
+- If you cannot identify a lazy trigger from the README, leave triggers unset (eager). Eager is correct for plugins that need to register autocmds on `VimEnter`.
+
+## Output format (REQUIRED)
+
+Reply with exactly these XML tags. No markdown code fences, no preamble, no explanation outside the tags:
+
+```
+<rvpm:plugin_entry>
+[[plugins]]
+url = "..."
+... TOML body ...
+</rvpm:plugin_entry>
+
+<rvpm:init_lua>
+... Lua source, or (none) if no init.lua needed ...
+</rvpm:init_lua>
+
+<rvpm:before_lua>
+... Lua source, or (none) ...
+</rvpm:before_lua>
+
+<rvpm:after_lua>
+... Lua source, or (none) ...
+</rvpm:after_lua>
+
+<rvpm:explanation>
+2-3 sentences explaining the choices. Reference specific README snippets, depends already in user config, why these triggers (or eager).
+</rvpm:explanation>
+```
+
+## Constraints
+
+- Match the user's `url_style` (`short` = `owner/repo`, `full` = `https://github.com/owner/repo`) — see User context.
+- For `depends`, only list plugins present in the user's `config.toml`.
+- Don't repeat the user's existing `[[plugins]]` entries — output only the **new** entry for this plugin.
+- Don't write hook files unless the plugin's README clearly demonstrates the configuration.
+- TOML must be syntactically valid. Strings need quotes. Arrays use brackets.
+- When uncertain, prefer eager (no triggers) over guessing wrong triggers — wrong triggers cause silent load failures.

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -182,6 +182,34 @@ pub async fn apply(wrote_to: &Path, target: &Path) {
     }
 }
 
+/// `write_path` + `fs::write` + `apply` をまとめた一発書き込み helper。
+///
+/// `enabled = false` (chezmoi 無効) なら target に直接書く。
+/// `enabled = true` なら source state へ書いて `chezmoi apply` で target へ反映する。
+///
+/// 親ディレクトリは存在しなければ自動作成する (chezmoi の source state 側に親が
+/// 無いケースに対応)。
+///
+/// ほとんどの呼び出し点で繰り返されていた以下のパターンを 1 行に短縮できる:
+/// ```ignore
+/// let wp = chezmoi::write_path(enabled, &target).await;
+/// std::fs::write(&wp, content)?;
+/// chezmoi::apply(&wp, &target).await;
+/// ```
+pub async fn write_routed(
+    enabled: bool,
+    target: &Path,
+    content: impl AsRef<[u8]>,
+) -> std::io::Result<()> {
+    let wrote_to = write_path(enabled, target).await;
+    if let Some(parent) = wrote_to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&wrote_to, content)?;
+    apply(&wrote_to, target).await;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,5 +294,26 @@ mod tests {
             res.is_ok(),
             "write_path must return within 10s even when chezmoi is missing or slow"
         );
+    }
+
+    #[tokio::test]
+    async fn write_routed_disabled_writes_directly_to_target() {
+        // chezmoi 無効時は target に直接書く。親 dir も自動作成される。
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("sub").join("nested").join("file.toml");
+        write_routed(false, &target, "hello = 1\n").await.unwrap();
+        let read = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(read, "hello = 1\n");
+    }
+
+    #[tokio::test]
+    async fn write_routed_disabled_overwrites_existing_target() {
+        // 既存ファイルがあっても上書きできる (chezmoi 経由しないので raw write 相当)。
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("file.toml");
+        std::fs::write(&target, "old = 1").unwrap();
+        write_routed(false, &target, "new = 2").await.unwrap();
+        let read = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(read, "new = 2");
     }
 }

--- a/src/chezmoi.rs
+++ b/src/chezmoi.rs
@@ -196,6 +196,12 @@ pub async fn apply(wrote_to: &Path, target: &Path) {
 /// std::fs::write(&wp, content)?;
 /// chezmoi::apply(&wp, &target).await;
 /// ```
+///
+/// **エラー伝播ポリシー**: 戻り値の `Ok(())` は **bytes が disk に書き込まれた** こと
+/// を示すだけで、`chezmoi apply` の成功までは保証しない。`apply()` は失敗時に
+/// stderr へ warn を出すが Result としては Ok を返す (resilience 設計 — apply 1 件
+/// の失敗で rvpm 全体を止めない)。chezmoi 側の状態反映を厳密に確認したいユース
+/// ケース (test 等) では別途 `chezmoi status` 等を呼ぶ必要がある。
 pub async fn write_routed(
     enabled: bool,
     target: &Path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,29 @@ pub struct Options {
     /// CLI の `--auto-lazy` / `--no-lazy` で per-call 上書き可能。
     #[serde(default)]
     pub auto_lazy: AutoLazyPolicy,
+    /// AI-assisted `rvpm add` の backend (#93)。
+    ///
+    /// - `"off"` (default): 静的 scan + auto_lazy 路を従来通り使う。
+    /// - `"claude"` / `"gemini"` / `"codex"`: 該当 CLI を subprocess 起動して
+    ///   `[[plugins]]` 全体 + 必要な hook を設計させる。**`auto_lazy` は無視**
+    ///   される (AI が end-to-end で構成する)。
+    ///
+    /// CLI の `--ai <backend>` / `--no-ai` で per-call 上書き可能。
+    /// 該当 CLI が PATH に無ければ `rvpm add` はエラーで停止する (静的 scan に
+    /// 自動 fallback はしない — user の意図 = AI を使うが明示的なため)。
+    #[serde(default)]
+    pub ai: AiBackend,
+    /// AI 出力の自然言語 (#93)。`<rvpm:explanation>` の本文や、対話モードでの
+    /// 応答言語に反映される。XML tag 構造そのものは英語固定。
+    ///
+    /// デフォルト `"en"`。`"ja"` 等の BCP-47 風コード or 自由文字列を許す
+    /// (AI が自然言語名で受け付けてくれるので)。
+    #[serde(default = "default_ai_language")]
+    pub ai_language: String,
+}
+
+fn default_ai_language() -> String {
+    "en".to_string()
 }
 
 /// `options.auto_lazy` が取る 3 値。
@@ -108,6 +131,22 @@ pub enum AutoLazyPolicy {
     Always,
     /// scan 自体を skip。
     Never,
+}
+
+/// `options.ai` が取る値。`"off"` 以外を指定すると `rvpm add` は AI subprocess 路に
+/// 切り替わる (静的 scan + `auto_lazy` の路は完全に bypass)。
+#[derive(Debug, Deserialize, PartialEq, Eq, Default, Clone, Copy, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum AiBackend {
+    /// 静的 scan + auto_lazy フローを使う (default)。
+    #[default]
+    Off,
+    /// `claude` CLI を subprocess 起動。
+    Claude,
+    /// `gemini` CLI を subprocess 起動。
+    Gemini,
+    /// `codex` CLI を subprocess 起動。
+    Codex,
 }
 
 impl Default for Options {
@@ -127,6 +166,8 @@ impl Default for Options {
             browse: BrowseOptions::default(),
             fetch_interval: None,
             auto_lazy: AutoLazyPolicy::default(),
+            ai: AiBackend::default(),
+            ai_language: default_ai_language(),
         }
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1308,6 +1308,8 @@ mod tests {
                 browse: BrowseOptions::default(),
                 fetch_interval: None,
                 auto_lazy: crate::config::AutoLazyPolicy::Ask,
+                ai: crate::config::AiBackend::Off,
+                ai_language: "en".to_string(),
             },
             plugins,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2536,9 +2536,7 @@ async fn run_add(
 
     let toml_content = doc.to_string();
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
-    std::fs::write(&wp, &toml_content)?;
-    chezmoi::apply(&wp, &config_path).await;
+    chezmoi::write_routed(chezmoi_enabled, &config_path, &toml_content).await?;
     println!("Added plugin to config: {}", stored_url);
 
     // 追加したプラグインだけ clone + merge し、loader.lua を再生成する
@@ -2618,6 +2616,7 @@ async fn run_add(
                         &cfg_root,
                         &config_path,
                         &config_data.options.ai_language,
+                        config_data.options.chezmoi,
                     )
                     .await
                     {
@@ -2638,13 +2637,12 @@ async fn run_add(
                                         );
                                     } else {
                                         let patched = doc_patch.to_string();
-                                        let wp = chezmoi::write_path(
+                                        chezmoi::write_routed(
                                             config_data.options.chezmoi,
                                             &config_path,
+                                            &patched,
                                         )
-                                        .await;
-                                        std::fs::write(&wp, &patched)?;
-                                        chezmoi::apply(&wp, &config_path).await;
+                                        .await?;
                                         println!(
                                             "Applied AI-proposed config for {} ({} hook file(s) created).",
                                             plugin.display_name(),
@@ -3258,9 +3256,7 @@ async fn run_set(
 
     if modified {
         let chezmoi_enabled = read_chezmoi_flag(&config_path);
-        let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
-        std::fs::write(&wp, doc.to_string())?;
-        chezmoi::apply(&wp, &config_path).await;
+        chezmoi::write_routed(chezmoi_enabled, &config_path, doc.to_string()).await?;
         println!("Updated config for: {}", selected_repo_url);
         return Ok(true);
     }
@@ -3407,9 +3403,7 @@ async fn run_remove(query: Option<String>) -> Result<()> {
     let mut doc = toml_content.parse::<DocumentMut>()?;
     remove_plugin_from_toml(&mut doc, &selected_url)?;
     let chezmoi_enabled = read_chezmoi_flag(&config_path);
-    let wp = chezmoi::write_path(chezmoi_enabled, &config_path).await;
-    std::fs::write(&wp, doc.to_string())?;
-    chezmoi::apply(&wp, &config_path).await;
+    chezmoi::write_routed(chezmoi_enabled, &config_path, doc.to_string()).await?;
     println!("Removed '{}' from config.", selected_url);
 
     let cache_root = resolve_cache_root(config.options.cache_root.as_deref());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2287,17 +2287,24 @@ fn decide_add_lazy_apply(
     }
 }
 
-/// AI mode 用 (#93): AI が返した `[[plugins]]` ブロック (1 entry のみ) で、
-/// stub `[[plugins]]` 行 (url のみ書き込み済み) を全置換する。
-/// `url` は `stored_url` に強制リセット (AI が url_style を勘違いしても拾える)。
+/// AI mode 用 (#93): AI が返した `[[plugins]]` ブロック (1 entry のみ) を、既存
+/// stub entry に **in-place マージ** する。
+///
+/// 設計ポイント:
+///   - **stub entry の文書中の位置 / 装飾 (改行・空白) を保つ** — `remove + insert`
+///     方式は toml_edit が新 entry を `[vars]` の直後など想定外の位置にレンダリング
+///     してしまう (user 報告: 既存 [[plugins]] の末尾ではなく `[vars]` 直後に配置される)。
+///   - **user の明示 CLI flag を尊重** — `preserved_keys` に挙げたキーは AI 提案で
+///     上書きしない (`rvpm add owner/repo --rev v1.0 --ai claude` で `--rev` を残す)。
+///     `url` は `stored_url` に強制リセット (canonical 化)。
 fn replace_plugin_entry_with_ai_toml(
     doc: &mut DocumentMut,
     stored_url: &str,
     proposal_toml: &str,
+    preserved_keys: &[&str],
 ) -> anyhow::Result<()> {
     use anyhow::{Context, anyhow};
 
-    // 提案 TOML を仮 doc としてパースして `[[plugins]]` 配列を取り出す。
     let proposal_doc: DocumentMut = proposal_toml
         .parse::<DocumentMut>()
         .context("AI proposal TOML failed to parse")?;
@@ -2311,11 +2318,9 @@ fn replace_plugin_entry_with_ai_toml(
             proposal_plugins.len()
         ));
     }
-    let mut new_entry = proposal_plugins.get(0).unwrap().clone();
-    // url は config 側の `stored_url` に揃える (AI が full/short を取り違える保険)
-    new_entry["url"] = value(stored_url);
+    let new_entry = proposal_plugins.get(0).unwrap();
 
-    // 既存 doc の plugins 配列から url 一致を探して in-place 差し替え。
+    // 既存 doc の plugins 配列から url 一致を探して in-place マージ。
     let plugins = doc
         .get_mut("plugins")
         .and_then(|p| p.as_array_of_tables_mut())
@@ -2326,12 +2331,25 @@ fn replace_plugin_entry_with_ai_toml(
             .and_then(|t| t.get("url"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        if existing_url == stored_url {
-            // toml_edit には Vec.replace 相当が無いので remove + insert で置換。
-            plugins.remove(i);
-            plugins.insert(i, new_entry);
-            return Ok(());
+        if existing_url != stored_url {
+            continue;
         }
+        let existing = plugins.get_mut(i).unwrap();
+
+        // AI 提案の各キーを既存 entry に書き込む。
+        // ただし `preserved_keys` (user が CLI flag で明示したもの) は skip。
+        // url は最後に強制セット。
+        for (key, value_item) in new_entry.iter() {
+            if key == "url" {
+                continue;
+            }
+            if preserved_keys.contains(&key) {
+                continue;
+            }
+            existing[key] = value_item.clone();
+        }
+        existing["url"] = value(stored_url);
+        return Ok(());
     }
     Err(anyhow!(
         "could not find stub [[plugins]] entry with url=`{stored_url}` in config.toml"
@@ -2452,6 +2470,35 @@ async fn run_add(
     }
     // 書き込み URL は options.url_style に従って整形 (GitHub 以外はそのまま)。
     let stored_url = format_plugin_url(&repo, url_style);
+
+    // user が明示的に CLI flag で指定したキー一覧 — AI mode 適用時はこれを尊重して
+    // 上書きしない (#95 review CodeRabbit Major)。`url` は常に保護 (canonical 化される)。
+    let preserved_keys: Vec<&'static str> = {
+        let mut k = vec!["url"];
+        if name.is_some() {
+            k.push("name");
+        }
+        if lazy.is_some() {
+            k.push("lazy");
+        }
+        if rev.is_some() {
+            k.push("rev");
+        }
+        if on_cmd.is_some() {
+            k.push("on_cmd");
+        }
+        if on_ft.is_some() {
+            k.push("on_ft");
+        }
+        if on_map.is_some() {
+            k.push("on_map");
+        }
+        if on_event.is_some() {
+            k.push("on_event");
+        }
+        k
+    };
+
     let mut new_plugin = table();
     new_plugin["url"] = value(&stored_url);
     if let Some(n) = name {
@@ -2562,10 +2609,12 @@ async fn run_add(
                         crate::config::AiBackend::Off => unreachable!(),
                     };
                     let cfg_root = resolve_config_root(config_data.options.config_root.as_deref());
+                    let plugin_cfg_dir = resolve_plugin_config_dir(&cfg_root, &plugin);
                     match crate::ai::run_ai_add(
                         backend,
                         &stored_url,
                         &dst_path,
+                        &plugin_cfg_dir,
                         &cfg_root,
                         &config_path,
                         &config_data.options.ai_language,
@@ -2582,6 +2631,7 @@ async fn run_add(
                                         &mut doc_patch,
                                         &stored_url,
                                         &prop.plugin_entry_toml,
+                                        &preserved_keys,
                                     ) {
                                         eprintln!(
                                             "\u{26a0} failed to apply AI proposal: {e}. Stub entry remains."
@@ -5447,6 +5497,118 @@ url = "owner/repo"
         patch_plugin_entry_triggers(&mut doc, "owner/repo", &applied);
         let out = doc.to_string();
         assert!(out.contains("ScannedFoo"));
+    }
+
+    // ─── replace_plugin_entry_with_ai_toml (#95) ─────────────────────────
+
+    #[test]
+    fn replace_plugin_entry_with_ai_toml_preserves_position_among_other_entries() {
+        // [vars] や既存 [[plugins]] の中に stub が並んでいるとき、in-place マージが
+        // entry の位置を維持することを確認 (user 報告: AI 提案が `[vars]` 直後に
+        // 飛んで配置される現象の回帰 test)。
+        let initial = r#"[vars]
+nvim_rc = "~/.config/nvim/rc"
+
+[[plugins]]
+url = "first/plugin"
+on_cmd = ["First"]
+
+[[plugins]]
+url = "second/stub"
+
+[[plugins]]
+url = "third/plugin"
+"#;
+        let mut doc = initial.parse::<DocumentMut>().unwrap();
+        let proposal = r#"[[plugins]]
+url = "second/stub"
+on_event = ["BufReadPre"]
+"#;
+        replace_plugin_entry_with_ai_toml(&mut doc, "second/stub", proposal, &[]).unwrap();
+        let out = doc.to_string();
+        // first/plugin → second/stub → third/plugin の順序が維持される
+        let first_pos = out.find("first/plugin").unwrap();
+        let second_pos = out.find("second/stub").unwrap();
+        let third_pos = out.find("third/plugin").unwrap();
+        assert!(first_pos < second_pos);
+        assert!(second_pos < third_pos);
+        assert!(out.contains(r#"on_event = ["BufReadPre"]"#));
+    }
+
+    #[test]
+    fn replace_plugin_entry_with_ai_toml_preserves_user_specified_keys() {
+        // user の `--rev` / `--on-cmd` が既に stub に書かれている場合、AI 提案で
+        // 上書きしないことを確認 (CodeRabbit Major #95)。
+        let initial = r#"[[plugins]]
+url = "owner/repo"
+rev = "stable"
+on_cmd = ["ManualCmd"]
+"#;
+        let mut doc = initial.parse::<DocumentMut>().unwrap();
+        let proposal = r#"[[plugins]]
+url = "owner/repo"
+rev = "main"
+on_cmd = ["AICmd"]
+on_map = ["<leader>x"]
+"#;
+        // user が --rev と --on-cmd を明示したシナリオ
+        let preserved = ["url", "rev", "on_cmd"];
+        replace_plugin_entry_with_ai_toml(&mut doc, "owner/repo", proposal, &preserved).unwrap();
+        let out = doc.to_string();
+        // user の rev / on_cmd が残る
+        assert!(
+            out.contains(r#"rev = "stable""#),
+            "user --rev must be preserved:\n{out}"
+        );
+        assert!(
+            out.contains(r#"on_cmd = ["ManualCmd"]"#),
+            "user --on-cmd must be preserved:\n{out}"
+        );
+        // AI が新規に追加した on_map は反映される
+        assert!(
+            out.contains("on_map"),
+            "AI-only field must be added:\n{out}"
+        );
+        // url は stored_url で正規化される
+        assert!(out.contains(r#"url = "owner/repo""#));
+    }
+
+    #[test]
+    fn replace_plugin_entry_with_ai_toml_writes_ai_keys_when_no_preservation() {
+        // preserved_keys が空 (user が CLI flag を出してない) なら AI 提案が全反映。
+        let initial = r#"[[plugins]]
+url = "owner/repo"
+"#;
+        let mut doc = initial.parse::<DocumentMut>().unwrap();
+        let proposal = r#"[[plugins]]
+url = "different/url"
+on_cmd = ["AICmd"]
+"#;
+        replace_plugin_entry_with_ai_toml(&mut doc, "owner/repo", proposal, &[]).unwrap();
+        let out = doc.to_string();
+        // url は stored_url を維持 (AI が url を勘違いしても保護)
+        assert!(out.contains(r#"url = "owner/repo""#));
+        assert!(!out.contains("different/url"));
+        assert!(out.contains(r#"on_cmd = ["AICmd"]"#));
+    }
+
+    #[test]
+    fn replace_plugin_entry_with_ai_toml_rejects_proposal_with_zero_or_many_entries() {
+        let initial = r#"[[plugins]]
+url = "x/y"
+"#;
+        let mut doc = initial.parse::<DocumentMut>().unwrap();
+
+        let zero = r#"name = "no plugins""#;
+        assert!(replace_plugin_entry_with_ai_toml(&mut doc, "x/y", zero, &[]).is_err());
+
+        let many = r#"[[plugins]]
+url = "a/b"
+
+[[plugins]]
+url = "c/d"
+"#;
+        assert!(replace_plugin_entry_with_ai_toml(&mut doc, "x/y", many, &[]).is_err());
     }
 
     fn write_file(path: &Path, content: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod ai;
 mod browse;
 mod browse_tui;
 mod chezmoi;
@@ -165,6 +166,17 @@ enum Commands {
         /// if the plugin is lazy via those, it stays lazy.
         #[arg(long)]
         no_lazy: bool,
+
+        /// AI backend for this `add`. Replaces the static-scan + auto-lazy path:
+        /// the chosen CLI (`claude` / `gemini` / `codex`) reads the plugin's
+        /// README + your config and proposes the full `[[plugins]]` block plus
+        /// any per-plugin hook files. Overrides `options.ai` for this call.
+        #[arg(long, value_enum, conflicts_with = "no_ai")]
+        ai: Option<crate::config::AiBackend>,
+
+        /// Force the static-scan path even if `options.ai` is set in config.
+        #[arg(long)]
+        no_ai: bool,
     },
 
     /// Edit per-plugin or global hook files in $EDITOR
@@ -397,6 +409,8 @@ async fn main() -> Result<()> {
             rev,
             auto_lazy,
             no_lazy,
+            ai,
+            no_ai,
         } => {
             let policy_override = if auto_lazy {
                 Some(crate::config::AutoLazyPolicy::Always)
@@ -404,6 +418,13 @@ async fn main() -> Result<()> {
                 Some(crate::config::AutoLazyPolicy::Never)
             } else {
                 None
+            };
+            // `--no-ai` は config の `ai` を打ち消して Off に固定。`--ai <backend>` は
+            // 明示指定 (Off 含む)。両方無指定 (None) なら config 値を使う。
+            let ai_override = if no_ai {
+                Some(crate::config::AiBackend::Off)
+            } else {
+                ai
             };
             run_add(
                 repo,
@@ -415,6 +436,7 @@ async fn main() -> Result<()> {
                 on_event,
                 rev,
                 policy_override,
+                ai_override,
             )
             .await?;
         }
@@ -2265,6 +2287,57 @@ fn decide_add_lazy_apply(
     }
 }
 
+/// AI mode 用 (#93): AI が返した `[[plugins]]` ブロック (1 entry のみ) で、
+/// stub `[[plugins]]` 行 (url のみ書き込み済み) を全置換する。
+/// `url` は `stored_url` に強制リセット (AI が url_style を勘違いしても拾える)。
+fn replace_plugin_entry_with_ai_toml(
+    doc: &mut DocumentMut,
+    stored_url: &str,
+    proposal_toml: &str,
+) -> anyhow::Result<()> {
+    use anyhow::{Context, anyhow};
+
+    // 提案 TOML を仮 doc としてパースして `[[plugins]]` 配列を取り出す。
+    let proposal_doc: DocumentMut = proposal_toml
+        .parse::<DocumentMut>()
+        .context("AI proposal TOML failed to parse")?;
+    let proposal_plugins = proposal_doc
+        .get("plugins")
+        .and_then(|p| p.as_array_of_tables())
+        .ok_or_else(|| anyhow!("AI proposal missing [[plugins]] array"))?;
+    if proposal_plugins.len() != 1 {
+        return Err(anyhow!(
+            "AI proposal must contain exactly 1 plugin entry; got {}",
+            proposal_plugins.len()
+        ));
+    }
+    let mut new_entry = proposal_plugins.get(0).unwrap().clone();
+    // url は config 側の `stored_url` に揃える (AI が full/short を取り違える保険)
+    new_entry["url"] = value(stored_url);
+
+    // 既存 doc の plugins 配列から url 一致を探して in-place 差し替え。
+    let plugins = doc
+        .get_mut("plugins")
+        .and_then(|p| p.as_array_of_tables_mut())
+        .ok_or_else(|| anyhow!("config.toml missing [[plugins]] array"))?;
+    for i in 0..plugins.len() {
+        let existing_url = plugins
+            .get(i)
+            .and_then(|t| t.get("url"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if existing_url == stored_url {
+            // toml_edit には Vec.replace 相当が無いので remove + insert で置換。
+            plugins.remove(i);
+            plugins.insert(i, new_entry);
+            return Ok(());
+        }
+    }
+    Err(anyhow!(
+        "could not find stub [[plugins]] entry with url=`{stored_url}` in config.toml"
+    ))
+}
+
 /// 既存 config.toml 内の `[[plugins]]` のうち url が一致するエントリに
 /// `on_cmd` / `on_map` を書き込む。toml_edit で in-place patch。
 fn patch_plugin_entry_triggers(
@@ -2336,6 +2409,7 @@ async fn run_add(
     on_event: Option<String>,
     rev: Option<String>,
     policy_override: Option<crate::config::AutoLazyPolicy>,
+    ai_override: Option<crate::config::AiBackend>,
 ) -> Result<()> {
     let config_path = rvpm_config_path();
     ensure_config_exists(&config_path)?;
@@ -2476,38 +2550,102 @@ async fn run_add(
                 // (旧実装はここで merge していたが run_generate に上書きされて冗長)
                 let _ = (&plugin, &dst_path, &merged_dir);
 
-                // ── auto-lazy scan + prompt (#87) ────────────────────────
-                // clone 直後、generate 前の隙間で plugin の plugin/ 配下を scan して、
-                // 対象コマンド / keymap が見つかれば user のポリシーに沿って
-                // config.toml の [[plugins]] entry に on_cmd / on_map を追記する。
-                //
-                // user が `--lazy false` で明示的に eager 指示した時は scan skip。
-                // 「eager で入れたい」と言ってるのに "accept (lazy-load)" を提案するのは
-                // 余計な摩擦 (PR #91 review 指摘)。`lazy_raw == Some(true)` (明示的
-                // lazy 指示) は逆に scan する (triggers 候補を広げる)、`None` (未指定、
-                // 自動推論) は policy に従う。
-                let policy = resolve_add_lazy_policy(policy_override, &config_data);
-                let skip_for_explicit_eager = plugin.lazy_raw == Some(false);
-                if !skip_for_explicit_eager
-                    && !matches!(policy, crate::config::AutoLazyPolicy::Never)
-                    && let Some(suggestion) =
-                        build_add_suggestion(&crate::plugin_scan::scan_plugin(&dst_path))
-                    && let Some(applied) =
-                        decide_add_lazy_apply(suggestion, policy, &plugin.display_name())
-                {
-                    // 同じ config.toml を再度 toml_edit で開いて patch (既に変更され
-                    // ているので doc を捨てて atomic read-modify-write)。
-                    let latest = std::fs::read_to_string(&config_path)?;
-                    let mut doc_patch = latest.parse::<DocumentMut>()?;
-                    patch_plugin_entry_triggers(&mut doc_patch, &stored_url, &applied);
-                    let patched = doc_patch.to_string();
-                    let wp = chezmoi::write_path(config_data.options.chezmoi, &config_path).await;
-                    std::fs::write(&wp, &patched)?;
-                    chezmoi::apply(&wp, &config_path).await;
-                    println!(
-                        "Recorded lazy triggers for {} in config.toml.",
-                        plugin.display_name()
-                    );
+                // ── ここで mode 分岐 ────────────────────────────
+                // AI 設定が `Off` 以外なら静的 scan を skip して AI 経路 (#93)。
+                // それ以外は従来の auto-lazy scan + prompt (#87) に流す。
+                let effective_ai = ai_override.unwrap_or(config_data.options.ai);
+                if !matches!(effective_ai, crate::config::AiBackend::Off) {
+                    let backend = match effective_ai {
+                        crate::config::AiBackend::Claude => crate::ai::Backend::Claude,
+                        crate::config::AiBackend::Gemini => crate::ai::Backend::Gemini,
+                        crate::config::AiBackend::Codex => crate::ai::Backend::Codex,
+                        crate::config::AiBackend::Off => unreachable!(),
+                    };
+                    let cfg_root = resolve_config_root(config_data.options.config_root.as_deref());
+                    match crate::ai::run_ai_add(
+                        backend,
+                        &stored_url,
+                        &dst_path,
+                        &cfg_root,
+                        &config_path,
+                        &config_data.options.ai_language,
+                    )
+                    .await
+                    {
+                        Ok(outcome) => match outcome.outcome {
+                            crate::ai::ChatOutcome::Applied { written_hooks } => {
+                                if let Some(prop) = outcome.proposal {
+                                    // AI 提案の `[[plugins]]` body で既存 stub entry を置換。
+                                    let latest = std::fs::read_to_string(&config_path)?;
+                                    let mut doc_patch = latest.parse::<DocumentMut>()?;
+                                    if let Err(e) = replace_plugin_entry_with_ai_toml(
+                                        &mut doc_patch,
+                                        &stored_url,
+                                        &prop.plugin_entry_toml,
+                                    ) {
+                                        eprintln!(
+                                            "\u{26a0} failed to apply AI proposal: {e}. Stub entry remains."
+                                        );
+                                    } else {
+                                        let patched = doc_patch.to_string();
+                                        let wp = chezmoi::write_path(
+                                            config_data.options.chezmoi,
+                                            &config_path,
+                                        )
+                                        .await;
+                                        std::fs::write(&wp, &patched)?;
+                                        chezmoi::apply(&wp, &config_path).await;
+                                        println!(
+                                            "Applied AI-proposed config for {} ({} hook file(s) created).",
+                                            plugin.display_name(),
+                                            written_hooks.len()
+                                        );
+                                    }
+                                }
+                            }
+                            crate::ai::ChatOutcome::Skipped => {
+                                eprintln!(
+                                    "AI proposal skipped — stub entry kept in config.toml. \
+                                     Edit manually or rerun `rvpm add {repo} --no-ai` for static-scan mode."
+                                );
+                            }
+                            crate::ai::ChatOutcome::HandedOff => {
+                                eprintln!(
+                                    "Handed off to {} CLI. rvpm exits — that session controls config.toml from here.",
+                                    backend.label()
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            eprintln!(
+                                "\u{26a0} AI add failed: {e}. Stub entry kept; rerun with `--no-ai` for static-scan mode."
+                            );
+                        }
+                    }
+                } else {
+                    // ── auto-lazy scan + prompt (#87) — 従来路 ──────────
+                    let policy = resolve_add_lazy_policy(policy_override, &config_data);
+                    let skip_for_explicit_eager = plugin.lazy_raw == Some(false);
+                    if !skip_for_explicit_eager
+                        && !matches!(policy, crate::config::AutoLazyPolicy::Never)
+                        && let Some(suggestion) =
+                            build_add_suggestion(&crate::plugin_scan::scan_plugin(&dst_path))
+                        && let Some(applied) =
+                            decide_add_lazy_apply(suggestion, policy, &plugin.display_name())
+                    {
+                        let latest = std::fs::read_to_string(&config_path)?;
+                        let mut doc_patch = latest.parse::<DocumentMut>()?;
+                        patch_plugin_entry_triggers(&mut doc_patch, &stored_url, &applied);
+                        let patched = doc_patch.to_string();
+                        let wp =
+                            chezmoi::write_path(config_data.options.chezmoi, &config_path).await;
+                        std::fs::write(&wp, &patched)?;
+                        chezmoi::apply(&wp, &config_path).await;
+                        println!(
+                            "Recorded lazy triggers for {} in config.toml.",
+                            plugin.display_name()
+                        );
+                    }
                 }
             }
         }
@@ -5175,9 +5313,21 @@ async fn run_browse() -> Result<bool> {
                         // 多い — policy_override は渡さず、config `options.auto_lazy`
                         // (デフォルト `Ask`) に委ねる。browse は always TTY なので
                         // `Ask` なら対話プロンプトが自然に出る。
-                        let result =
-                            run_add(url.clone(), None, None, None, None, None, None, None, None)
-                                .await;
+                        // browse から add する場合も config の `options.ai` を尊重する
+                        // (user が AI mode を default にしてれば browse 経由でも AI 経路)。
+                        let result = run_add(
+                            url.clone(),
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await;
                         let added = result.is_ok();
                         match result {
                             Ok(_) => println!("Added {} successfully!", url),


### PR DESCRIPTION
## Summary

- New AI path for `rvpm add` that designs the full `[[plugins]]` block (lazy triggers, depends, per-plugin hook files) by delegating to an AI CLI tool the user has installed and authenticated.
- Three backends: `claude`, `gemini`, `codex`. Selected via `options.ai` or `--ai <backend>`. `--no-ai` forces the static-scan path.
- Two modes: **Mode A** (in-process chat loop with structured XML output) and **Mode B** (native handoff — rvpm exits and the CLI tool drives further file edits).

## Why

Static scan (#90) handles the common case but has known blind spots: wrapper-based command registration (obsidian.nvim's `M.register`), table-driven `nvim_create_user_command(v.cmd, ...)`, dynamic setup-time definitions, sensible \`depends\` inference, mode detection from README usage examples. An AI assistant fed the README + user config can propose end-to-end configs that go beyond what static analysis can do.

## Design highlights

- **CLI subprocess only.** No SDK / API key management — uses the user's existing `claude login` / `gemini auth`. Three CLIs share one trait via thin per-backend matchers (different `-p` / `exec` invocations).
- **Structured output.** AI replies inside `<rvpm:plugin_entry>` / `<rvpm:init_lua>` / `<rvpm:before_lua>` / `<rvpm:after_lua>` / `<rvpm:explanation>` tags. Robust to code-fence wrapping, preamble text, etc.
- **Schema is English, explanation can be localized.** The schema brief shown to the AI is always in English to avoid mode-confusion across CLIs. The `<rvpm:explanation>` body and chat replies follow `options.ai_language` (default `"en"`).
- **Mode B is fire-and-forget.** Handing off to native CLI exits rvpm; the CLI's own file-editing tools take it from there. README documents this clearly.
- **stub-then-replace flow.** Add path still writes a stub `[[plugins]]` entry to config.toml first, then clones, then asks the AI. On Apply, the stub is replaced in-place by the AI's proposal (URL forced to match what was stored, in case the AI used a different style).

## Test plan

- [x] `cargo make check` — 642 → 643 unit tests pass on the new branch.
- [ ] Manual: `claude` installed → `rvpm add owner/repo --ai claude`, verify proposal preview, Apply path, hook files written.
- [ ] Manual: chat refinement (\"add depends on plenary\") → updated proposal.
- [ ] Manual: handoff (`hand off to native CLI`) → CLI takes over.
- [ ] Manual: CLI not installed → friendly error with install hint.

## Notes

- Issue #94 tracks translating the existing CLAUDE.md to English (separate PR).
- AI mode ignores `auto_lazy` and `--auto-lazy` / `--no-lazy` flags (documented).
- Existing static-scan path is unchanged when `ai = "off"` (default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered plugin add mode (Claude/Gemini/Codex) with interactive Apply / Chat / Hand off / Skip flow
  * Per-call flags: --ai <backend> and --no-ai
  * ai_language controls natural-language portions while XML tag structure remains English
  * Hand off proposals to the external AI CLI for interactive editing

* **Behavior Changes**
  * Enabling AI skips the static auto-lazy trigger scan
  * Applied AI proposals merge into the existing plugin stub, preserving user-selected fields when present
  * Missing backend CLI surfaces clear errors; handoff invokes the external CLI

* **Documentation**
  * README and reference docs updated with AI mode usage, overrides, and runtime requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->