### PR TITLE
fix: self-update on Windows fails with access-denied during cargo install

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -887,14 +887,16 @@ async fn run_self_update(yes: bool, check_only: bool) -> Result<()> {
             if let Err(e) = swap_result {
                 // swap 失敗時は temp dir を leak させ、 ユーザーが手動 recover できる
                 // よう new binary の path をエラーメッセージに含める。
+                // path separator を OS 別に正しく出すため、 文字列連結ではなく
+                // `Path::join` で構築する (Gemini PR #131 指摘)。
                 let leaked = tmp.keep();
+                let preserved_path = leaked.join("bin").join(bin_name);
                 return Err(anyhow::anyhow!(
                     "cargo install succeeded but failed to swap running rvpm binary: {}\n\
-                     new binary is preserved at {}\\bin\\{} — \
+                     new binary is preserved at {} — \
                      after closing every running rvpm process you can manually copy it to {}.",
                     e,
-                    leaked.display(),
-                    bin_name,
+                    preserved_path.display(),
                     exe.display()
                 ));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,7 +779,9 @@ async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
 /// 4. `--yes` 以外は対話プロンプト (`y/N`)
 /// 5. `current_exe()` から install 方法を検出して dispatch:
 ///    - `DevBuild` → 拒否 + manual rebuild 案内
-///    - `CargoInstall` → `cargo install rvpm --force` を spawn
+///    - `CargoInstall` → `cargo install rvpm --force --root <tmp>` で temp dir に build →
+///      `self_replace` crate で running binary を atomic 置換 (Windows で running
+///      .exe を直接上書きできないため)
 ///    - `DirectBinary` → `self_update` crate で atomic 自己置換
 ///
 /// resilience: ネットワーク失敗 / API 失敗時は明示的にエラー終了する
@@ -835,16 +837,65 @@ async fn run_self_update(yes: bool, check_only: bool) -> Result<()> {
             ));
         }
         self_update::InstallMethod::CargoInstall => {
-            eprintln!("running: cargo install rvpm --force");
+            // Windows では実行中の rvpm.exe を `cargo install --force` が直接 replace
+            // できない (cargo は MoveFile で binary を上書きしようとするが、 Windows は
+            // 実行中 .exe にロックをかけるため `os error 5: アクセスが拒否されました`)。
+            //
+            // 対策: 一旦 temp dir に install して、 self_replace crate (self_update の
+            // re-export) で running binary を atomic 置換する。 self_replace は Windows
+            // では「running .exe を rename → reboot 時 delete を schedule → 元 path に
+            // 新 binary を rename」 という 3 段階で running .exe の安全な swap を実装
+            // しており、 file lock を回避できる。 Linux/macOS でもそのまま動く。
+            let tmp = tempfile::Builder::new()
+                .prefix("rvpm-self-update-")
+                .tempdir()
+                .context("failed to create temp dir for cargo install --root")?;
+            let tmp_root = tmp.path().to_path_buf();
+            eprintln!(
+                "running: cargo install rvpm --force --root {}",
+                tmp_root.display()
+            );
             let status = tokio::process::Command::new("cargo")
-                .args(["install", "rvpm", "--force"])
+                .arg("install")
+                .arg("rvpm")
+                .arg("--force")
+                .arg("--root")
+                .arg(&tmp_root)
                 .status()
                 .await
                 .context("failed to spawn `cargo install` (is cargo on PATH?)")?;
             if !status.success() {
                 return Err(anyhow::anyhow!(
-                    "`cargo install rvpm --force` exited with {}",
+                    "`cargo install rvpm --force --root <tmp>` exited with {}",
                     status
+                ));
+            }
+            let bin_name = if cfg!(windows) { "rvpm.exe" } else { "rvpm" };
+            let new_exe = tmp_root.join("bin").join(bin_name);
+            if !new_exe.exists() {
+                return Err(anyhow::anyhow!(
+                    "cargo install reported success but expected binary not found at {}",
+                    new_exe.display()
+                ));
+            }
+            let new_exe_owned = new_exe.clone();
+            let swap_result = tokio::task::spawn_blocking(move || {
+                ::self_update::self_replace::self_replace(&new_exe_owned)
+            })
+            .await
+            .context("self_replace task panicked")?;
+            if let Err(e) = swap_result {
+                // swap 失敗時は temp dir を leak させ、 ユーザーが手動 recover できる
+                // よう new binary の path をエラーメッセージに含める。
+                let leaked = tmp.keep();
+                return Err(anyhow::anyhow!(
+                    "cargo install succeeded but failed to swap running rvpm binary: {}\n\
+                     new binary is preserved at {}\\bin\\{} — \
+                     after closing every running rvpm process you can manually copy it to {}.",
+                    e,
+                    leaked.display(),
+                    bin_name,
+                    exe.display()
                 ));
             }
             println!("\u{2713} rvpm v{} installed.", latest_clean);


### PR DESCRIPTION
## Summary

`rvpm self-update` consistently fails on Windows when the install path is detected as `CargoInstall`:

```
   Replacing C:\Users\...\.cargo\bin\rvpm.exe
error: failed to move `...\cargo-installXXXXXX\rvpm.exe` to `...\rvpm.exe`

Caused by:
  アクセスが拒否されました。 (os error 5)
Error: \`cargo install rvpm --force\` exited with exit code: 101
```

The previous flow shelled out to `cargo install rvpm --force`, which builds in a temp dir and then performs an atomic `MoveFile` on top of `.cargo/bin/rvpm.exe`. Windows holds an exclusive lock on a running `.exe` during execution, so the move always fails — and since the running process **is** rvpm itself (the one that just launched cargo), the failure is unavoidable.

## Fix

Install to a dedicated temp directory via `cargo install rvpm --force --root <tmp>`, then atomically swap the running binary using `self_replace::self_replace()` (already a transitive dep through the `self_update` crate, and already used by the `DirectBinary` path which works on Windows).

On Windows, `self_replace` implements the safe-swap idiom by:

1. Renaming the running `.exe` to a relocated suffix (allowed even while running),
2. Scheduling deletion of that renamed file on next reboot,
3. Moving the new binary into the original path.

On Linux / macOS the running binary can be replaced freely, and `self_replace` handles both platforms — so behavior outside Windows is effectively unchanged.

If the swap step fails after a successful build, the temp dir is preserved (via `TempDir::keep()`) and its path is included in the error so the user can manually copy the new binary into place after closing rvpm processes.

## Test plan

- [x] `cargo make check` (fmt + clippy + 793 tests) passes locally
- [x] Confirmed the original failure with `rvpm self-update --yes` on Windows (exit 101 / os error 5)
- [x] Verified `cargo install rvpm --force --root <tmp>` produces `<tmp>/bin/rvpm.exe` as expected on Windows
- [ ] After release, run `rvpm self-update` from a `cargo install`-installed binary on Windows and confirm clean swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)