### PR TITLE
feat(options): add merge_lazy_doc to surface lazy plugin help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ concurrency = 16
 # (default true). Lazy plugins are not on runtimepath, so rvpm enumerates the
 # target doc/ directories itself and runs :helptags <path> for each.
 # auto_helptags = false
+# Also link the doc/ files of lazy plugins into merged/doc/ so that
+# `:help <topic>` can find their tags before the plugin loads (default false).
+# Only the doc/ subdirectory is linked — lua/ and plugin/ stay out of merged/,
+# so lazy semantics are preserved. Tag-name conflicts are first-wins.
+# merge_lazy_doc = true
 # URL form written by `rvpm add`: "short" (owner/repo, default) or
 # "full" (https://github.com/owner/repo). Duplicate detection normalizes both forms before comparing.
 # url_style = "full"

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,22 @@ pub struct Options {
     /// 個別実行する。`nvim` が PATH に無い場合は警告して skip (resilience)。
     #[serde(default = "default_auto_helptags")]
     pub auto_helptags: bool,
+    /// `true` なら lazy プラグインの `doc/` も `merged/doc/` にリンクする。
+    /// デフォルト `false`。
+    ///
+    /// lazy プラグインは trigger 前は runtimepath に乗らないので、
+    /// `:help <topic>` でその plugin の help tag を引けない (tags ファイルは
+    /// `auto_helptags` 経由で生成されているが、`merged/` 以外にあるので
+    /// `:help` の rtp 走査からは見えない)。
+    /// この option を有効にすると、lazy plugin の `doc/` 配下のファイルだけを
+    /// `merged/doc/` にも hard-link し、`:help <topic>` で全 plugin の tag を
+    /// 引けるようになる。`lua/` 等の他のディレクトリは引き続き merged に
+    /// 流れないので、lazy 性は維持される。
+    ///
+    /// トレードオフ: 未ロードの plugin の help も引けるようになる (人によっては
+    /// feature、人によっては気持ち悪い)。tag 名衝突は first-wins。
+    #[serde(default)]
+    pub merge_lazy_doc: bool,
     /// `rvpm add` が `config.toml` に書き込む URL の形式。
     /// - `"short"` (デフォルト): `owner/repo`
     /// - `"full"`: `https://github.com/owner/repo`
@@ -162,6 +178,7 @@ impl Default for Options {
             chezmoi: false,
             auto_clean: false,
             auto_helptags: default_auto_helptags(),
+            merge_lazy_doc: false,
             url_style: UrlStyle::default(),
             browse: BrowseOptions::default(),
             fetch_interval: None,
@@ -744,6 +761,31 @@ url = "owner/repo"
 "#;
         let config = parse_config(toml).unwrap();
         assert!(!config.options.auto_helptags);
+    }
+
+    #[test]
+    fn test_parse_config_merge_lazy_doc_defaults_to_false() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(!config.options.merge_lazy_doc);
+    }
+
+    #[test]
+    fn test_parse_config_accepts_merge_lazy_doc_true() {
+        let toml = r#"
+[options]
+merge_lazy_doc = true
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert!(config.options.merge_lazy_doc);
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1304,6 +1304,7 @@ mod tests {
                 chezmoi: false,
                 auto_clean: false,
                 auto_helptags: false,
+                merge_lazy_doc: false,
                 url_style: UrlStyle::Short,
                 browse: BrowseOptions::default(),
                 fetch_interval: None,

--- a/src/link.rs
+++ b/src/link.rs
@@ -74,6 +74,36 @@ pub fn merge_plugin(src: &Path, dst_root: &Path) -> Result<MergeResult> {
     Ok(result)
 }
 
+/// プラグインの `doc/` ディレクトリだけを merged にリンクする。`merge_plugin` の
+/// subset 版。
+///
+/// 用途: lazy プラグインは `merge_plugin` から外しているので
+/// `<plugin>/doc/` が runtimepath に乗らず、trigger 前は `:help <topic>` で
+/// 見つけられない。`doc/` だけを `merged/doc/` にリンクすれば、
+/// `merged/` は常に rtp に乗っているので `:help` が引けるようになる。
+/// `lua/` 等は引き続き merged に流れないので lazy 性は維持される。
+///
+/// 挙動:
+/// - `<src>/doc/` が無ければ何もせず空 `MergeResult` を返す。
+/// - 衝突 / 隠しファイル / `doc/tags` 系の skip ルールは `merge_plugin` と共通
+///   (内部で同じ `walk` を再利用)。
+pub fn merge_plugin_doc_only(src: &Path, dst_root: &Path) -> Result<MergeResult> {
+    let mut result = MergeResult::default();
+    let src_doc = src.join("doc");
+    if !src_doc.is_dir() {
+        return Ok(result);
+    }
+    if !dst_root.exists() {
+        std::fs::create_dir_all(dst_root)?;
+    }
+    let dst_doc = dst_root.join("doc");
+    if !dst_doc.exists() {
+        std::fs::create_dir_all(&dst_doc)?;
+    }
+    walk(src, &src_doc, dst_root, &mut result)?;
+    Ok(result)
+}
+
 fn walk(plugin_root: &Path, dir: &Path, dst_root: &Path, result: &mut MergeResult) -> Result<()> {
     let at_plugin_root = dir == plugin_root;
     for entry in std::fs::read_dir(dir)? {
@@ -571,6 +601,116 @@ mod tests {
             "unexpected content: {}",
             merged_content
         );
+    }
+
+    #[test]
+    fn test_doc_only_links_doc_files_only() {
+        // lazy プラグインに対して doc/ だけ merged に流す。lua/ や plugin/ は
+        // 流れない (lazy 性を保つため)。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("doc/bar.txt"), "*bar*");
+        write(&p.join("lua/foo/init.lua"), "return {}");
+        write(&p.join("plugin/foo.vim"), "echo 'foo'");
+
+        let r = merge_plugin_doc_only(&p, &merged).unwrap();
+
+        // doc 配下は merged に来る
+        assert!(merged.join("doc/foo.txt").exists());
+        assert!(merged.join("doc/bar.txt").exists());
+        // lua / plugin は来ない (lazy 性維持)
+        assert!(!merged.join("lua").exists());
+        assert!(!merged.join("plugin").exists());
+        assert!(r.conflicts.is_empty());
+        assert_eq!(r.placed.len(), 2);
+    }
+
+    #[test]
+    fn test_doc_only_no_doc_dir_is_noop() {
+        // doc/ が無いプラグインに対しては何もしない (エラーにもならない)。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let p = root.path().join("plug");
+        write(&p.join("lua/foo/init.lua"), "return {}");
+
+        let r = merge_plugin_doc_only(&p, &merged).unwrap();
+
+        assert!(r.conflicts.is_empty());
+        assert!(r.placed.is_empty());
+        assert!(!merged.join("doc").exists());
+    }
+
+    #[test]
+    fn test_doc_only_first_wins_with_existing_merged() {
+        // 既に merged/doc/foo.txt が居る (merge=true な eager プラグインが配置済) ところに
+        // 別の lazy プラグインが doc only で来る → first-wins で skip + conflict 記録。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let a = root.path().join("plug_a");
+        let b = root.path().join("plug_b");
+        write(&a.join("doc/foo.txt"), "from a");
+        write(&b.join("doc/foo.txt"), "from b");
+
+        // 先に A を full-merge で配置
+        let _ = merge_plugin(&a, &merged).unwrap();
+        // B は doc-only で後から来る
+        let r2 = merge_plugin_doc_only(&b, &merged).unwrap();
+
+        let content = fs::read_to_string(merged.join("doc/foo.txt")).unwrap();
+        assert_eq!(content, "from a");
+        assert_eq!(r2.conflicts.len(), 1);
+        assert_eq!(r2.conflicts[0].relative, PathBuf::from("doc").join("foo.txt"));
+    }
+
+    #[test]
+    fn test_doc_only_skips_committed_doc_tags() {
+        // doc/tags は merge_plugin と同じく skip (後段の :helptags merged/doc が再生成する)。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("doc/tags"), "stale-tags");
+
+        let r = merge_plugin_doc_only(&p, &merged).unwrap();
+
+        assert!(merged.join("doc/foo.txt").exists());
+        assert!(!merged.join("doc/tags").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_doc_only_skips_dotfiles_in_doc() {
+        // doc/.gitignore のような dotfile は skip (merge_plugin と同じ)。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("doc/.gitignore"), "tags");
+
+        let r = merge_plugin_doc_only(&p, &merged).unwrap();
+
+        assert!(merged.join("doc/foo.txt").exists());
+        assert!(!merged.join("doc/.gitignore").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_doc_only_handles_nested_doc_subdirs() {
+        // 一部 plugin は doc/<lang>/<topic>.txt のように doc 配下にサブディレクトリを
+        // 持つ。再帰的にリンクされる。
+        let root = tempdir().unwrap();
+        let merged = root.path().join("merged");
+        let p = root.path().join("plug");
+        write(&p.join("doc/main.txt"), "*main*");
+        write(&p.join("doc/sub/extra.txt"), "*extra*");
+
+        let r = merge_plugin_doc_only(&p, &merged).unwrap();
+
+        assert!(merged.join("doc/main.txt").exists());
+        assert!(merged.join("doc/sub/extra.txt").exists());
+        assert!(r.conflicts.is_empty());
     }
 
     #[test]

--- a/src/link.rs
+++ b/src/link.rs
@@ -661,7 +661,10 @@ mod tests {
         let content = fs::read_to_string(merged.join("doc/foo.txt")).unwrap();
         assert_eq!(content, "from a");
         assert_eq!(r2.conflicts.len(), 1);
-        assert_eq!(r2.conflicts[0].relative, PathBuf::from("doc").join("foo.txt"));
+        assert_eq!(
+            r2.conflicts[0].relative,
+            PathBuf::from("doc").join("foo.txt")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1344,6 +1344,16 @@ async fn run_sync(
                 &plugin.display_name(),
                 &mut merge_ownership,
                 &mut merge_conflicts,
+                false,
+            );
+        } else if plugin.merge && plugin.lazy && config.options.merge_lazy_doc {
+            merge_and_record(
+                &dst_path,
+                &merged_dir,
+                &plugin.display_name(),
+                &mut merge_ownership,
+                &mut merge_conflicts,
+                true,
             );
         }
         plugin_scripts.push(build_plugin_scripts(plugin, &dst_path, &plugin_config_dir));
@@ -1403,7 +1413,10 @@ async fn run_sync(
                         });
                     }
                     // lazy プラグインは merge しない (trigger 前に merged/ 経由で
-                    // lua モジュールが rtp に漏れて lazy の意味がなくなるため)
+                    // lua モジュールが rtp に漏れて lazy の意味がなくなるため)。
+                    // ただし `options.merge_lazy_doc = true` のときは `doc/` のみ
+                    // 部分マージし、`:help <topic>` を引けるようにする (lua/ 等は
+                    // 引き続き merge しないので lazy 性は維持)。
                     if plugin.merge && !plugin.lazy {
                         merge_and_record(
                             &dst_path,
@@ -1411,6 +1424,16 @@ async fn run_sync(
                             &plugin.display_name(),
                             &mut merge_ownership,
                             &mut merge_conflicts,
+                            false,
+                        );
+                    } else if plugin.merge && plugin.lazy && config.options.merge_lazy_doc {
+                        merge_and_record(
+                            &dst_path,
+                            &merged_dir,
+                            &plugin.display_name(),
+                            &mut merge_ownership,
+                            &mut merge_conflicts,
+                            true,
                         );
                     }
                     let config_root = resolve_config_root(config.options.config_root.as_deref());
@@ -1447,6 +1470,7 @@ async fn run_sync(
                     &ps.name,
                     &mut merge_ownership,
                     &mut merge_conflicts,
+                    false,
                 );
             }
         }
@@ -1702,6 +1726,19 @@ async fn run_generate() -> Result<()> {
                     &ps.name,
                     &mut merge_ownership,
                     &mut merge_conflicts,
+                    false,
+                );
+            }
+        } else if ps.lazy && ps.merge && config.options.merge_lazy_doc {
+            let dst = PathBuf::from(&ps.path);
+            if dst.exists() {
+                merge_and_record(
+                    &dst,
+                    &merged_dir,
+                    &ps.name,
+                    &mut merge_ownership,
+                    &mut merge_conflicts,
+                    true,
                 );
             }
         }
@@ -4479,14 +4516,23 @@ fn resolve_merged_dir(cache_root: &Path) -> PathBuf {
 /// `ownership` は merged/ 上の relative path → 勝者 plugin 名の shared map。
 /// 各 plugin 処理前に呼び出し側で 1 つだけ作り、順次 merge_and_record に
 /// 渡すことで、後続 plugin の衝突時に勝者を lookup できる。
+///
+/// `doc_only = true` で呼ぶと `<src>/doc/` 配下のファイルだけを merged にリンク
+/// する (lazy plugin に対して `:help` を引けるようにするための部分マージ)。
 fn merge_and_record(
     src: &Path,
     dst_root: &Path,
     plugin_name: &str,
     ownership: &mut std::collections::HashMap<PathBuf, String>,
     conflicts: &mut Vec<crate::merge_conflicts::MergeConflictReport>,
+    doc_only: bool,
 ) {
-    match crate::link::merge_plugin(src, dst_root) {
+    let result = if doc_only {
+        crate::link::merge_plugin_doc_only(src, dst_root)
+    } else {
+        crate::link::merge_plugin(src, dst_root)
+    };
+    match result {
         Ok(result) => {
             // 今回新規配置したファイルを ownership に登録 (勝者 = この plugin)。
             for placed in result.placed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1337,23 +1337,16 @@ async fn run_sync(
     for plugin in config.plugins.iter().filter(|p| p.dev) {
         let dst_path = resolve_plugin_dst(plugin, &cache_root);
         let plugin_config_dir = resolve_plugin_config_dir(&config_root, plugin);
-        if plugin.merge && !plugin.lazy {
+        if let Some(doc_only) =
+            decide_merge_mode(plugin.merge, plugin.lazy, config.options.merge_lazy_doc)
+        {
             merge_and_record(
                 &dst_path,
                 &merged_dir,
                 &plugin.display_name(),
                 &mut merge_ownership,
                 &mut merge_conflicts,
-                false,
-            );
-        } else if plugin.merge && plugin.lazy && config.options.merge_lazy_doc {
-            merge_and_record(
-                &dst_path,
-                &merged_dir,
-                &plugin.display_name(),
-                &mut merge_ownership,
-                &mut merge_conflicts,
-                true,
+                doc_only,
             );
         }
         plugin_scripts.push(build_plugin_scripts(plugin, &dst_path, &plugin_config_dir));
@@ -1412,28 +1405,23 @@ async fn run_sync(
                             commit,
                         });
                     }
-                    // lazy プラグインは merge しない (trigger 前に merged/ 経由で
+                    // lazy プラグインは通常 merge しない (trigger 前に merged/ 経由で
                     // lua モジュールが rtp に漏れて lazy の意味がなくなるため)。
                     // ただし `options.merge_lazy_doc = true` のときは `doc/` のみ
                     // 部分マージし、`:help <topic>` を引けるようにする (lua/ 等は
                     // 引き続き merge しないので lazy 性は維持)。
-                    if plugin.merge && !plugin.lazy {
+                    if let Some(doc_only) = decide_merge_mode(
+                        plugin.merge,
+                        plugin.lazy,
+                        config.options.merge_lazy_doc,
+                    ) {
                         merge_and_record(
                             &dst_path,
                             &merged_dir,
                             &plugin.display_name(),
                             &mut merge_ownership,
                             &mut merge_conflicts,
-                            false,
-                        );
-                    } else if plugin.merge && plugin.lazy && config.options.merge_lazy_doc {
-                        merge_and_record(
-                            &dst_path,
-                            &merged_dir,
-                            &plugin.display_name(),
-                            &mut merge_ownership,
-                            &mut merge_conflicts,
-                            true,
+                            doc_only,
                         );
                     }
                     let config_root = resolve_config_root(config.options.config_root.as_deref());
@@ -1717,7 +1705,8 @@ async fn run_generate() -> Result<()> {
     let mut merge_ownership: std::collections::HashMap<PathBuf, String> =
         std::collections::HashMap::new();
     for ps in &plugin_scripts {
-        if !ps.lazy && ps.merge {
+        if let Some(doc_only) = decide_merge_mode(ps.merge, ps.lazy, config.options.merge_lazy_doc)
+        {
             let dst = PathBuf::from(&ps.path);
             if dst.exists() {
                 merge_and_record(
@@ -1726,19 +1715,7 @@ async fn run_generate() -> Result<()> {
                     &ps.name,
                     &mut merge_ownership,
                     &mut merge_conflicts,
-                    false,
-                );
-            }
-        } else if ps.lazy && ps.merge && config.options.merge_lazy_doc {
-            let dst = PathBuf::from(&ps.path);
-            if dst.exists() {
-                merge_and_record(
-                    &dst,
-                    &merged_dir,
-                    &ps.name,
-                    &mut merge_ownership,
-                    &mut merge_conflicts,
-                    true,
+                    doc_only,
                 );
             }
         }
@@ -4507,6 +4484,27 @@ fn resolve_repos_dir(cache_root: &Path) -> PathBuf {
 /// merged ディレクトリ。`<cache_root>/plugins/merged`。
 fn resolve_merged_dir(cache_root: &Path) -> PathBuf {
     cache_root.join("plugins").join("merged")
+}
+
+/// プラグインの merge モードを決定する純粋関数。
+/// 返り値:
+///   - `Some(false)` — full merge (eager + merge=true)
+///   - `Some(true)`  — doc-only merge (lazy + merge=true + merge_lazy_doc=true)
+///   - `None`        — merge しない (merge=false、または lazy だが merge_lazy_doc=false)
+///
+/// 3 箇所 (run_sync の dev 用 / 通常 task 用 / run_generate) で同じ判定を
+/// 行う必要があったので、Gemini Code Assist の指摘 (#116) を受けて関数化。
+fn decide_merge_mode(plugin_merge: bool, plugin_lazy: bool, merge_lazy_doc: bool) -> Option<bool> {
+    if !plugin_merge {
+        return None;
+    }
+    if !plugin_lazy {
+        Some(false)
+    } else if merge_lazy_doc {
+        Some(true)
+    } else {
+        None
+    }
 }
 
 /// link.rs::merge_plugin を呼び出して、発生した衝突を勝者 (先に同じ path を
@@ -7349,6 +7347,34 @@ url = "owner/repo"
         let result = resolve_concurrency(None);
         assert_eq!(result, DEFAULT_CONCURRENCY);
         assert_eq!(result, 13);
+    }
+
+    #[test]
+    fn test_decide_merge_mode_eager_merge_returns_full_merge() {
+        // eager + merge=true → full merge (lazy_doc 設定の影響を受けない)
+        assert_eq!(decide_merge_mode(true, false, false), Some(false));
+        assert_eq!(decide_merge_mode(true, false, true), Some(false));
+    }
+
+    #[test]
+    fn test_decide_merge_mode_lazy_with_doc_merge_returns_doc_only() {
+        // lazy + merge=true + merge_lazy_doc=true → doc only
+        assert_eq!(decide_merge_mode(true, true, true), Some(true));
+    }
+
+    #[test]
+    fn test_decide_merge_mode_lazy_without_doc_merge_returns_none() {
+        // lazy + merge=true + merge_lazy_doc=false → no merge (現状の挙動)
+        assert_eq!(decide_merge_mode(true, true, false), None);
+    }
+
+    #[test]
+    fn test_decide_merge_mode_no_merge_always_none() {
+        // merge=false なら何があっても merge しない (lazy_doc 設定にも従わない)
+        assert_eq!(decide_merge_mode(false, false, false), None);
+        assert_eq!(decide_merge_mode(false, false, true), None);
+        assert_eq!(decide_merge_mode(false, true, false), None);
+        assert_eq!(decide_merge_mode(false, true, true), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `options.merge_lazy_doc` (default `false`). When enabled, lazy plugins'
  `doc/` files are hard-linked into `merged/doc/` so `:help <topic>` finds them
  even before the plugin loads.
- `lua/` and `plugin/` stay out of `merged/` for lazy plugins, so lazy
  semantics are preserved — only help-tag discovery changes.
- Implementation: new `merge_plugin_doc_only` helper in `src/link.rs`; the
  existing `merge_and_record` in `src/main.rs` gains a `doc_only: bool`
  parameter and the four call sites are updated.
- Default is `false` to keep current behavior intact; users opt in when they
  want `:help` to span every installed plugin.

## Why

Lazy plugins are intentionally excluded from `merged/` so `lua/` does not leak
onto the runtimepath before the trigger fires. The side effect is that
`:help <topic>` cannot find their tags either, since `:help` only walks
`&rtp/doc/tags`. `auto_helptags` already generates each plugin's tags file but
they live in `<plugin>/doc/tags`, which is off-rtp until the plugin loads.

`merge_lazy_doc` carves out a "doc-only" merge so the merged tags file (already
on rtp) covers every plugin.

## Test plan

- [x] `cargo test` — 730 → 738 pass (6 new doc-only link tests + 2 config parse tests)
- [x] `cargo fmt --check` clean (pre-push hook gate)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual verification: enable `merge_lazy_doc = true`, run `rvpm sync`,
      open Neovim, confirm `:help <lazy-plugin-tag>` resolves before triggering
      the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `merge_lazy_doc` configuration option (disabled by default) that links lazy plugins' help documentation into the merged documentation directory, enabling `:help` tag resolution before lazy plugins are loaded.

* **Documentation**
  * Documented the new setting and clarified that only the `doc/` directory is linked to preserve lazy loading semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->