### PR TITLE
refactor: remove git CLI dependency from log / diff code paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,6 +451,15 @@ merge 戦略がファイル単位 hard link に切り替わって以降、Window
 **廃止コマンド:**
 - `status` → `list --no-tui` に統合 (plain text 出力で機能同等)
 
+### CLI フラグ / サブコマンド追加時のチェックリスト
+
+サブコマンドフラグ (`--prune` / `--ai` / `--no-tui` 等) を **追加・改名・削除** したり、**新規サブコマンド** を増やしたりした場合、[rvpm.nvim](https://github.com/yukimemi/rvpm.nvim) の `lua/rvpm/command.lua` も同期更新すること。具体的には:
+
+- 新規サブコマンド: `SUBCOMMANDS` 配列に追加。TUI に流すなら `TUI` テーブル、plugin 名引数を取るなら `PLUGIN_ARG_SUBS` テーブルにも登録。フラグを持つなら `FLAGS` テーブルにエントリ追加。`lua/rvpm/init.lua` の便利 Lua API も検討。
+- 既存サブコマンドへのフラグ追加/改名/削除: 該当する `FLAGS[<sub>]` エントリを更新。
+
+rvpm.nvim 側は `:Rvpm <sub> --<Tab>` の補完候補のために rvpm core のフラグ一覧を **ハードコードでミラー** している (動的な `--help` parse は Neovim 起動時のコスト観点から採用していない)。同期し忘れると Neovim 上で「実在するフラグが補完候補に出ない」or「廃止済みフラグが候補に残る」という silent な drift が発生する。CLI 関連 PR の self-review checklist に含めること。
+
 ### ディレクトリレイアウト (デフォルト)
 
 | パス | 用途 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,12 +453,12 @@ merge 戦略がファイル単位 hard link に切り替わって以降、Window
 
 ### CLI フラグ / サブコマンド追加時のチェックリスト
 
-サブコマンドフラグ (`--prune` / `--ai` / `--no-tui` 等) を **追加・改名・削除** したり、**新規サブコマンド** を増やしたりした場合、[rvpm.nvim](https://github.com/yukimemi/rvpm.nvim) の `lua/rvpm/command.lua` も同期更新すること。具体的には:
+サブコマンドフラグ (`--prune` / `--ai` / `--no-tui` 等) を **追加・改名・削除** したり、**新規サブコマンド** を追加したりした場合、[rvpm.nvim](https://github.com/yukimemi/rvpm.nvim) の `lua/rvpm/command.lua` も同期更新すること。具体的には:
 
 - 新規サブコマンド: `SUBCOMMANDS` 配列に追加。TUI に流すなら `TUI` テーブル、plugin 名引数を取るなら `PLUGIN_ARG_SUBS` テーブルにも登録。フラグを持つなら `FLAGS` テーブルにエントリ追加。`lua/rvpm/init.lua` の便利 Lua API も検討。
 - 既存サブコマンドへのフラグ追加/改名/削除: 該当する `FLAGS[<sub>]` エントリを更新。
 
-rvpm.nvim 側は `:Rvpm <sub> --<Tab>` の補完候補のために rvpm core のフラグ一覧を **ハードコードでミラー** している (動的な `--help` parse は Neovim 起動時のコスト観点から採用していない)。同期し忘れると Neovim 上で「実在するフラグが補完候補に出ない」or「廃止済みフラグが候補に残る」という silent な drift が発生する。CLI 関連 PR の self-review checklist に含めること。
+rvpm.nvim 側は `:Rvpm <sub> --<Tab>` の補完候補のために rvpm core のフラグ一覧を **ハードコードでミラー**している (動的な `--help` parse は Neovim 起動時のコスト観点から採用していない)。同期し忘れると Neovim 上で「実在するフラグが補完候補に出ない」または「廃止済みフラグが候補に残る」という silent な drift が発生する。CLI 関連 PR の self-review checklist に含めること。
 
 ### ディレクトリレイアウト (デフォルト)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Selecting the `[user config]` pseudo-plugin swaps the detail pane for a **requir
 - **Diagnostics & history** — `rvpm doctor` reports config / state / env in one
   shot; `rvpm log` shows what commits landed on the last sync, with `⚠ BREAKING`
   highlight and optional inline `--diff`
+- **Pure-Rust git via `gix`** — clone, fetch, checkout, status, and diff all run
+  in-process; no `git` binary required at runtime
 - **Resilient** — cyclic dependencies, missing plugins, and config errors emit
   warnings, not crashes
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -926,22 +926,22 @@ pub async fn check_tool_nvim(resolver: &dyn VersionResolver) -> Diagnostic {
     }
 }
 
-/// `git` コマンドの存在とバージョン。必須。
+/// `git` コマンドの存在とバージョン。rvpm 自体は gix で動くので runtime 依存ではなく
+/// 任意。インストール済みかどうかを情報として表示する。
 pub async fn check_tool_git(resolver: &dyn VersionResolver) -> Diagnostic {
     match resolver.version("git").await {
         Some(v) => Diagnostic::new(
             Severity::Ok,
             CAT_TOOLS,
             "git",
-            format!("{}            (required)", shorten_version(&v)),
+            format!("{}            (optional)", shorten_version(&v)),
         ),
         None => Diagnostic::new(
-            Severity::Error,
+            Severity::Ok,
             CAT_TOOLS,
             "git",
-            "not found             (required)",
-        )
-        .with_hint("install git"),
+            "not found             (optional)",
+        ),
     }
 }
 
@@ -2026,6 +2026,16 @@ mod tests {
         let d = check_tool_git(&r).await;
         assert_eq!(d.severity, Severity::Ok);
         assert!(d.summary.contains("v2.49.1"));
+        assert!(d.summary.contains("optional"));
+    }
+
+    /// git は runtime 依存ではないので、未インストールでも Severity::Ok。
+    #[tokio::test]
+    async fn test_check_tool_git_missing_is_ok() {
+        let r = MockResolver::new();
+        let d = check_tool_git(&r).await;
+        assert_eq!(d.severity, Severity::Ok);
+        assert!(d.summary.contains("optional"));
     }
 
     #[tokio::test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -373,42 +373,206 @@ fn split_subject_body(msg: &str) -> (&str, &str) {
 }
 
 /// `<from>..<to>` で変更があった README/CHANGELOG/doc 系ファイルの相対パス一覧を返す。
-/// `git diff --name-only` を spawn する (gix の diff API は複雑なため subprocess)。
-/// `git` が PATH に無い / 失敗時は空 Vec (resilience)。
+/// `gix::Repository::diff_tree_to_tree` で tree-walk し、ファイル名で filter する。
+/// 失敗時 (repo open / rev parse / tree peel) は空 Vec (resilience)。
 fn doc_files_changed(dst: &Path, from: &str, to: &str) -> Vec<String> {
-    let output = match std::process::Command::new("git")
-        .arg("-C")
-        .arg(dst)
-        .args([
-            "diff",
-            "--name-only",
-            &format!("{}..{}", from, to),
-            "--",
-            "README*",
-            "readme*",
-            "Readme*",
-            "CHANGELOG*",
-            "changelog*",
-            "Changelog*",
-            "doc/",
-        ])
-        .output()
-    {
-        Ok(o) => o,
-        Err(_) => return Vec::new(),
-    };
-    if !output.status.success() {
-        return Vec::new();
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut files: Vec<String> = stdout
-        .lines()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+    let mut files: Vec<String> = tree_changes(dst, from, to)
+        .into_iter()
+        .flat_map(change_paths)
+        .filter(|p| is_doc_path(p))
         .collect();
     files.sort();
     files.dedup();
     files
+}
+
+/// `<from>..<to>` の tree diff を返す共通ヘルパー。
+/// repo open / rev parse / tree peel のいずれかで失敗したら空 Vec (resilience)。
+fn tree_changes(dst: &Path, from: &str, to: &str) -> Vec<gix::object::tree::diff::ChangeDetached> {
+    fn inner(
+        dst: &Path,
+        from: &str,
+        to: &str,
+    ) -> Result<Vec<gix::object::tree::diff::ChangeDetached>> {
+        let repo = gix::open(dst)?;
+        let from_id = repo.rev_parse_single(from)?;
+        let to_id = repo.rev_parse_single(to)?;
+        let from_tree = repo.find_commit(from_id)?.tree()?;
+        let to_tree = repo.find_commit(to_id)?.tree()?;
+        Ok(repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)?)
+    }
+    inner(dst, from, to).unwrap_or_default()
+}
+
+/// `ChangeDetached` から path を 1 つ以上取り出す。
+/// Rewrite (rename / copy) は source / dest の両方を返し、`git diff --name-only` の
+/// rewrite-tracking 無効時の挙動 (deletion + addition の 2 行) と等価な情報量にする。
+fn change_paths(change: gix::object::tree::diff::ChangeDetached) -> Vec<String> {
+    use gix::object::tree::diff::ChangeDetached;
+    match change {
+        ChangeDetached::Addition { location, .. }
+        | ChangeDetached::Deletion { location, .. }
+        | ChangeDetached::Modification { location, .. } => vec![location.to_string()],
+        ChangeDetached::Rewrite {
+            source_location,
+            location,
+            ..
+        } => vec![source_location.to_string(), location.to_string()],
+    }
+}
+
+/// path が "doc files" 集合 (top-level README*/CHANGELOG* + `doc/` 配下) に該当するか。
+/// 旧実装の `git diff -- README* readme* Readme* CHANGELOG* changelog* Changelog* doc/`
+/// と等価な集合を case-insensitive で表現する (top-level 限定なのは git pathspec の `*`
+/// が `/` を跨がないため)。
+fn is_doc_path(path: &str) -> bool {
+    if let Some(rest) = path.strip_prefix("doc/") {
+        return !rest.is_empty();
+    }
+    let top_level = !path.contains('/');
+    if top_level {
+        let lower = path.to_ascii_lowercase();
+        return lower.starts_with("readme") || lower.starts_with("changelog");
+    }
+    false
+}
+
+/// `<from>..<to>` で変更があった `path` の unified diff を返す。
+/// `path` が変化していない / repo open 失敗時は `None` (resilience)。
+/// バイナリは "Binary files ... differ" の 1 行に丸める (git の挙動と同じ)。
+pub fn doc_file_patch(dst: &Path, from: &str, to: &str, path: &str) -> Option<String> {
+    use gix::object::tree::diff::ChangeDetached;
+
+    let repo = gix::open(dst).ok()?;
+    let from_id = repo.rev_parse_single(from).ok()?;
+    let to_id = repo.rev_parse_single(to).ok()?;
+    let from_tree = repo.find_commit(from_id).ok()?.tree().ok()?;
+    let to_tree = repo.find_commit(to_id).ok()?.tree().ok()?;
+    let changes = repo
+        .diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
+        .ok()?;
+
+    let path_bytes = path.as_bytes();
+    let change = changes.into_iter().find(|c| match c {
+        ChangeDetached::Addition { location, .. }
+        | ChangeDetached::Deletion { location, .. }
+        | ChangeDetached::Modification { location, .. } => location.as_slice() == path_bytes,
+        ChangeDetached::Rewrite {
+            source_location,
+            location,
+            ..
+        } => location.as_slice() == path_bytes || source_location.as_slice() == path_bytes,
+    })?;
+
+    let read_blob = |oid: gix::ObjectId| repo.find_blob(oid).ok().map(|b| b.detach().data);
+
+    let (before, after, before_oid, after_oid) = match change {
+        ChangeDetached::Modification {
+            previous_id, id, ..
+        } => (
+            read_blob(previous_id).unwrap_or_default(),
+            read_blob(id).unwrap_or_default(),
+            previous_id.to_string(),
+            id.to_string(),
+        ),
+        ChangeDetached::Addition { id, .. } => (
+            Vec::new(),
+            read_blob(id).unwrap_or_default(),
+            "0000000".to_string(),
+            id.to_string(),
+        ),
+        ChangeDetached::Deletion { id, .. } => (
+            read_blob(id).unwrap_or_default(),
+            Vec::new(),
+            id.to_string(),
+            "0000000".to_string(),
+        ),
+        ChangeDetached::Rewrite { source_id, id, .. } => (
+            read_blob(source_id).unwrap_or_default(),
+            read_blob(id).unwrap_or_default(),
+            source_id.to_string(),
+            id.to_string(),
+        ),
+    };
+
+    Some(format_unified_diff(
+        path,
+        &before,
+        &after,
+        &before_oid,
+        &after_oid,
+    ))
+}
+
+/// git の null byte ヒューリスティック: 先頭 8KB に NUL があれば binary。
+fn is_binary(buf: &[u8]) -> bool {
+    let probe = &buf[..buf.len().min(8 * 1024)];
+    probe.contains(&0u8)
+}
+
+fn format_unified_diff(
+    path: &str,
+    before: &[u8],
+    after: &[u8],
+    before_oid: &str,
+    after_oid: &str,
+) -> String {
+    use gix::diff::blob::{
+        Algorithm, Diff, InternedInput, UnifiedDiff,
+        sources::byte_lines,
+        unified_diff::{ConsumeHunk, ContextSize, DiffLineKind, HunkHeader},
+    };
+
+    let short = |oid: &str| oid.get(..7).unwrap_or(oid).to_string();
+    let mut out = String::new();
+    out.push_str(&format!("diff --git a/{path} b/{path}\n"));
+    out.push_str(&format!(
+        "index {}..{}\n",
+        short(before_oid),
+        short(after_oid)
+    ));
+
+    if is_binary(before) || is_binary(after) {
+        out.push_str(&format!("Binary files a/{path} and b/{path} differ\n"));
+        return out;
+    }
+
+    out.push_str(&format!("--- a/{path}\n"));
+    out.push_str(&format!("+++ b/{path}\n"));
+
+    let input = InternedInput::new(byte_lines(before), byte_lines(after));
+    let mut diff = Diff::compute(Algorithm::Histogram, &input);
+    diff.postprocess_lines(&input);
+
+    struct Sink(String);
+    impl ConsumeHunk for Sink {
+        type Out = String;
+        fn consume_hunk(
+            &mut self,
+            header: HunkHeader,
+            lines: &[(DiffLineKind, &[u8])],
+        ) -> std::io::Result<()> {
+            // HunkHeader implements Display as `@@ -A,B +C,D @@`.
+            self.0.push_str(&format!("{}\n", header));
+            for (kind, line) in lines {
+                self.0.push(kind.to_prefix());
+                self.0.push_str(&String::from_utf8_lossy(line));
+                if !line.ends_with(b"\n") {
+                    self.0.push('\n');
+                }
+            }
+            Ok(())
+        }
+        fn finish(self) -> Self::Out {
+            self.0
+        }
+    }
+
+    let body = UnifiedDiff::new(&diff, &input, Sink(String::new()), ContextSize::default())
+        .consume()
+        .unwrap_or_default();
+    out.push_str(&body);
+    out
 }
 
 fn clone_impl(url: &str, dst: &Path) -> Result<()> {
@@ -1438,5 +1602,243 @@ mod tests {
         let c = repo.update().await.unwrap().expect("HEAD moved");
         assert!(c.from.is_some());
         assert!(c.subjects.iter().any(|s| s.contains("bump")));
+    }
+
+    #[test]
+    fn test_is_doc_path() {
+        assert!(is_doc_path("README"));
+        assert!(is_doc_path("README.md"));
+        assert!(is_doc_path("readme.txt"));
+        assert!(is_doc_path("ReadMe"));
+        assert!(is_doc_path("CHANGELOG"));
+        assert!(is_doc_path("CHANGELOG.md"));
+        assert!(is_doc_path("changelog"));
+        assert!(is_doc_path("doc/foo.txt"));
+        assert!(is_doc_path("doc/sub/bar.txt"));
+        assert!(!is_doc_path(""));
+        assert!(!is_doc_path("doc/"));
+        assert!(!is_doc_path("docs/foo.txt")); // not "doc/"
+        assert!(!is_doc_path("src/README.md")); // not top-level
+        assert!(!is_doc_path("Cargo.toml"));
+    }
+
+    /// `<from>..<to>` で README.md / doc/ の変更が拾え、無関係ファイルが落ちる。
+    #[tokio::test]
+    async fn test_doc_files_changed_filters_to_doc_set() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        fs::create_dir_all(src.join("doc")).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "v1\n").unwrap();
+        fs::write(src.join("doc/intro.txt"), "hello\n").unwrap();
+        fs::write(src.join("src.txt"), "code v1\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("README.md"), "v2\n").unwrap();
+        fs::write(src.join("doc/intro.txt"), "world\n").unwrap();
+        fs::write(src.join("src.txt"), "code v2\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let mut files = doc_files_changed(&src, &from, &to);
+        files.sort();
+        assert_eq!(
+            files,
+            vec!["README.md".to_string(), "doc/intro.txt".to_string()]
+        );
+    }
+
+    /// repo open / rev parse 失敗で空 Vec (resilience)。
+    #[tokio::test]
+    async fn test_doc_files_changed_resilient_to_missing_repo() {
+        let root = tempdir().unwrap();
+        let nowhere = root.path().join("nowhere");
+        let files = doc_files_changed(&nowhere, "deadbeef", "cafebabe");
+        assert!(files.is_empty());
+    }
+
+    /// unified diff の hunk header と +/- 行が想定どおり生成される。
+    #[tokio::test]
+    async fn test_doc_file_patch_emits_unified_diff() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "alpha\nbeta\ngamma\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("README.md"), "alpha\nBETA\ngamma\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let patch = doc_file_patch(&src, &from, &to, "README.md").expect("patch");
+        assert!(patch.contains("diff --git a/README.md b/README.md"));
+        assert!(patch.contains("--- a/README.md"));
+        assert!(patch.contains("+++ b/README.md"));
+        assert!(patch.contains("@@"));
+        assert!(patch.contains("-beta"));
+        assert!(patch.contains("+BETA"));
+    }
+
+    /// 追加ファイルでも patch が出る (`/dev/null` 起点でなくても header は出す)。
+    #[tokio::test]
+    async fn test_doc_file_patch_handles_addition() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "v1\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("CHANGELOG.md"), "first release\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "add cl"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let patch = doc_file_patch(&src, &from, &to, "CHANGELOG.md").expect("patch");
+        assert!(patch.contains("diff --git a/CHANGELOG.md b/CHANGELOG.md"));
+        assert!(patch.contains("+first release"));
+    }
+
+    /// 該当ファイルが diff に含まれない場合は `None`。
+    #[tokio::test]
+    async fn test_doc_file_patch_returns_none_for_unchanged_path() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "v1\n").unwrap();
+        fs::write(src.join("other.txt"), "stable\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("README.md"), "v2\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        assert!(doc_file_patch(&src, &from, &to, "other.txt").is_none());
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -373,12 +373,14 @@ fn split_subject_body(msg: &str) -> (&str, &str) {
 }
 
 /// `<from>..<to>` で変更があった README/CHANGELOG/doc 系ファイルの相対パス一覧を返す。
-/// `gix::Repository::diff_tree_to_tree` で tree-walk し、ファイル名で filter する。
 /// 失敗時 (repo open / rev parse / tree peel) は空 Vec (resilience)。
 fn doc_files_changed(dst: &Path, from: &str, to: &str) -> Vec<String> {
-    let mut files: Vec<String> = tree_changes(dst, from, to)
+    let Some((_repo, changes)) = open_and_diff(dst, from, to) else {
+        return Vec::new();
+    };
+    let mut files: Vec<String> = changes
         .into_iter()
-        .flat_map(change_paths)
+        .map(change_location)
         .filter(|p| is_doc_path(p))
         .collect();
     files.sort();
@@ -386,38 +388,43 @@ fn doc_files_changed(dst: &Path, from: &str, to: &str) -> Vec<String> {
     files
 }
 
-/// `<from>..<to>` の tree diff を返す共通ヘルパー。
-/// repo open / rev parse / tree peel のいずれかで失敗したら空 Vec (resilience)。
-fn tree_changes(dst: &Path, from: &str, to: &str) -> Vec<gix::object::tree::diff::ChangeDetached> {
-    fn inner(
-        dst: &Path,
-        from: &str,
-        to: &str,
-    ) -> Result<Vec<gix::object::tree::diff::ChangeDetached>> {
-        let repo = gix::open(dst)?;
-        let from_id = repo.rev_parse_single(from)?;
-        let to_id = repo.rev_parse_single(to)?;
-        let from_tree = repo.find_commit(from_id)?.tree()?;
-        let to_tree = repo.find_commit(to_id)?.tree()?;
-        Ok(repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)?)
-    }
-    inner(dst, from, to).unwrap_or_default()
+/// repo open / rev parse / tree peel / tree diff をまとめて行うヘルパー。
+/// 失敗時は `None` (resilience)。Rewrite tracking は明示的に無効化することで、
+/// rename を Deletion + Addition の 2 件として返させる
+/// (旧 `git diff --name-only` (rename detection 無し) と等価な挙動)。
+fn open_and_diff(
+    dst: &Path,
+    from: &str,
+    to: &str,
+) -> Option<(
+    gix::Repository,
+    Vec<gix::object::tree::diff::ChangeDetached>,
+)> {
+    let repo = gix::open(dst).ok()?;
+    // `from_tree` / `to_tree` borrow from `repo`; scope them in a block so they
+    // drop before we move `repo` into the returned tuple.
+    let changes = {
+        let from_id = repo.rev_parse_single(from).ok()?;
+        let to_id = repo.rev_parse_single(to).ok()?;
+        let from_tree = repo.find_commit(from_id).ok()?.tree().ok()?;
+        let to_tree = repo.find_commit(to_id).ok()?.tree().ok()?;
+        let options = gix::diff::Options::default().with_rewrites(None);
+        repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(options))
+            .ok()?
+    };
+    Some((repo, changes))
 }
 
-/// `ChangeDetached` から path を 1 つ以上取り出す。
-/// Rewrite (rename / copy) は source / dest の両方を返し、`git diff --name-only` の
-/// rewrite-tracking 無効時の挙動 (deletion + addition の 2 行) と等価な情報量にする。
-fn change_paths(change: gix::object::tree::diff::ChangeDetached) -> Vec<String> {
+/// `ChangeDetached` から destination path を返す。Rewrite tracking は
+/// `open_and_diff` で無効化しているのでこの実装で出会わない想定だが、
+/// 保険として location を返しておく (パスの重複は呼び出し側で `dedup`)。
+fn change_location(change: gix::object::tree::diff::ChangeDetached) -> String {
     use gix::object::tree::diff::ChangeDetached;
     match change {
         ChangeDetached::Addition { location, .. }
         | ChangeDetached::Deletion { location, .. }
-        | ChangeDetached::Modification { location, .. } => vec![location.to_string()],
-        ChangeDetached::Rewrite {
-            source_location,
-            location,
-            ..
-        } => vec![source_location.to_string(), location.to_string()],
+        | ChangeDetached::Modification { location, .. }
+        | ChangeDetached::Rewrite { location, .. } => location.to_string(),
     }
 }
 
@@ -437,59 +444,80 @@ fn is_doc_path(path: &str) -> bool {
     false
 }
 
-/// `<from>..<to>` で変更があった `path` の unified diff を返す。
-/// `path` が変化していない / repo open 失敗時は `None` (resilience)。
-/// バイナリは "Binary files ... differ" の 1 行に丸める (git の挙動と同じ)。
-pub fn doc_file_patch(dst: &Path, from: &str, to: &str, path: &str) -> Option<String> {
+/// `<from>..<to>` で `paths` に含まれるファイルそれぞれの unified diff をまとめて返す。
+/// repo を 1 度だけ open して tree diff も 1 度だけ計算するので、`run_log --diff` が
+/// 1 plugin × 多数 doc ファイルを処理するときの I/O を抑える。
+/// repo open / rev parse / blob lookup 失敗時は当該 path の entry を結果に含めない
+/// (resilience: 偽の空 diff を作らない)。
+pub fn doc_file_patches(
+    dst: &Path,
+    from: &str,
+    to: &str,
+    paths: &[String],
+) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    let Some((repo, changes)) = open_and_diff(dst, from, to) else {
+        return out;
+    };
+    for path in paths {
+        if let Some(patch) = build_patch_for_path(&repo, &changes, path) {
+            out.insert(path.clone(), patch);
+        }
+    }
+    out
+}
+
+/// 単一ファイルの patch 生成 (テスト用 thin wrapper)。本番経路は
+/// `doc_file_patches` を使ってまとめて取得する。
+#[cfg(test)]
+fn doc_file_patch(dst: &Path, from: &str, to: &str, path: &str) -> Option<String> {
+    doc_file_patches(dst, from, to, std::slice::from_ref(&path.to_string())).remove(path)
+}
+
+fn build_patch_for_path(
+    repo: &gix::Repository,
+    changes: &[gix::object::tree::diff::ChangeDetached],
+    path: &str,
+) -> Option<String> {
     use gix::object::tree::diff::ChangeDetached;
 
-    let repo = gix::open(dst).ok()?;
-    let from_id = repo.rev_parse_single(from).ok()?;
-    let to_id = repo.rev_parse_single(to).ok()?;
-    let from_tree = repo.find_commit(from_id).ok()?.tree().ok()?;
-    let to_tree = repo.find_commit(to_id).ok()?.tree().ok()?;
-    let changes = repo
-        .diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
-        .ok()?;
-
     let path_bytes = path.as_bytes();
-    let change = changes.into_iter().find(|c| match c {
+    let change = changes.iter().find(|c| match c {
         ChangeDetached::Addition { location, .. }
         | ChangeDetached::Deletion { location, .. }
-        | ChangeDetached::Modification { location, .. } => location.as_slice() == path_bytes,
-        ChangeDetached::Rewrite {
-            source_location,
-            location,
-            ..
-        } => location.as_slice() == path_bytes || source_location.as_slice() == path_bytes,
+        | ChangeDetached::Modification { location, .. }
+        | ChangeDetached::Rewrite { location, .. } => location.as_slice() == path_bytes,
     })?;
 
     let read_blob = |oid: gix::ObjectId| repo.find_blob(oid).ok().map(|b| b.detach().data);
 
-    let (before, after, before_oid, after_oid) = match change {
+    let (before, after, before_oid, after_oid) = match *change {
         ChangeDetached::Modification {
             previous_id, id, ..
         } => (
-            read_blob(previous_id).unwrap_or_default(),
-            read_blob(id).unwrap_or_default(),
+            read_blob(previous_id)?,
+            read_blob(id)?,
             previous_id.to_string(),
             id.to_string(),
         ),
         ChangeDetached::Addition { id, .. } => (
             Vec::new(),
-            read_blob(id).unwrap_or_default(),
+            read_blob(id)?,
             "0000000".to_string(),
             id.to_string(),
         ),
         ChangeDetached::Deletion { id, .. } => (
-            read_blob(id).unwrap_or_default(),
+            read_blob(id)?,
             Vec::new(),
             id.to_string(),
             "0000000".to_string(),
         ),
+        // Rewrite tracking は `open_and_diff` で無効化済み。万一 rename が
+        // Rewrite で来たら destination → destination で素直に diff する
+        // (source 側は Deletion として別 entry に分離されるはず)。
         ChangeDetached::Rewrite { source_id, id, .. } => (
-            read_blob(source_id).unwrap_or_default(),
-            read_blob(id).unwrap_or_default(),
+            read_blob(source_id)?,
+            read_blob(id)?,
             source_id.to_string(),
             id.to_string(),
         ),
@@ -1791,6 +1819,170 @@ mod tests {
         let patch = doc_file_patch(&src, &from, &to, "CHANGELOG.md").expect("patch");
         assert!(patch.contains("diff --git a/CHANGELOG.md b/CHANGELOG.md"));
         assert!(patch.contains("+first release"));
+    }
+
+    /// バイナリ blob は `Binary files ... differ` の 1 行に丸める。
+    #[tokio::test]
+    async fn test_doc_file_patch_handles_binary_blob() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        // null-byte を含む binary 風 blob (現実的には PNG / dat 等の `doc/` 内画像)。
+        fs::create_dir_all(src.join("doc")).unwrap();
+        fs::write(
+            src.join("doc/asset.bin"),
+            [0xFFu8, 0x00, 0xAB, 0x00, b'd', b'\n'],
+        )
+        .unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("doc/asset.bin"), [0x00u8, 0x01, 0x02, 0x03, b'\n']).unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let patch = doc_file_patch(&src, &from, &to, "doc/asset.bin").expect("patch");
+        assert!(patch.contains("diff --git a/doc/asset.bin b/doc/asset.bin"));
+        assert!(patch.contains("Binary files a/doc/asset.bin and b/doc/asset.bin differ"));
+        // bin だと unified hunk は出ない (early return)。
+        assert!(!patch.contains("@@"));
+    }
+
+    /// blob 取得が失敗してもパス自体が tree diff に含まれていない (= 無関係) なら
+    /// `None`。`unwrap_or_default` を使っていないことを担保する回帰テスト。
+    #[tokio::test]
+    async fn test_doc_file_patches_skips_paths_not_in_diff() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "v1\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("README.md"), "v2\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let paths = vec!["README.md".to_string(), "ghost.md".to_string()];
+        let patches = doc_file_patches(&src, &from, &to, &paths);
+        assert!(patches.contains_key("README.md"));
+        assert!(!patches.contains_key("ghost.md"));
+    }
+
+    /// `gix_diff::blob::sources::byte_lines` は token に改行を含むので、
+    /// unified diff の output で行と行が連結しない。retro-fix 防止。
+    #[tokio::test]
+    async fn test_doc_file_patch_lines_are_separated() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("repo");
+        fs::create_dir_all(&src).unwrap();
+        git_cmd(&src).args(["init"]).output().await.unwrap();
+        fs::write(src.join("README.md"), "alpha\nbeta\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+        let from = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        fs::write(src.join("README.md"), "ALPHA\nBETA\n").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "bump"])
+            .output()
+            .await
+            .unwrap();
+        let to = String::from_utf8(
+            git_cmd(&src)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .await
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        let patch = doc_file_patch(&src, &from, &to, "README.md").expect("patch");
+        // 行が `-alpha-beta` のように連結していたら byte_lines が改行を切り捨てている。
+        assert!(patch.contains("-alpha\n"));
+        assert!(patch.contains("-beta\n"));
+        assert!(patch.contains("+ALPHA\n"));
+        assert!(patch.contains("+BETA\n"));
     }
 
     /// 該当ファイルが diff に含まれない場合は `None`。

--- a/src/main.rs
+++ b/src/main.rs
@@ -5156,10 +5156,15 @@ async fn run_log(query: Option<String>, last: usize, full: bool, diff: bool) -> 
                     continue;
                 };
                 let dst_path = resolve_plugin_dst(plugin, &cache_root);
+                // 1 plugin 分の patch をまとめて取得 (repo open / tree diff は 1 回)。
+                let patches = crate::git::doc_file_patches(
+                    &dst_path,
+                    from,
+                    &change.to,
+                    &change.doc_files_changed,
+                );
                 for file in &change.doc_files_changed {
-                    if let Some(patch) =
-                        crate::git::doc_file_patch(&dst_path, from, &change.to, file)
-                    {
+                    if let Some(patch) = patches.get(file) {
                         diffs.insert(
                             crate::update_log::DiffKey {
                                 url: change.url.clone(),
@@ -5167,7 +5172,7 @@ async fn run_log(query: Option<String>, last: usize, full: bool, diff: bool) -> 
                                 to: change.to.clone(),
                                 file: file.clone(),
                             },
-                            patch,
+                            patch.clone(),
                         );
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5157,16 +5157,9 @@ async fn run_log(query: Option<String>, last: usize, full: bool, diff: bool) -> 
                 };
                 let dst_path = resolve_plugin_dst(plugin, &cache_root);
                 for file in &change.doc_files_changed {
-                    let output = tokio::process::Command::new("git")
-                        .arg("-C")
-                        .arg(&dst_path)
-                        .args(["diff", &format!("{}..{}", from, change.to), "--", file])
-                        .output()
-                        .await;
-                    if let Ok(out) = output
-                        && out.status.success()
+                    if let Some(patch) =
+                        crate::git::doc_file_patch(&dst_path, from, &change.to, file)
                     {
-                        let patch = String::from_utf8_lossy(&out.stdout).to_string();
                         diffs.insert(
                             crate::update_log::DiffKey {
                                 url: change.url.clone(),


### PR DESCRIPTION
## Summary

Restores rvpm's "no `git` CLI required at runtime" invariant by replacing the two `git` subprocess invocations introduced in #52 with `gix`-native equivalents. Closes #69.

- `doc_files_changed` (sync path, runs on every successful pull) → `Repository::diff_tree_to_tree` + `is_doc_path` predicate equivalent to the previous `README* CHANGELOG* doc/` pathspec.
- `rvpm log --diff` patch rendering → `gix_diff::blob::UnifiedDiff` with `byte_lines` tokenization. Emits the standard `diff --git` / `index` / `--- a/...` / `+++ b/...` headers and unified hunks. Binary blobs are detected via the null-byte heuristic and rendered as a one-line `Binary files ... differ` notice.
- Both call sites share a `tree_changes` helper that swallows open / rev-parse / tree-peel failures into an empty `Vec` to preserve the existing best-effort resilience.
- `rvpm doctor` no longer flags a missing `git` as `Severity::Error`. It is now reported as `(optional)`.

The only remaining `git` invocation in the tree is in `git_cmd` inside the `git.rs` test module, which builds fixture repos with the CLI — this is dev-time only and not in the runtime path.

## Test plan

- [x] `cargo test` (719 passed, 1 ignored)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] New tests cover `is_doc_path`, `doc_files_changed` (filter set + missing-repo resilience), `doc_file_patch` (modification, addition, no-match → `None`), and `check_tool_git` for the missing case.
- [ ] Manual smoke: `rvpm log --diff` against a real plugin upgrade with README changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git is now marked as optional instead of required—missing git no longer produces an error or installation prompt.

* **Improvements**
  * Doc file diff generation improved through more efficient internal processing.

* **Documentation**
  * Added CLI maintenance checklist to ensure tool completions remain synchronized with core updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->