### PR TITLE
fix(link): link build artifacts into views/<plug>/

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -70,21 +70,56 @@ pub fn merge_plugin(src: &Path, dst_root: &Path) -> Result<MergeResult> {
     if !dst_root.exists() {
         std::fs::create_dir_all(dst_root)?;
     }
-    walk(src, src, dst_root, &mut result)?;
+    walk(
+        src,
+        src,
+        dst_root,
+        &mut result,
+        WalkOptions { rtp_only: true },
+    )?;
     Ok(result)
 }
 
-/// `merge_plugin` の **`doc/` 抜き** 版。 `views/<plug>/` 用 (#119)。
+/// 指定したプラグインの全ファイルを `views/<plug>/` ディレクトリにファイル単位で
+/// リンクする (`#119` の view 戦略)。
 ///
-/// 用途: `PluginMergeMode::ViewWithoutDoc` のとき、 plugin の rtp dir を
+/// `merge_plugin` との違い: `RTP_DIRS` の絞り込みも、 ルート直下のメタファイル
+/// (README.md / Cargo.toml 等) の除外も **しない**。 views/<plug>/ は per-plugin で
+/// cross-plugin の衝突は発生しないので、 絞り込みノイズ抑制が不要。
+///
+/// 重要: `build` / `build_lua` を持つ plugin の build artifact (`target/release/...`,
+/// `build/` 等の plugin 任意のディレクトリ) も拾うために rtp 慣習外を含めて全部 link
+/// する。 これが無いと blink.cmp 等の `debug.getinfo()` ベースで自分の lua module
+/// 位置から相対参照する plugin が build 出力を見つけられない。
+///
+/// `.git/` 等のドットファイルと `doc/tags` の上書き対策は引き続き skip する
+/// (内部で同じ `walk` を `rtp_only: false` で呼び分け)。
+pub fn merge_plugin_view(src: &Path, dst_root: &Path) -> Result<MergeResult> {
+    let mut result = MergeResult::default();
+    if !dst_root.exists() {
+        std::fs::create_dir_all(dst_root)?;
+    }
+    walk(
+        src,
+        src,
+        dst_root,
+        &mut result,
+        WalkOptions { rtp_only: false },
+    )?;
+    Ok(result)
+}
+
+/// `merge_plugin_view` の **`doc/` 抜き** 版。 `views/<plug>/` 用 (`#119`)。
+///
+/// 用途: `PluginMergeMode::ViewWithoutDoc` のとき、 plugin の全 entry を
 /// `views/<plug>/` に `doc/` を除いて hard-link する。 doc/ は別途
 /// `merge_plugin_doc_only` で `merged/doc/` に集約される。
 /// 結果として rtp に乗るのは doc を持たない view → `:tselect` の重複が発生せず、
 /// `:help` は集約された `merged/doc/tags` を 1 経路で引ける。
 ///
-/// 衝突検出 / 隠しファイル / `doc/tags` 系の skip ルールは `merge_plugin` と
-/// 共通 (内部で同じ `walk` を再利用)。
-pub fn merge_plugin_no_doc(src: &Path, dst_root: &Path) -> Result<MergeResult> {
+/// `merge_plugin_view` と同じく rtp 慣習外も含めて全部 link する (build artifact
+/// を拾うため)。 doc/ だけ root 直下で除外する点が異なる。
+pub fn merge_plugin_view_no_doc(src: &Path, dst_root: &Path) -> Result<MergeResult> {
     let mut result = MergeResult::default();
     if !dst_root.exists() {
         std::fs::create_dir_all(dst_root)?;
@@ -96,28 +131,38 @@ pub fn merge_plugin_no_doc(src: &Path, dst_root: &Path) -> Result<MergeResult> {
         let entry = entry?;
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
-        if name_str == "doc" {
-            continue;
-        }
-        // それ以外は plugin ルート相当として walk に渡す
-        // (= `at_plugin_root=true` 相当の filter を効かせる)。
-        let entry_path = entry.path();
         if name_str.starts_with('.') {
             continue;
         }
+        if name_str == "doc" {
+            continue;
+        }
+        let entry_path = entry.path();
         if entry_path.is_file() {
-            // ルート直下のメタファイル (README.md etc.) は merge_plugin と同様 skip
+            // ルート直下のファイル (README.md / Cargo.toml etc.) も link する
+            let dst_path = dst_root.join(&name);
+            if dst_path.exists() {
+                result.conflicts.push(MergeConflict {
+                    relative: PathBuf::from(&name),
+                });
+            } else {
+                hard_link_or_copy(&entry_path, &dst_path)?;
+                result.placed.push(PathBuf::from(&name));
+            }
             continue;
         }
-        if !RTP_DIRS.contains(&name_str.as_ref()) {
-            continue;
-        }
+        // ディレクトリは rtp_only=false で walk (rtp 慣習外も含めて全部)
         let dst_subdir = dst_root.join(name.as_os_str());
         if !dst_subdir.exists() {
             std::fs::create_dir_all(&dst_subdir)?;
         }
-        // 各 rtp dir 配下に再帰 (この時点で `at_plugin_root=false` 相当)
-        walk(src, &entry_path, dst_root, &mut result)?;
+        walk(
+            src,
+            &entry_path,
+            dst_root,
+            &mut result,
+            WalkOptions { rtp_only: false },
+        )?;
     }
     Ok(result)
 }
@@ -148,11 +193,34 @@ pub fn merge_plugin_doc_only(src: &Path, dst_root: &Path) -> Result<MergeResult>
     if !dst_doc.exists() {
         std::fs::create_dir_all(&dst_doc)?;
     }
-    walk(src, &src_doc, dst_root, &mut result)?;
+    walk(
+        src,
+        &src_doc,
+        dst_root,
+        &mut result,
+        WalkOptions { rtp_only: true },
+    )?;
     Ok(result)
 }
 
-fn walk(plugin_root: &Path, dir: &Path, dst_root: &Path, result: &mut MergeResult) -> Result<()> {
+/// `walk` のフィルタオプション。 merged/ 用 (rtp_only=true) と views/ 用
+/// (rtp_only=false) で plugin ルート直下の挙動を切り替える。
+#[derive(Clone, Copy)]
+struct WalkOptions {
+    /// plugin ルート直下で `RTP_DIRS` 縛りと「ファイル除外」を効かせるか。
+    /// `merged/` (cross-plugin 共有) は cross-plugin 衝突ノイズを抑える必要が
+    /// あるので true。 `views/<plug>/` は per-plugin で衝突無し、 build
+    /// artifact (target/, build/ 等) も拾いたいので false。
+    rtp_only: bool,
+}
+
+fn walk(
+    plugin_root: &Path,
+    dir: &Path,
+    dst_root: &Path,
+    result: &mut MergeResult,
+    opts: WalkOptions,
+) -> Result<()> {
     let at_plugin_root = dir == plugin_root;
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -167,7 +235,7 @@ fn walk(plugin_root: &Path, dir: &Path, dst_root: &Path, result: &mut MergeResul
             continue;
         }
 
-        if at_plugin_root {
+        if at_plugin_root && opts.rtp_only {
             // plugin ルート直下のファイル (README.md / LICENSE / Makefile /
             // package.json / *.toml 等のメタファイル) は rtp に置く意味が無く、
             // plugin 横断で同名衝突するだけのノイズなので merge しない。
@@ -215,7 +283,7 @@ fn walk(plugin_root: &Path, dir: &Path, dst_root: &Path, result: &mut MergeResul
             if !dst_path.exists() {
                 std::fs::create_dir_all(&dst_path)?;
             }
-            walk(plugin_root, &src_path, dst_root, result)?;
+            walk(plugin_root, &src_path, dst_root, result, opts)?;
         } else if dst_path.exists() {
             // first-wins: 既にファイル / ディレクトリが居る → skip
             // (dst が dir で src が file の対称ケースもここでカバー)
@@ -652,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_doc_links_everything_except_doc() {
+    fn test_view_no_doc_links_everything_except_doc() {
         // ViewWithoutDoc 用: doc/ は触らず、それ以外の rtp dir を全部 link。
         let root = tempdir().unwrap();
         let view = root.path().join("view");
@@ -662,7 +730,7 @@ mod tests {
         write(&p.join("plugin/bar.vim"), "echo 'bar'");
         write(&p.join("ftplugin/rust.vim"), "setl shiftwidth=4");
 
-        let r = merge_plugin_no_doc(&p, &view).unwrap();
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
 
         // doc/ は来ない
         assert!(!view.join("doc").exists());
@@ -674,28 +742,147 @@ mod tests {
     }
 
     #[test]
-    fn test_no_doc_skips_root_meta_and_dotfiles() {
-        // merge_plugin と同じくルート直下メタ + dotfile は除外する。
+    fn test_view_no_doc_skips_dotfiles_but_keeps_meta() {
+        // views/ は per-plugin なので衝突発生せず、 root meta files は link する。
+        // dotfile (.git/ など) のみ除外。
         let root = tempdir().unwrap();
         let view = root.path().join("view");
         let p = root.path().join("plug");
         write(&p.join("README.md"), "# plug");
         write(&p.join(".git/config"), "[core]");
         write(&p.join("Makefile"), "all:");
+        write(&p.join("Cargo.toml"), "[package]");
         write(&p.join("lua/foo.lua"), "return {}");
 
-        let r = merge_plugin_no_doc(&p, &view).unwrap();
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
 
-        assert!(!view.join("README.md").exists());
+        // dotfile は除外
         assert!(!view.join(".git").exists());
-        assert!(!view.join("Makefile").exists());
+        // root meta files は link される (views は per-plugin なので衝突無し)
+        assert!(view.join("README.md").exists());
+        assert!(view.join("Makefile").exists());
+        assert!(view.join("Cargo.toml").exists());
         assert!(view.join("lua/foo.lua").exists());
         assert!(r.conflicts.is_empty());
     }
 
     #[test]
-    fn test_no_doc_includes_all_rtp_dirs_except_doc() {
-        // RTP_DIRS のうち doc 以外は全部対象。
+    fn test_view_no_doc_links_build_artifacts() {
+        // blink.cmp の build_lua が target/release/ に吐く .dll / .so 等を views/<plug>/
+        // 配下にも link する (#119 fix)。 元々 RTP_DIRS 縛りで除外されてて、 plugin が
+        // debug.getinfo() で自分の lua から相対参照する設計の場合に library が見つからない
+        // 不具合があった。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("lua/blink/cmp/init.lua"), "return {}");
+        write(&p.join("target/release/blink_cmp_fuzzy.dll"), "DLL");
+        write(&p.join("build/native/lib.so"), "SO");
+
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
+
+        // doc/ は来ない
+        assert!(!view.join("doc").exists());
+        // build artifact ディレクトリも link される
+        assert!(view.join("target/release/blink_cmp_fuzzy.dll").exists());
+        assert!(view.join("build/native/lib.so").exists());
+        assert!(view.join("lua/blink/cmp/init.lua").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_no_doc_includes_non_rtp_dirs() {
+        // tests/ scripts/ examples/ 等も link する (rtp 慣習外も含めて全部)。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        write(&p.join("tests/spec.lua"), "test");
+        write(&p.join("scripts/build.sh"), "#!/bin/sh");
+        write(&p.join("examples/demo.lua"), "demo");
+        write(&p.join("src/main.rs"), "fn main() {}");
+        write(&p.join("plugin/foo.vim"), "echo 'foo'");
+
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
+
+        assert!(view.join("tests/spec.lua").exists());
+        assert!(view.join("scripts/build.sh").exists());
+        assert!(view.join("examples/demo.lua").exists());
+        assert!(view.join("src/main.rs").exists());
+        assert!(view.join("plugin/foo.vim").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_links_everything_except_dotfiles() {
+        // ViewWithDoc 用: doc/ も含めて全部 link。 dotfile のみ除外。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("lua/foo/init.lua"), "return {}");
+        write(&p.join("plugin/bar.vim"), "echo 'bar'");
+        write(&p.join("README.md"), "# plug");
+        write(&p.join("Cargo.toml"), "[package]");
+        write(&p.join(".git/config"), "[core]");
+        write(&p.join(".github/workflows/ci.yml"), "name: CI");
+
+        let r = merge_plugin_view(&p, &view).unwrap();
+
+        // doc/ も含めて link される
+        assert!(view.join("doc/foo.txt").exists());
+        assert!(view.join("lua/foo/init.lua").exists());
+        assert!(view.join("plugin/bar.vim").exists());
+        assert!(view.join("README.md").exists());
+        assert!(view.join("Cargo.toml").exists());
+        // dotfile (.git, .github 等) は除外
+        assert!(!view.join(".git").exists());
+        assert!(!view.join(".github").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_links_build_artifacts() {
+        // ViewWithDoc でも build artifact (target/release/) を view に link する。
+        // blink.cmp が eager + merge=false で自分で build_lua を持つケース。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("lua/blink/cmp/init.lua"), "return {}");
+        write(&p.join("target/release/blink_cmp_fuzzy.dll"), "DLL");
+
+        let r = merge_plugin_view(&p, &view).unwrap();
+
+        assert!(view.join("doc/foo.txt").exists());
+        assert!(view.join("lua/blink/cmp/init.lua").exists());
+        assert!(view.join("target/release/blink_cmp_fuzzy.dll").exists());
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_skips_committed_doc_tags() {
+        // doc/tags の skip ルールは views でも維持 (helptags が view 配下で
+        // 走るとき hard link 経由で repos の tags まで上書きするのを防ぐ)。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        write(&p.join("doc/foo.txt"), "*foo*");
+        write(&p.join("doc/tags"), "stale-tags");
+
+        let r = merge_plugin_view(&p, &view).unwrap();
+
+        assert!(view.join("doc/foo.txt").exists());
+        assert!(
+            !view.join("doc/tags").exists(),
+            "doc/tags should be skipped in views/"
+        );
+        assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_no_doc_includes_all_rtp_dirs_except_doc() {
+        // 旧 test の互換確認: RTP_DIRS のうち doc 以外は全部対象 (views も同じ)。
         let root = tempdir().unwrap();
         let view = root.path().join("view");
         let p = root.path().join("plug");
@@ -703,14 +890,14 @@ mod tests {
             write(&p.join(dir).join("file.txt"), dir);
         }
 
-        let r = merge_plugin_no_doc(&p, &view).unwrap();
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
         assert!(r.conflicts.is_empty());
         for dir in RTP_DIRS {
             let expected = view.join(dir).join("file.txt");
             if *dir == "doc" {
                 assert!(
                     !expected.exists(),
-                    "doc/ should be skipped by merge_plugin_no_doc"
+                    "doc/ should be skipped by merge_plugin_view_no_doc"
                 );
             } else {
                 assert!(expected.exists(), "missing rtp dir in view: {}", dir);

--- a/src/link.rs
+++ b/src/link.rs
@@ -153,6 +153,16 @@ pub fn merge_plugin_view_no_doc(src: &Path, dst_root: &Path) -> Result<MergeResu
         }
         // ディレクトリは rtp_only=false で walk (rtp 慣習外も含めて全部)
         let dst_subdir = dst_root.join(name.as_os_str());
+        // dst_subdir に **ファイル** が居るケース (先行 plugin 等が同 path にファイル
+        // を張り済) は first-wins で skip + conflict 記録。 create_dir_all は ENOTDIR
+        // で落ちるので、 walk 内のディレクトリ衝突ハンドリングと整合させる
+        // (CodeRabbit PR #124 指摘)。
+        if dst_subdir.is_file() {
+            result.conflicts.push(MergeConflict {
+                relative: PathBuf::from(&name),
+            });
+            continue;
+        }
         if !dst_subdir.exists() {
             std::fs::create_dir_all(&dst_subdir)?;
         }
@@ -878,6 +888,49 @@ mod tests {
             "doc/tags should be skipped in views/"
         );
         assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_view_no_doc_root_dir_vs_file_collision_is_recorded_as_conflict() {
+        // dst_root に **ファイル** が居るところに src ルート直下の同名 **ディレクトリ** を
+        // 張ろうとした場合、 create_dir_all で ENOTDIR にして全体 abort せず first-wins
+        // で skip + conflict 記録 (CodeRabbit PR #124 MAJOR)。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        // 先に view/lua という **ファイル** を置く (別 plugin が張った想定)
+        write(&view.join("lua"), "i am a file");
+        // src 側は lua/foo.lua という **ディレクトリ階層**
+        write(&p.join("lua/foo.lua"), "return {}");
+
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
+
+        // 既存ファイル lua はそのまま残る (first-wins)
+        assert!(view.join("lua").is_file());
+        // conflict に lua が記録される
+        assert_eq!(r.conflicts.len(), 1);
+        assert_eq!(r.conflicts[0].relative, PathBuf::from("lua"));
+    }
+
+    #[test]
+    fn test_view_no_doc_root_file_vs_file_collision_is_recorded_as_conflict() {
+        // ルート直下のファイル衝突も first-wins。
+        let root = tempdir().unwrap();
+        let view = root.path().join("view");
+        let p = root.path().join("plug");
+        // 先に view/README.md を置く (別 plugin が張った想定)
+        write(&view.join("README.md"), "from a");
+        // src 側も README.md
+        write(&p.join("README.md"), "from b");
+
+        let r = merge_plugin_view_no_doc(&p, &view).unwrap();
+
+        // 既存ファイルは残る
+        let content = fs::read_to_string(view.join("README.md")).unwrap();
+        assert_eq!(content, "from a");
+        // conflict に README.md が記録される
+        assert_eq!(r.conflicts.len(), 1);
+        assert_eq!(r.conflicts[0].relative, PathBuf::from("README.md"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4912,14 +4912,20 @@ fn dispatch_plugin_merge(
         PluginMergeMode::ViewWithDoc => {
             // view 側は per-plugin 専用 dir なので、 別 plugin との衝突は発生しない。
             // ownership / conflicts は便宜上同じ map を渡すが、 通常空のまま戻る。
+            // `merge_plugin_view` は RTP_DIRS の絞り込みをせず、 ルート直下のメタファイル
+            // (README.md / Cargo.toml / Makefile) や rtp 慣習外ディレクトリ
+            // (target/ build/ tests/ src/ examples/) も含めて全部 link する。
+            // これは build / build_lua を持つ plugin が build artifact を view 経由で
+            // 参照できるようにするため (#119 fix)。
             let _ = std::fs::remove_dir_all(view_dir);
-            let r = crate::link::merge_plugin(src, view_dir);
+            let r = crate::link::merge_plugin_view(src, view_dir);
             record_merge_result(plugin_name, r, ownership, conflicts);
         }
         PluginMergeMode::ViewWithoutDoc => {
             let _ = std::fs::remove_dir_all(view_dir);
-            // 1) view (doc 抜き) を per-plugin に
-            let r = crate::link::merge_plugin_no_doc(src, view_dir);
+            // 1) view (doc 抜き) を per-plugin に。 RTP_DIRS の絞り込みなしで
+            //    全 entry (build artifact 含む) を link する。
+            let r = crate::link::merge_plugin_view_no_doc(src, view_dir);
             record_merge_result(plugin_name, r, ownership, conflicts);
             // 2) doc/ だけ merged/ に集約 (これが merge_doc=true の本命)
             let r = crate::link::merge_plugin_doc_only(src, merged_dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4879,6 +4879,23 @@ fn record_merge_result(
     }
 }
 
+/// View 系 dispatch 前に既存 `views/<plug>/` を削除する。 NotFound は無視 (初回 sync 時)、
+/// それ以外のエラー (permission denied / busy 等) は warn を stderr に出すが abort はしない
+/// (resilience: 後続の `merge_plugin_view*` が first-wins で動くので、 残骸があっても
+/// upstream で削除されたファイルがゴミとして残るだけで、 致命的では無い)。
+/// CodeRabbit PR #124 指摘: silent な `let _ =` を避けて user に見える形にする。
+fn clear_view_dir_or_warn(view_dir: &Path) {
+    if let Err(e) = std::fs::remove_dir_all(view_dir)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        eprintln!(
+            "\u{26a0} failed to clear view dir {}: {} (relinking will proceed but stale files may remain)",
+            view_dir.display(),
+            e
+        );
+    }
+}
+
 /// `PluginMergeMode` に従って sync 時のリンク tree を作る (#119 統一案)。
 ///
 /// - `Full` → `merged/` に全 rtp dir を集約
@@ -4911,22 +4928,37 @@ fn dispatch_plugin_merge(
         }
         PluginMergeMode::ViewWithDoc => {
             // view 側は per-plugin 専用 dir なので、 別 plugin との衝突は発生しない。
-            // ownership / conflicts は便宜上同じ map を渡すが、 通常空のまま戻る。
             // `merge_plugin_view` は RTP_DIRS の絞り込みをせず、 ルート直下のメタファイル
             // (README.md / Cargo.toml / Makefile) や rtp 慣習外ディレクトリ
             // (target/ build/ tests/ src/ examples/) も含めて全部 link する。
             // これは build / build_lua を持つ plugin が build artifact を view 経由で
             // 参照できるようにするため (#119 fix)。
-            let _ = std::fs::remove_dir_all(view_dir);
+            clear_view_dir_or_warn(view_dir);
             let r = crate::link::merge_plugin_view(src, view_dir);
-            record_merge_result(plugin_name, r, ownership, conflicts);
+            // ownership map は merged/ 用 (cross-plugin first-wins winner attribution)
+            // なので、 view-only placement で同名 path の attribution を上書きしないよう
+            // 隔離した temp map に流す (CodeRabbit PR #124 指摘)。
+            // view dir は per-plugin 専用なので、 view 内で別 plugin と衝突することは無く、
+            // conflicts も基本空のまま戻る (root file vs dir collision のみ捕捉される)。
+            let mut view_ownership: std::collections::HashMap<PathBuf, String> =
+                std::collections::HashMap::new();
+            let mut view_conflicts: Vec<crate::merge_conflicts::MergeConflictReport> = Vec::new();
+            record_merge_result(plugin_name, r, &mut view_ownership, &mut view_conflicts);
+            // view 内で発生した root collision (まれ) は merged/ の conflicts と
+            // 区別せずユーザーに見せる方が親切なので、 そのまま append する。
+            conflicts.extend(view_conflicts);
         }
         PluginMergeMode::ViewWithoutDoc => {
-            let _ = std::fs::remove_dir_all(view_dir);
+            clear_view_dir_or_warn(view_dir);
             // 1) view (doc 抜き) を per-plugin に。 RTP_DIRS の絞り込みなしで
             //    全 entry (build artifact 含む) を link する。
             let r = crate::link::merge_plugin_view_no_doc(src, view_dir);
-            record_merge_result(plugin_name, r, ownership, conflicts);
+            // ownership 隔離は ViewWithDoc と同じ理由 (#124 指摘)。
+            let mut view_ownership: std::collections::HashMap<PathBuf, String> =
+                std::collections::HashMap::new();
+            let mut view_conflicts: Vec<crate::merge_conflicts::MergeConflictReport> = Vec::new();
+            record_merge_result(plugin_name, r, &mut view_ownership, &mut view_conflicts);
+            conflicts.extend(view_conflicts);
             // 2) doc/ だけ merged/ に集約 (これが merge_doc=true の本命)
             let r = crate::link::merge_plugin_doc_only(src, merged_dir);
             record_merge_result(plugin_name, r, ownership, conflicts);


### PR DESCRIPTION
## Summary

- Remove the `RTP_DIRS` whitelist filter when populating `views/<plug>/` so that plugins generating runtime artifacts outside Neovim's rtp conventions (e.g. blink.cmp's `target/release/blink_cmp_fuzzy.dll`, telescope-fzf-native's `build/`) end up under their view path and remain discoverable via `debug.getinfo()`-relative lookups.
- Keep the filter in place for the shared `merged/` tree where cross-plugin name collisions still need to be suppressed.

## Behavior change

Before: `views/<plug>/` only contained `RTP_DIRS` (lua/, doc/, plugin/, parser/, ...). Build outputs in `target/`, `build/`, `result/` were dropped.

After: `views/<plug>/` mirrors the entire `repos/<plug>/` tree, hard-link only, minus dotfiles (`.git/`, `.github/`, ...) and minus `doc/tags` (preserves the existing rule that prevents `:helptags` from rewriting the upstream clone via shared inodes).

`merge_plugin` (used for `merged/`) is untouched. Disk cost of the wider view is hard-link inodes only.

## Implementation

- `walk` now takes `WalkOptions { rtp_only: bool }`.
- New `merge_plugin_view(src, dst)` and `merge_plugin_view_no_doc(src, dst)` (replaces `merge_plugin_no_doc`).
- `dispatch_plugin_merge` calls the new functions for `ViewWithDoc` / `ViewWithoutDoc`; `Full` still routes through `merge_plugin` into `merged/`.

## Test plan

- [x] `cargo test` (756 pass, 1 ignored — unchanged from main)
- [x] New unit tests assert build artifacts (`target/release/...`, `build/native/...`) are linked into both `merge_plugin_view` and `merge_plugin_view_no_doc` output.
- [x] New tests assert root-level meta files (README.md, Cargo.toml, Makefile) are now retained in views.
- [x] New tests assert `.git/` and `.github/` are still skipped.
- [x] Existing `merge_plugin` tests continue to pass — RTP_DIRS filter behavior on `merged/` is unchanged.
- [ ] Verify on real config: `rvpm sync` with blink.cmp + `build_lua = "require('blink.cmp').build():wait(60000)"` → `views/.../blink.cmp/target/release/blink_cmp_fuzzy.dll` exists, `:lua require('blink.cmp.fuzzy.rust')` succeeds, no "No fuzzy matching library found" warning.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined plugin view generation to independently manage documentation and file linking.
  * Enhanced metadata file handling in plugin view modes.
  * Improved artifact and directory inclusion in view-based merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->