### PR TITLE
feat(ai): add mechanism to dump raw AI responses for debugging

### DIFF
--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -297,7 +297,20 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
         ));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    // RVPM_AI_DUMP_RESPONSE=<path> があれば生の応答を保存 (#141)
+    if let Ok(dump_path) = std::env::var("RVPM_AI_DUMP_RESPONSE")
+        && !dump_path.trim().is_empty()
+    {
+        if let Err(e) = std::fs::write(&dump_path, &stdout) {
+            eprintln!("\u{26a0}\u{fe0f}  Failed to dump AI response to {dump_path}: {e}");
+        } else {
+            eprintln!("\u{1f4dd} AI response dumped to {dump_path}");
+        }
+    }
+
+    Ok(stdout)
 }
 
 /// AI 応答から `<rvpm:plugin_entry>` 等の XML tag を抜き取る。


### PR DESCRIPTION
## Description

Adds a new debugging mechanism to save raw stdout from AI CLI tools to a file. This is useful for diagnosing cases where the AI fails to produce the expected XML tags or when investigating internal AI errors.

## Changes

- Implemented `RVPM_AI_DUMP_RESPONSE` environment variable support in `src/ai/mod.rs`.
- When set to a file path, rvpm writes the raw AI output to that path.

## Usage

```bash
$ export RVPM_AI_DUMP_RESPONSE=/tmp/ai_response.txt
$ rvpm add owner/repo --ai opencode
# If it fails, check the file:
$ cat /tmp/ai_response.txt
```

Fixes #141