### PR TITLE
docs(readme): document merge_lazy_doc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ concurrency = 16
 # Default: true. Set to false to skip.
 # auto_helptags = false
 
+# Also link the doc/ files of lazy plugins into merged/doc/ so that
+# `:help <topic>` can find their tags before the plugin loads. Default: false.
+# Only doc/ is linked — lua/ and plugin/ stay out, so lazy semantics survive.
+# merge_lazy_doc = true
+
 # How `rvpm add` records GitHub plugin URLs in config.toml.
 # "short" (default) → owner/repo ; "full" → https://github.com/owner/repo
 # url_style = "full"
@@ -148,6 +153,7 @@ for fully isolated test configs.
 | `chezmoi` | `boolean` | `false` | Route writes through chezmoi source state. See [Advanced → chezmoi integration](#advanced) |
 | `auto_clean` | `boolean` | `false` | `sync` / `generate` auto-delete plugin dirs no longer in `config.toml` (= always `--prune`) |
 | `auto_helptags` | `boolean` | `true` | `sync` / `generate` run `nvim --headless` once at the end to build helptags for every plugin's `doc/`. Skipped with a warning if `nvim` is missing |
+| `merge_lazy_doc` | `boolean` | `false` | Also hard-link lazy plugins' `doc/` into `merged/doc/` so `:help <topic>` resolves their tags before the trigger fires. Only `doc/` is linked — `lua/` and `plugin/` stay out, so lazy semantics survive. Tag-name conflicts are first-wins |
 | `url_style` | `"short"` \| `"full"` | `"short"` | How `rvpm add` writes GitHub plugin URLs. Duplicate detection normalizes between styles |
 | `fetch_interval` | duration string (`"6h"`, `"30m"`, `"45s"`, `"1d"`, `"0"`) | `"6h"` | Per-plugin fetch cache window. `sync` skips `git fetch` for plugins pulled within the last *fetch_interval*. Accepted units: `s` / `m` / `h` / `d`. Set to `"0"` to disable caching (pre-v3.19 behavior). Override per-run with `rvpm sync --refresh` / `--no-refresh` |
 | `auto_lazy` | `"ask"` \| `"always"` \| `"never"` | `"ask"` | How `rvpm add` (and `rvpm browse → Enter`) handles the post-clone scan that looks for `nvim_create_user_command` / keymaps in the plugin's `plugin/` + `ftplugin/` + `after/plugin/` + `lua/` dirs. `"ask"` (default) prompts interactively on TTY and skips silently on non-TTY. `"always"` accepts the suggestion unconditionally. `"never"` skips the scan entirely. Per-call override via `--auto-lazy` / `--no-lazy` on `rvpm add`. Accepted suggestions cluster commands by 3-char LCP (3+ char shared prefix becomes `/^Prefix/` regex so future commands in that family auto-load) and enumerate keymaps (maps don't LCP well). **Ignored when `ai != "off"`** — the AI handles the design end-to-end |

--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ concurrency = 16
 # Default: true. Set to false to skip.
 # auto_helptags = false
 
-# Also link the doc/ files of lazy plugins into merged/doc/ so that
-# `:help <topic>` can find their tags before the plugin loads. Default: false.
-# Only doc/ is linked — lua/ and plugin/ stay out, so lazy semantics survive.
+# For lazy plugins with `merge = true`, also link their doc/ files into
+# merged/doc/ so `:help <topic>` can find their tags before the plugin loads.
+# Default: false. Only doc/ is linked — lua/ and plugin/ stay out, so lazy
+# semantics survive. Filename conflicts inside doc/ are first-wins.
 # merge_lazy_doc = true
 
 # How `rvpm add` records GitHub plugin URLs in config.toml.
@@ -153,7 +154,7 @@ for fully isolated test configs.
 | `chezmoi` | `boolean` | `false` | Route writes through chezmoi source state. See [Advanced → chezmoi integration](#advanced) |
 | `auto_clean` | `boolean` | `false` | `sync` / `generate` auto-delete plugin dirs no longer in `config.toml` (= always `--prune`) |
 | `auto_helptags` | `boolean` | `true` | `sync` / `generate` run `nvim --headless` once at the end to build helptags for every plugin's `doc/`. Skipped with a warning if `nvim` is missing |
-| `merge_lazy_doc` | `boolean` | `false` | Also hard-link lazy plugins' `doc/` into `merged/doc/` so `:help <topic>` resolves their tags before the trigger fires. Only `doc/` is linked — `lua/` and `plugin/` stay out, so lazy semantics survive. Tag-name conflicts are first-wins |
+| `merge_lazy_doc` | `boolean` | `false` | For lazy plugins with `merge = true`, also hard-link their `doc/` into `merged/doc/` so `:help <topic>` resolves their tags before the trigger fires. Only `doc/` is linked — `lua/` and `plugin/` stay out, so lazy semantics survive. Filename conflicts inside `doc/` are first-wins |
 | `url_style` | `"short"` \| `"full"` | `"short"` | How `rvpm add` writes GitHub plugin URLs. Duplicate detection normalizes between styles |
 | `fetch_interval` | duration string (`"6h"`, `"30m"`, `"45s"`, `"1d"`, `"0"`) | `"6h"` | Per-plugin fetch cache window. `sync` skips `git fetch` for plugins pulled within the last *fetch_interval*. Accepted units: `s` / `m` / `h` / `d`. Set to `"0"` to disable caching (pre-v3.19 behavior). Override per-run with `rvpm sync --refresh` / `--no-refresh` |
 | `auto_lazy` | `"ask"` \| `"always"` \| `"never"` | `"ask"` | How `rvpm add` (and `rvpm browse → Enter`) handles the post-clone scan that looks for `nvim_create_user_command` / keymaps in the plugin's `plugin/` + `ftplugin/` + `after/plugin/` + `lua/` dirs. `"ask"` (default) prompts interactively on TTY and skips silently on non-TTY. `"always"` accepts the suggestion unconditionally. `"never"` skips the scan entirely. Per-call override via `--auto-lazy` / `--no-lazy` on `rvpm add`. Accepted suggestions cluster commands by 3-char LCP (3+ char shared prefix becomes `/^Prefix/` regex so future commands in that family auto-load) and enumerate keymaps (maps don't LCP well). **Ignored when `ai != "off"`** — the AI handles the design end-to-end |


### PR DESCRIPTION
## Summary

Follow-up to #116. Adds the `merge_lazy_doc` option to two places in
README.md — the `[options]` snippet and the options reference table —
so users discover the trade-off (lazy plugins' `:help` works at the
cost of doc files appearing before the trigger fires, first-wins on
tag-name conflicts) wherever they look first.

Wording mirrors `CLAUDE.md` to avoid drift.

## Test plan

- [x] Visual diff: README's `[options]` block and reference table now
      both list `merge_lazy_doc` with consistent wording.
- [x] Pre-push hook gates clean (`cargo fmt --check`, `clippy`, `test`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new `merge_lazy_doc` configuration option (default: `false`), which enables access to documentation tags for lazy-loaded plugins before initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->