### PR TITLE
fix(ai): address post-merge CodeRabbit review on PR #104

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -398,15 +398,25 @@ pub fn validate_proposal_toml(toml_src: &str) -> Result<()> {
 ///     新しいバージョンの CLI で試したい場合等の escape hatch)
 ///   - `RVPM_AI_NO_MERGED=1` — backend に関わらず強制 OFF (デバッグ用)
 pub fn should_emit_merged(backend: Backend) -> bool {
-    let env_flag = |name: &str| {
-        std::env::var(name)
+    should_emit_merged_with(backend, |k| std::env::var(k).ok())
+}
+
+/// `should_emit_merged` の testable な実体。env 読み込みを closure に注入する。
+///
+/// なぜ injection: Rust 2024 では `std::env::set_var` / `remove_var` が `unsafe`
+/// 扱いになり、cargo test の並列実行下で他テストが env を変更すると非決定的
+/// になる。closure を取れば process-global env を触らずに backend dispatch /
+/// override 優先順位の単体テストが書ける (CodeRabbit PR #104 post-merge 指摘)。
+pub fn should_emit_merged_with(backend: Backend, get_env: impl Fn(&str) -> Option<String>) -> bool {
+    let flag = |name: &str| {
+        get_env(name)
             .map(|v| !v.is_empty() && v != "0")
             .unwrap_or(false)
     };
-    if env_flag("RVPM_AI_FORCE_MERGED") {
+    if flag("RVPM_AI_FORCE_MERGED") {
         return true;
     }
-    if env_flag("RVPM_AI_NO_MERGED") {
+    if flag("RVPM_AI_NO_MERGED") {
         return false;
     }
     match backend {
@@ -652,19 +662,72 @@ mod tests {
 
     #[test]
     fn should_emit_merged_default_per_backend() {
-        // env mutation はテスト並列実行で副作用が出るので、env を触らない判定だけ
-        // 確認する。デフォルトは backend dispatch:
-        //   - Gemini → false (gemini-cli の _recoverFromLoop 回避)
-        //   - Claude / Codex → true
-        // env override 系 (RVPM_AI_FORCE_MERGED / RVPM_AI_NO_MERGED) は手元で
-        // env 設定して確認する運用 (ここでは弾性が低い test なので skip)。
-        unsafe {
-            std::env::remove_var("RVPM_AI_FORCE_MERGED");
-            std::env::remove_var("RVPM_AI_NO_MERGED");
-        }
-        assert!(should_emit_merged(Backend::Claude));
-        assert!(should_emit_merged(Backend::Codex));
-        assert!(!should_emit_merged(Backend::Gemini));
+        // closure injection で process-global env を触らずに判定。
+        // 並列実行下でも他テストの env 変更に影響されない (CodeRabbit 指摘対応)。
+        let no_env = |_: &str| None;
+        assert!(should_emit_merged_with(Backend::Claude, no_env));
+        assert!(should_emit_merged_with(Backend::Codex, no_env));
+        assert!(!should_emit_merged_with(Backend::Gemini, no_env));
+    }
+
+    #[test]
+    fn should_emit_merged_force_overrides_backend_default() {
+        // RVPM_AI_FORCE_MERGED=1 は backend に関わらず ON
+        let force_on = |k: &str| {
+            if k == "RVPM_AI_FORCE_MERGED" {
+                Some("1".to_string())
+            } else {
+                None
+            }
+        };
+        assert!(should_emit_merged_with(Backend::Gemini, force_on));
+        assert!(should_emit_merged_with(Backend::Claude, force_on));
+    }
+
+    #[test]
+    fn should_emit_merged_no_merged_overrides_backend_default() {
+        // RVPM_AI_NO_MERGED=1 は backend に関わらず OFF
+        let no_merged = |k: &str| {
+            if k == "RVPM_AI_NO_MERGED" {
+                Some("1".to_string())
+            } else {
+                None
+            }
+        };
+        assert!(!should_emit_merged_with(Backend::Claude, no_merged));
+        assert!(!should_emit_merged_with(Backend::Codex, no_merged));
+        assert!(!should_emit_merged_with(Backend::Gemini, no_merged));
+    }
+
+    #[test]
+    fn should_emit_merged_force_wins_over_no_merged() {
+        // 両方立ってたら FORCE が勝つ (escape hatch を尊重)
+        let both = |k: &str| match k {
+            "RVPM_AI_FORCE_MERGED" | "RVPM_AI_NO_MERGED" => Some("1".to_string()),
+            _ => None,
+        };
+        assert!(should_emit_merged_with(Backend::Gemini, both));
+    }
+
+    #[test]
+    fn should_emit_merged_treats_zero_and_empty_as_unset() {
+        // "0" と "" は flag 立ってない扱い (rvpm 一般の環境変数規約)
+        let zero = |k: &str| {
+            if k == "RVPM_AI_NO_MERGED" {
+                Some("0".to_string())
+            } else {
+                None
+            }
+        };
+        assert!(should_emit_merged_with(Backend::Claude, zero));
+        let empty = |k: &str| {
+            if k == "RVPM_AI_NO_MERGED" {
+                Some(String::new())
+            } else {
+                None
+            }
+        };
+        assert!(should_emit_merged_with(Backend::Claude, empty));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2988,10 +2988,20 @@ async fn run_add(
                                     // apply の regression を示す。silent に stub を残すと
                                     // 「green path に化けたバグ」になるので明示 fail する
                                     // (CodeRabbit PR #104 post-merge レビュー指摘)。
+                                    //
+                                    // **state note (Gemini PR #105 指摘)**: stub entry は
+                                    // run_add の冒頭で既に config.toml に書き込まれている。
+                                    // ここでの bail はそれを rollback しないので、stub は
+                                    // disk に残ったまま。message でその事実 + リカバリ手段を
+                                    // 明示し、「refusing to keep」みたいな誤読しやすい表現は
+                                    // 避ける。
                                     anyhow::bail!(
-                                        "AI add returned no [[plugins]] proposal for {}; \
-                                         refusing to keep the stub entry from `rvpm add --ai`",
-                                        plugin.display_name()
+                                        "AI add returned no [[plugins]] proposal for {0}. \
+                                         The stub entry written to {1} is left as-is — \
+                                         remove it manually with `rvpm remove {0}` or rerun \
+                                         `rvpm add` with `--no-ai` for the static-scan path.",
+                                        plugin.display_name(),
+                                        config_path.display()
                                     );
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,8 +192,14 @@ enum Commands {
     /// At Apply time you pick per-section: `Use FRESH` (overwrite),
     /// `Use MERGED` (overwrite, keep your edits), or `Keep existing`
     /// (no change). Same choice applies to the `[[plugins]]` entry
-    /// itself. Use the Chat action to tell the AI to keep a particular
-    /// field, or just pick `Keep existing` for that section.
+    /// itself.
+    ///
+    /// Note: selecting `FRESH` or `MERGED` still overwrites that section.
+    /// For the `[[plugins]]` entry, fields the chosen proposal omits are
+    /// removed (destructive replace); only `Keep existing` leaves the
+    /// current entry untouched. Use the Chat action to tell the AI to
+    /// keep a particular field, or just pick `Keep existing` for that
+    /// section.
     Tune {
         /// Fuzzy match plugin url (omit to pick interactively)
         query: Option<String>,
@@ -2977,10 +2983,15 @@ async fn run_add(
                                         );
                                     }
                                 } else {
-                                    println!(
-                                        "Kept existing entry for {} ({} hook file(s) created/overwritten).",
-                                        plugin.display_name(),
-                                        written_hooks.len()
+                                    // `add --ai` には "keep existing" の概念が無い (stub
+                                    // entry しか存在しない) ので、ここに来るのは chat /
+                                    // apply の regression を示す。silent に stub を残すと
+                                    // 「green path に化けたバグ」になるので明示 fail する
+                                    // (CodeRabbit PR #104 post-merge レビュー指摘)。
+                                    anyhow::bail!(
+                                        "AI add returned no [[plugins]] proposal for {}; \
+                                         refusing to keep the stub entry from `rvpm add --ai`",
+                                        plugin.display_name()
                                     );
                                 }
                             }


### PR DESCRIPTION
## Summary

Three actionable items that CodeRabbit posted after PR #104 was already merged:

- **`run_add` silently kept stub on `plugin_entry_toml = None` (Major)** — `rvpm add --ai` doesn't have an "existing entry to keep" concept; the None branch only made sense for `tune`. The previous code printed \"Kept existing entry\" and exited successfully, hiding any chat/apply regression behind a green path. Now it \`anyhow::bail!\`s.
- **Tune help text conflated MergeMode::Replace with `_merged` (Minor)** — added a \"Note:\" paragraph clarifying that selecting FRESH or MERGED for the \`[[plugins]]\` entry is a destructive replace; only \`Keep existing\` leaves the current entry untouched.
- **`should_emit_merged` test mutated process env (Minor)** — refactored \`should_emit_merged\` to delegate to \`should_emit_merged_with(backend, get_env)\` so tests inject closures and never touch process-global env. Added 4 deterministic tests covering: per-backend default, FORCE_MERGED override, NO_MERGED override, FORCE-wins-over-NO_MERGED, and treatment of \`\"0\"\` / empty as unset.

Will be released as v3.30.1 after merge.

## Test plan

- [x] \`cargo test\` — 708 pass (was 704, +4 from the new env-resolver tests).
- [x] \`cargo clippy --all-targets\` clean.
- [x] \`cargo fmt --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)