### PR TITLE
fix: expose plugin clone .git into view dir so blink.cmp etc. detect their own tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,9 @@ Always go through the `resolve_*` helpers in `src/main.rs` — never hardcode `.
 
 ### Windows support
 
-File-level hard links (`std::fs::hard_link`) on NTFS — no admin rights, no junctions, no symlinks. Falls back to `std::fs::copy` for cross-volume cases.
+Plugin contents are merged with file-level hard links (`std::fs::hard_link`) on NTFS — no admin rights required. Falls back to `std::fs::copy` for cross-volume cases.
+
+The single exception is the per-view `.git` indirection: `views/<plug>/.git` is a directory junction (Windows; created via the `junction` crate, no `mklink` cmd-spawn) or symlink (Unix) pointing to the plugin's clone `.git` dir. Junctions also need no admin rights. This is required for plugins that detect their own git state from the rtp dir (e.g. blink.cmp's `vim.fs.root('.git')` + `git describe --tags`).
 
 ## CLI commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,6 +2655,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +3860,7 @@ dependencies = [
  "gix",
  "humantime",
  "indicatif 0.18.4",
+ "junction",
  "open",
  "ratatui",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,13 @@ gix = { version = "0.83", default-features = false, features = [
     "revision",
 ] }
 
+# Windows directory junction (view dir のルートに repos clone の `.git` を露出
+# する用途; #blink.cmp の `vim.fs.root('.git')` 検出対応)。 Windows-only target
+# dep — `mklink /J` の cmd-spawn を避けてネイティブ API で junction 作成。
+# admin 権限不要、 path 内 forward-slash の cmd-tokenizer 問題なし、
+# process spawn コストもゼロ。
+[target.'cfg(windows)'.dependencies]
+junction = "1"
+
 [dev-dependencies]
 tempfile = "3.27"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,6 +233,19 @@ Resolution rule:
 - **Directories at the plugin root are allow-listed to rtp conventions + denops** — `plugin/`, `lua/`, `doc/`, `ftplugin/`, `ftdetect/`, `syntax/`, `indent/`, `colors/`, `compiler/`, `autoload/`, `after/`, `queries/`, `parser/`, `rplugin/`, `spell/`, `keymap/`, `lang/`, `pack/`, `tutor/` (for `:Tutor`), and `denops/` (for denops.vim TypeScript plugins). `tests/` `scripts/` `examples/` `src/` etc. are unrelated to the rtp and are excluded.
 - **Skip dotfiles at every level** (`.gitignore`, `.luarc.json`, `.editorconfig`, `.gitkeep`, etc.) — they are unrelated to Neovim startup, and at deep levels (e.g. `doc/.gitignore`) would just collide across plugins and add conflict-warning noise.
 
+### `.git` exposure in views (`link_dotgit_into_view`)
+
+The dotfile-skip rule above intentionally drops `.git/` during the merge walk. But some plugins detect their own git state from the rtp directory — blink.cmp, for example, calls `vim.fs.root(plugin_dir, '.git')` followed by `git describe --tags --exact-match HEAD` to decide whether the prebuilt fuzzy library matches the current tag. Without `.git` visible from the view path, that probe sees "not a git repository" and falls back to the Lua implementation with a warning.
+
+`link_dotgit_into_view` adds an indirection at view root pointing back to the plugin clone's real `.git`:
+
+- **Windows**: directory junction via the [`junction`](https://crates.io/crates/junction) crate (native `DeviceIoControl` + `FSCTL_SET_REPARSE_POINT`, no `mklink` cmd-spawn, no admin rights required).
+- **Unix**: `std::os::unix::fs::symlink`.
+
+This is the **only** non-hardlink filesystem operation in the merge pipeline; all other merging stays at file granularity. The link is created inside the `atomic_replace_view_dir` tmp builder so it lands together with the rest of the view via atomic rename. Plugins without `.git` (e.g. `dev = true`) silently skip. Failures are warned but never abort the sync (resilience).
+
+This fix only applies to `ViewWithDoc` / `ViewWithoutDoc` modes. `Full` mode (`merge=true && eager`) cannot expose a single plugin's `.git` because `merged/` is shared across plugins; if such a plugin needs git-state self-detection, the user should set `merge = false` to route it through the View modes.
+
 ### View cleanup
 
 `prune_stale_views()` walks `views/` after each `sync` and removes any

--- a/src/link.rs
+++ b/src/link.rs
@@ -177,6 +177,71 @@ pub fn merge_plugin_view_no_doc(src: &Path, dst_root: &Path) -> Result<MergeResu
     Ok(result)
 }
 
+/// view dir のルートに `.git` を repos clone (`<repos>/<plug>/.git`) から見える
+/// ようにリンクする。
+///
+/// 動機: blink.cmp のように `vim.fs.root(plugin_dir, '.git')` で自分のリポジトリ
+/// 状態を判定するプラグインが、 view 経由で rtp に乗ってると `.git` が見つから
+/// ない問題 (#blink-cmp-tag-warning)。 plugin の clone 本体 (`repos/<plug>/`) には
+/// `.git` があるので、 view からそこへ indirection を張れば plugin 内蔵の git
+/// 検出ロジックがそのまま動く。
+///
+/// 実装:
+/// - Windows: `mklink /J` で directory junction (admin 不要、reparse point)
+/// - Unix: symlink
+///
+/// `<plugin_clone>/.git` が無い場合 (dev = true プラグインなど) は何もせず
+/// `Ok(())` を返す。 リンク作成失敗は anyhow::Error で返す (caller は warn に
+/// 留めて sync 全体を止めない判断ができる)。
+pub fn link_dotgit_into_view(plugin_clone: &Path, view_dir: &Path) -> Result<()> {
+    let src = plugin_clone.join(".git");
+    if !src.exists() {
+        return Ok(());
+    }
+    let dst = view_dir.join(".git");
+    // atomic_replace_view_dir の tmp に build 中なので dst は通常存在しないが、
+    // テストで手動ビルドするケース等のために idempotent にしておく。
+    //
+    // `Path::exists()` は **broken symlink で false を返す** ため、 前回 sync が
+    // 残した壊れた symlink (= clone を別 path に動かした等) があると cleanup を
+    // 飛ばしてしまい、 後段の create_dotgit_link が "file already exists" で失敗
+    // していた (Gemini PR #135 high)。 `symlink_metadata` で symlink を follow せず
+    // type を取り、 ファイル種別ごとに正しい remove API を呼ぶ。
+    if let Ok(meta) = std::fs::symlink_metadata(&dst) {
+        let ft = meta.file_type();
+        let _ = if ft.is_symlink() {
+            // Unix symlink / Windows directory junction (= reparse point) のどちらでも
+            // remove_dir で外せる。 Unix の **file** symlink は remove_file が必要なので
+            // フォールバックも残す。
+            std::fs::remove_dir(&dst).or_else(|_| std::fs::remove_file(&dst))
+        } else if ft.is_dir() {
+            // user が手動で `.git/` ディレクトリを作っていた等の非空ディレクトリにも
+            // 対応する (Gemini PR #135 medium: idempotency 強化)。
+            // CVE-2022-21658 修正済の Rust (>= 1.62) では reparse point を follow しない
+            // ので安全。
+            std::fs::remove_dir_all(&dst)
+        } else {
+            std::fs::remove_file(&dst)
+        };
+    }
+    create_dotgit_link(&src, &dst)
+}
+
+#[cfg(windows)]
+fn create_dotgit_link(src: &Path, dst: &Path) -> Result<()> {
+    // `junction` crate でネイティブ API 経由 (DeviceIoControl + FSCTL_SET_REPARSE_POINT)
+    // で directory junction を作る。 admin 不要、 process spawn コストなし、
+    // `mklink /J` の cmd-tokenizer (path 内 `/` をスイッチ扱いする) 問題も無い。
+    junction::create(src, dst)
+        .map_err(|e| anyhow::anyhow!("junction {} -> {}: {}", dst.display(), src.display(), e))
+}
+
+#[cfg(not(windows))]
+fn create_dotgit_link(src: &Path, dst: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+        .map_err(|e| anyhow::anyhow!("symlink {} -> {}: {}", dst.display(), src.display(), e))
+}
+
 /// プラグインの `doc/` ディレクトリだけを merged にリンクする。`merge_plugin` の
 /// subset 版。
 ///
@@ -1069,6 +1134,113 @@ mod tests {
         assert!(merged.join("doc/main.txt").exists());
         assert!(merged.join("doc/sub/extra.txt").exists());
         assert!(r.conflicts.is_empty());
+    }
+
+    #[test]
+    fn test_link_dotgit_into_view_creates_traversable_link() {
+        // view から `.git/HEAD` が読めれば junction / symlink どちらでも OK。
+        let root = tempdir().unwrap();
+        let plugin_clone = root.path().join("clone");
+        let view = root.path().join("view");
+        // plugin clone 側の .git を作る
+        write(&plugin_clone.join(".git/HEAD"), "ref: refs/heads/main\n");
+        write(&plugin_clone.join(".git/refs/heads/main"), "deadbeef\n");
+        fs::create_dir_all(&view).unwrap();
+
+        link_dotgit_into_view(&plugin_clone, &view).unwrap();
+
+        // view 側から `.git/HEAD` が読めること (= リンクが効いている)
+        let head = fs::read_to_string(view.join(".git/HEAD")).unwrap();
+        assert_eq!(head, "ref: refs/heads/main\n");
+        let main_ref = fs::read_to_string(view.join(".git/refs/heads/main")).unwrap();
+        assert_eq!(main_ref, "deadbeef\n");
+    }
+
+    #[test]
+    fn test_link_dotgit_into_view_is_noop_when_no_git_dir() {
+        // dev = true プラグイン等 .git を持たないソースは静かにスキップ。
+        let root = tempdir().unwrap();
+        let plugin_clone = root.path().join("clone");
+        let view = root.path().join("view");
+        // plugin_clone は存在するが .git は無い
+        fs::create_dir_all(&plugin_clone).unwrap();
+        write(&plugin_clone.join("plugin/foo.vim"), "echo 'foo'");
+        fs::create_dir_all(&view).unwrap();
+
+        link_dotgit_into_view(&plugin_clone, &view).expect("noop should not error");
+
+        assert!(
+            !view.join(".git").exists(),
+            "view/.git should not be created when source has no .git"
+        );
+    }
+
+    #[test]
+    fn test_link_dotgit_into_view_overwrites_existing_link() {
+        // 前回の sync で残った .git を新しい clone のものに張り替えられる
+        // (idempotent)。 上書きで panic しない。
+        let root = tempdir().unwrap();
+        let plugin_clone = root.path().join("clone");
+        let view = root.path().join("view");
+        write(&plugin_clone.join(".git/HEAD"), "ref: refs/heads/main\n");
+        fs::create_dir_all(&view).unwrap();
+
+        link_dotgit_into_view(&plugin_clone, &view).unwrap();
+        // 2 回目も成功すること
+        link_dotgit_into_view(&plugin_clone, &view).unwrap();
+
+        let head = fs::read_to_string(view.join(".git/HEAD")).unwrap();
+        assert_eq!(head, "ref: refs/heads/main\n");
+    }
+
+    #[test]
+    fn test_merge_view_with_dotgit_link_works_together() {
+        // merge_plugin_view と link_dotgit_into_view を順に呼ぶ統合シナリオ。
+        // walk が dotfile を skip するので .git の中身は merge では張られない。
+        // その後 link_dotgit_into_view で .git だけ junction / symlink で露出する。
+        let root = tempdir().unwrap();
+        let plugin_clone = root.path().join("clone");
+        let view = root.path().join("view");
+        write(&plugin_clone.join("lua/foo/init.lua"), "return {}");
+        write(&plugin_clone.join(".git/HEAD"), "ref: refs/heads/main\n");
+        write(&plugin_clone.join(".git/packed-refs"), "# packed-refs v2\n");
+
+        let r = merge_plugin_view(&plugin_clone, &view).unwrap();
+        assert!(r.conflicts.is_empty());
+        // walk は .git を skip するので、 hard-link 配下に .git/HEAD は来ない
+        assert!(
+            !view.join(".git").join("HEAD").exists() || view.join(".git").is_symlink_or_junction(),
+            "before linking, .git/HEAD should not exist in view"
+        );
+
+        link_dotgit_into_view(&plugin_clone, &view).unwrap();
+
+        // lua の hard-link はそのまま、 .git は indirection 越しに読める
+        assert_eq!(
+            fs::read_to_string(view.join("lua/foo/init.lua")).unwrap(),
+            "return {}"
+        );
+        assert_eq!(
+            fs::read_to_string(view.join(".git/HEAD")).unwrap(),
+            "ref: refs/heads/main\n"
+        );
+        assert_eq!(
+            fs::read_to_string(view.join(".git/packed-refs")).unwrap(),
+            "# packed-refs v2\n"
+        );
+    }
+
+    /// テスト中で junction / symlink 判定したいだけのヘルパー。 std には統一 API
+    /// が無いのでここで簡略実装。 実プロダクションパスでは使わない。
+    trait IsSymlinkOrJunction {
+        fn is_symlink_or_junction(&self) -> bool;
+    }
+    impl IsSymlinkOrJunction for std::path::PathBuf {
+        fn is_symlink_or_junction(&self) -> bool {
+            std::fs::symlink_metadata(self)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5335,45 +5335,68 @@ fn dispatch_plugin_merge(
             // atomic_replace_view_dir で tmp に build → atomic rename することで、
             // Neovim が走ってる状態で `rvpm generate` が動いても、 view dir が
             // 空になる窓を作らない (lazy plugin の require / autoload race を回避)。
-            let mut view_ownership: std::collections::HashMap<PathBuf, String> =
-                std::collections::HashMap::new();
-            let mut view_conflicts: Vec<crate::merge_conflicts::MergeConflictReport> = Vec::new();
-            let mut merge_result: Option<anyhow::Result<crate::link::MergeResult>> = None;
-            let atomic_res = atomic_replace_view_dir(view_dir, |tmp| {
-                let m = crate::link::merge_plugin_view(src, tmp)?;
-                merge_result = Some(Ok(m));
-                Ok(())
-            });
-            if let Err(e) = atomic_res {
-                merge_result = Some(Err(e.context("atomic view replace failed")));
-            }
-            if let Some(r) = merge_result {
-                record_merge_result(plugin_name, r, &mut view_ownership, &mut view_conflicts);
-            }
-            conflicts.extend(view_conflicts);
+            build_view_atomically(
+                src,
+                view_dir,
+                plugin_name,
+                conflicts,
+                crate::link::merge_plugin_view,
+            );
         }
         PluginMergeMode::ViewWithoutDoc => {
-            let mut view_ownership: std::collections::HashMap<PathBuf, String> =
-                std::collections::HashMap::new();
-            let mut view_conflicts: Vec<crate::merge_conflicts::MergeConflictReport> = Vec::new();
-            let mut merge_result: Option<anyhow::Result<crate::link::MergeResult>> = None;
-            let atomic_res = atomic_replace_view_dir(view_dir, |tmp| {
-                let m = crate::link::merge_plugin_view_no_doc(src, tmp)?;
-                merge_result = Some(Ok(m));
-                Ok(())
-            });
-            if let Err(e) = atomic_res {
-                merge_result = Some(Err(e.context("atomic view replace failed")));
-            }
-            if let Some(r) = merge_result {
-                record_merge_result(plugin_name, r, &mut view_ownership, &mut view_conflicts);
-            }
-            conflicts.extend(view_conflicts);
+            build_view_atomically(
+                src,
+                view_dir,
+                plugin_name,
+                conflicts,
+                crate::link::merge_plugin_view_no_doc,
+            );
             // 2) doc/ だけ merged/ に集約 (これが merge_doc=true の本命)
             let r = crate::link::merge_plugin_doc_only(src, merged_dir);
             record_merge_result(plugin_name, r, ownership, conflicts);
         }
     }
+}
+
+/// `views/<plug>/` を tmp 経由で atomic rebuild するヘルパー。
+///
+/// `merge_view_fn` で plugin の rtp dir を tmp に集約し、 続けて `link_dotgit_into_view`
+/// で `.git` を repos clone から junction / symlink で露出する (blink.cmp 等が
+/// 自分の tag 状態を `vim.fs.root('.git')` で判定するため。 failure は warn のみ
+/// で続行 = sync 全体を止めない resilience)。
+///
+/// 元々 `dispatch_plugin_merge` の `ViewWithDoc` / `ViewWithoutDoc` で同じ block が
+/// 2 回登場していたので 1 関数に括った (Gemini PR #135 medium)。
+fn build_view_atomically(
+    src: &Path,
+    view_dir: &Path,
+    plugin_name: &str,
+    conflicts: &mut Vec<crate::merge_conflicts::MergeConflictReport>,
+    merge_view_fn: fn(&Path, &Path) -> anyhow::Result<crate::link::MergeResult>,
+) {
+    let mut view_ownership: std::collections::HashMap<PathBuf, String> =
+        std::collections::HashMap::new();
+    let mut view_conflicts: Vec<crate::merge_conflicts::MergeConflictReport> = Vec::new();
+    let mut merge_result: Option<anyhow::Result<crate::link::MergeResult>> = None;
+    let atomic_res = atomic_replace_view_dir(view_dir, |tmp| {
+        let m = merge_view_fn(src, tmp)?;
+        if let Err(e) = crate::link::link_dotgit_into_view(src, tmp) {
+            eprintln!(
+                "\u{26a0} failed to expose .git in view {}: {}",
+                view_dir.display(),
+                e
+            );
+        }
+        merge_result = Some(Ok(m));
+        Ok(())
+    });
+    if let Err(e) = atomic_res {
+        merge_result = Some(Err(e.context("atomic view replace failed")));
+    }
+    if let Some(r) = merge_result {
+        record_merge_result(plugin_name, r, &mut view_ownership, &mut view_conflicts);
+    }
+    conflicts.extend(view_conflicts);
 }
 
 /// 収集した衝突を plugin ごとにグループ化して stderr にサマリ出力する。


### PR DESCRIPTION
## Summary

- Some plugins probe their own repository state from the rtp directory to decide on prebuilt-binary downloads or version warnings — the canonical case is **blink.cmp** (`fuzzy/download/git.lua`):

  ```lua
  local repo_dir = vim.fs.root(files.root_dir, '.git')
  vim.system({ 'git', '--git-dir', vim.fs.joinpath(repo_dir, '.git'),
               '--work-tree', repo_dir, 'describe', '--tags', '--exact-match' })
  ```

- When the plugin is reached via rvpm's view path (`<cache_root>/plugins/views/<host>/<owner>/<repo>/`), `.git` was never exposed (the merge walk strips dotfiles by design). The probe returned _not a git repository_, and blink.cmp emitted:

  > Found an outdated version of the locally built fuzzy matching library / Couldn't download the updated fuzzy matching library due to not being on a git tag

  even when the user had pinned a literal tag like `rev = "v1.10.2"`.

## What changed

`link.rs::link_dotgit_into_view` adds a single indirection at view root pointing back to the plugin clone's real `.git`:

| OS | Mechanism |
|---|---|
| Windows | Directory junction via the [`junction`](https://crates.io/crates/junction) crate (native `DeviceIoControl` + `FSCTL_SET_REPARSE_POINT`). No `mklink` cmd-spawn, no admin rights required, no `cmd` path-tokenizer issues with forward slashes. |
| Unix | `std::os::unix::fs::symlink`. |

`dispatch_plugin_merge` calls it inside the `atomic_replace_view_dir` tmp builder for both `ViewWithDoc` and `ViewWithoutDoc` modes, so the link lands together with the rest of the view via atomic rename. Failures are warned but never abort the sync (resilience). Plugins without `.git` (e.g. `dev = true`) silently skip.

## Scope / known limitation

`Full` mode (`merge=true && eager`) is intentionally **not** affected — `merged/` is shared across plugins so a single `.git` cannot be exposed there. Users whose eager plugins need git self-detection should set `merge = false` on the affected plugin to route it through the View modes. CLAUDE.md and `docs/architecture.md` document this.

## Verification on the dev box

After `cargo build --release` from this branch, running `rvpm sync`:

```
$ ls -la ~/.cache/rvpm/nvim/plugins/views/github.com/saghen/blink.lib/.git
lrwxrwxrwx ... .git -> .../repos/github.com/saghen/blink.lib/.git

$ cd .../views/github.com/saghen/blink.lib
$ git --git-dir .git --work-tree . log --oneline -1
f29d8ba feat(nix): refactor and some minor improvements (#16)
```

`git --git-dir <view>/.git` works through the junction, which is exactly what blink.cmp's probe needs.

## Test plan

- [x] `cargo make check` — fmt + clippy + test (796 passed, 1 ignored)
- [x] `link::tests::test_link_dotgit_into_view_creates_traversable_link` — junction/symlink lets the test read `.git/HEAD` from the view root
- [x] `link::tests::test_link_dotgit_into_view_is_noop_when_no_git_dir` — dev plugin path
- [x] `link::tests::test_link_dotgit_into_view_overwrites_existing_link` — re-sync idempotency
- [x] `link::tests::test_merge_view_with_dotgit_link_works_together` — `merge_plugin_view` + `link_dotgit_into_view` integrated; `walk` skips `.git` so no double-link
- [x] Smoke-tested by running release `rvpm sync` against the maintainer's actual nvim plugin set: junction created for every lazy plugin, `git --git-dir <view>/.git rev-parse HEAD` returns the expected commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)