### PR TITLE
chore: adopt kata template (pj-presets:rust-cli)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[Makefile,*.mk]
+indent_style = tab

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeDirectories": ["~/wt"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,45 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
+  RUST_BACKTRACE: 1
 
 jobs:
+  check:
+    name: check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-targets
+
   fmt:
-    name: Format
+    name: rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,7 +52,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
+    name: clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,21 +62,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
-  test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+  lockfile:
+    # Catches stale Cargo.lock (e.g. version bumped in Cargo.toml but lock
+    # still points at the old version) before it reaches the publish job,
+    # which uses --locked and would otherwise fail there.
+    name: cargo lockfile in sync
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Configure git (for git integration tests)
-        run: |
-          git config --global user.email "ci@example.com"
-          git config --global user.name "CI"
-          git config --global init.defaultBranch main
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo check --locked --all-targets

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 
 # APM dependencies
 apm_modules/
+# kata:gitignore:base:begin
+# Editor / OS noise — kata-managed (yukimemi/pj-base).
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store
+Thumbs.db
+# kata:gitignore:base:end

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,0 +1,71 @@
+preset = "github.com/yukimemi/pj-presets:rust-cli"
+applied_at = "2026-05-10T01:47:19.7370279Z"
+
+[[templates]]
+source = "github.com/yukimemi/pj-base"
+rev = "280ca2337400c0fe4cd2da17dc16185581f3a2dd"
+version = "0.3.0"
+
+[[templates]]
+source = "github.com/yukimemi/pj-rust"
+rev = "8c3842eb0e073b506f6bc293423a2d20273accae"
+version = "0.2.0"
+
+[[templates]]
+source = "github.com/yukimemi/pj-rust-cli"
+rev = "048e9fecbe348a9f0507b4fe61d259810d6c704a"
+version = "0.2.0"
+
+[files.".editorconfig"]
+once_applied = true
+
+[files.".gemini/settings.json"]
+content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e"
+
+[files.".github/workflows/ci.yml"]
+content_hash = "a7a9e10867d5b2ec06fecb9f3248b0f2ad940584cc583bd2b9dd48cccff624b8"
+
+[files.".github/workflows/release.yml"]
+once_applied = true
+
+[files.".gitignore"]
+content_hash = "733fc58cfdd43e5c91b522e71932bbd22c83b51700937fed382564bbe7262193"
+
+[files."AGENTS.md"]
+content_hash = "e4f146a1c66d11e6b6c707f52507b3e37da2fe52d8d7cf13f75edcf9ad5d3a7f"
+
+[files."CLAUDE.md"]
+content_hash = "a76b3af252969b8120128d7ce44f2b6cfdcf88c7420ee00675732f542d047529"
+
+[files."GEMINI.md"]
+content_hash = "3670f70a2f0be4013926bab6e878b90a42ad64c17899080aef4d193b246fa390"
+
+[files.LICENSE]
+once_applied = true
+
+[files."Makefile.toml"]
+content_hash = "656e02f02146079b1d966219eb395000462fe9121719621dc2d9696f80b13e25"
+
+[files."OPENCODE.md"]
+content_hash = "11993dc7feec5fca8e83934f135de33879b88f100c48aeba0729de2f57a11a48"
+
+[files."apm.yml"]
+once_applied = true
+
+[files."clippy.toml"]
+content_hash = "89dbb3b4fd63c479f61f077d2383ab5c0998ea838f271ed57fd09281975deda0"
+
+[files."opencode.json"]
+content_hash = "2ada1cf4347db9e98fadd67ca72cd9e29042c5bf6ab719d666b5d71f97663e81"
+
+[files."renovate.json"]
+content_hash = "32569a8b8904be51b03feff5955357333e191a4e95d93bc2b38bf067f56a6bbb"
+
+[files."renri.toml"]
+content_hash = "f4751570494ba62997cfb47e3abee2e707d3e01d924d1e8b940905a4e7c974f3"
+
+[files."rust-toolchain.toml"]
+content_hash = "9eac3c057320afbad00022718e0c14731122b4c3f28abd2dc702846244c39f66"
+
+[files."rustfmt.toml"]
+content_hash = "8a0bd07a7aaaf3e9fed5dd297b04a5f96c4a969d895375aa4e00247a95aa616c"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,400 @@
+# AGENTS.md
+
+Guidance for AI agents (Claude / Codex / Gemini) working in this
+repo. The yukimemi/* shared conventions live in the
+`<!-- kata:agents:* -->` blocks below, sourced from
+`yukimemi/pj-base` / `pj-rust` / `pj-rust-cli` via `kata apply` —
+see those for git workflow, PR review cycle, build/lint/test
+commands, release flow, and renri's worktree usage.
+
+The sections above the marker blocks are rvpm-specific and
+consumer-owned: edit them freely; `kata apply` won't touch them.
+
+> Detailed references live under [`docs/`](docs/):
+> - [`docs/architecture.md`](docs/architecture.md) — loader.lua phases, lazy triggers, lockfile / merge / path internals
+> - [`docs/cli.md`](docs/cli.md) — full subcommand list & contributor checklist for adding flags
+
+## Concept
+
+- **Extremely Fast**: Blazing-fast startup via Rust concurrency (Tokio), a merged directory layout, and a pre-compiled loader.lua.
+- **Type Safe & Robust**: TOML-based configuration typed with serde. The `resilience` principle ensures that one plugin's failure does not stop the whole system.
+- **Convention over Configuration**: `init.lua` / `before.lua` / `after.lua` placed under `{config_root}/<host>/<owner>/<repo>/` are auto-loaded by convention.
+- **Hybrid CLI**: One-shot operations via arguments alongside interactive operations through `FuzzySelect` / TUI.
+- **Pre-compiled loader**: Disables Neovim's plugin loading with `vim.go.loadplugins = false` and emits a static loader.lua at generate time. Reduces startup I/O via merge optimization and pre-resolved globs.
+
+## Design Principles
+
+**Always implement using TDD.** Write tests first (and confirm they fail) before implementing.
+
+**Resilience:** A single plugin's failure must not bring down the whole system. Sync failures and config mistakes (e.g. missing dependencies) are reported as warnings, and subsequent processing (`generate`, etc.) continues whenever possible. Safety at Neovim startup is the top priority — even an incomplete configuration must guarantee a minimal startup.
+
+## TOML Configuration Schema
+
+```toml
+[vars]
+# User-defined variables. Reference them from Tera templates inside the TOML as {{ vars.xxx }}.
+repo_base   = "~/.cache/nvim/rvpm"
+nvim_rc = "~/.config/nvim/rc"
+
+[options]
+# Root directory holding per-plugin init/before/after.lua.
+# Defaults to ~/.config/rvpm/<appname>/plugins when unset.
+config_root = "{{ vars.nvim_rc }}/plugins"
+# Max parallelism (default 13, kept conservative to avoid GitHub rate limits).
+concurrency = 16
+# Auto-delete plugin directories that were dropped from config.toml on sync /
+# generate completion (default false). Replaces having to pass `sync --prune` every time.
+# auto_clean = true
+# Auto-generate helptags via nvim --headless on sync / generate completion
+# (default true). Lazy plugins are not on runtimepath, so rvpm enumerates the
+# target doc/ directories itself and runs :helptags <path> for each.
+# auto_helptags = false
+# Aggregate every non-Full plugin's `doc/` into `merged/doc/` so `:help <topic>`
+# can find their tags before the plugin loads (default false). The plugin's
+# rtp entry routes through `views/<plug>/` (a doc-stripped, hard-link tree of
+# the clone) so `:tselect` shows no duplicate. Eager + merge=true (Full merge)
+# is unaffected — those still go entirely into `merged/`. Per-plugin override
+# is `[[plugins]] merge_doc = true|false`. Filename conflicts inside `doc/`
+# are first-wins (recorded in `merge_conflicts.json`). #119
+# merge_doc = true
+# URL form written by `rvpm add`: "short" (owner/repo, default) or
+# "full" (https://github.com/owner/repo). Duplicate detection normalizes both forms before comparing.
+# url_style = "full"
+# Override rvpm's data root (defaults to ~/.cache/rvpm/<appname> when unset).
+# repos / merged / loader.lua all live under `{cache_root}/plugins/`.
+# cache_root = "~/.cache/nvim/rvpm"
+# Post-scan auto-lazy suggestion policy for `rvpm add`:
+#   "ask" (default) — TTY interactive prompt / skipped on non-TTY
+#   "always"        — accept scan results unconditionally (for scripts)
+#   "never"         — skip scanning, eager add
+# auto_lazy = "ask"
+# Backend used to delegate `rvpm add` to an AI CLI (#93).
+#   "off" (default) — use the static scan + auto_lazy flow
+#   "claude" / "gemini" / "codex" / "opencode" — spawn the corresponding CLI as a subprocess
+# Errors out if the CLI is not installed. `auto_lazy` is ignored.
+# CLI flags `--ai claude` / `--no-ai` allow per-call overrides.
+# ai = "claude"
+# Natural language used in AI output (explanation prose + chat replies). Default "en".
+# The XML tag structure itself is fixed in English (for parse stability).
+# ai_language = "ja"
+
+[options.browse]
+# Delegate README rendering to an external command (browse TUI only).
+# Pipes raw markdown on stdin and converts ANSI escapes from stdout into
+# ratatui Text via ansi-to-tui. Falls back to the built-in tui-markdown path on failure/timeout.
+# Placeholders use Tera-style `{{ name }}` syntax (consistent with the rest of rvpm):
+#   {{ width }} / {{ height }} / {{ file_path }} / {{ file_dir }}
+#   {{ file_name }} / {{ file_stem }} / {{ file_ext }}
+# readme_command = ["mdcat"]
+# readme_command = ["glow", "-s", "dark", "-w", "{{ width }}", "{{ file_path }}"]
+
+[[plugins]]
+name  = "snacks"
+url   = "folke/snacks.nvim"
+# No on_* → eager (loaded at startup)
+
+[[plugins]]
+name = "telescope"
+url  = "nvim-telescope/telescope.nvim"
+depends = ["snacks.nvim"]
+# rev: branch / tag / commit hash, or `/regex/` to pick the highest semver tag matching the pattern
+# rev = "v0.1.0"
+# rev = "/^v1\\..*/"   # picks max semver tag among /^v1\..*/ — re-resolves on every sync
+# build: shell command (run after sync / update completes, 5 min timeout)
+# build = "cargo build --release"
+# build_lua: Lua snippet executed via nvim --headless -u NONE -l (#97)
+# Appends self + transitive depends to rtp; stdpath() reflects the real env, so
+# native lib installs (e.g. blink.cmp) land properly in the user's data dir.
+# build_lua = "require('blink.cmp').build():wait(60000)"
+
+# Lazy-loading triggers (writing any one of these auto-infers lazy = true)
+on_cmd    = ["Telescope", "/^Chezmoi/"]      # exact name or /regex/ (expanded by rvpm generate)
+on_ft     = ["rust", "toml"]                 # string | string[]
+on_event  = ["BufReadPre", "User LazyDone", "/^User Chezmoi/"]  # exact "User Xxx" or /regex/ also OK
+on_path   = ["*.rs", "Cargo.toml"]           # BufRead/BufNewFile glob
+on_source = ["snacks.nvim"]                  # triggered by another plugin's load-completion User event (specify by display_name)
+# on_map allows mixing string (simple) and table (mode + desc) forms.
+# Writing `/regex/` for lhs expands by matching against the plugin's <Plug>(...) list (#88).
+on_map = [
+  "<leader>f",                                              # mode = ["n"] (default)
+  { lhs = "<leader>v",  mode = ["n", "x"] },
+  { lhs = "<leader>g",  mode = ["n", "x"], desc = "Grep" },
+  { lhs = "/^<Plug>\\(Chezmoi/", mode = ["n"] },           # bulk-lazy <Plug> family
+]
+# Conditional loading (Lua expression)
+cond = "vim.fn.has('win32') == 1"
+# Per-plugin override of `options.merge_doc` (#119).
+# - Some(true)  → for this plugin, merge `doc/` into `merged/doc/` and route rtp through `views/<plug>/`
+# - Some(false) → opt out of doc-merge even when global default is true
+# - omitted     → follow `options.merge_doc`. With `cond` set, an unset value is auto-forced false
+#                 (only sweeps cond plugins out of the global default — explicit Some(true) is honored)
+# merge_doc = true
+```
+
+## Global hooks
+
+Auto-applied just by placing files directly under `<config_root>/` (default `~/.config/rvpm/<appname>/`). No entries in the config file are needed (Convention over Configuration).
+
+| File | Phase | Timing |
+|---|---|---|
+| `<config_root>/before.lua` | 3 | After the `load_lazy` helper is defined, before any plugin's `init.lua` |
+| `<config_root>/after.lua` | 9 | After all lazy triggers are registered |
+
+When `options.config_root` is unset, `<config_root>` is `~/.config/rvpm/<appname>` (`<appname>` = `$RVPM_APPNAME` → `$NVIM_APPNAME` → `nvim`).
+
+`generate_loader()` takes a `LoaderOptions` struct (`global_before: Option<PathBuf>`, `global_after: Option<PathBuf>`) and embeds `dofile(...)` only when the file exists.
+
+## per-plugin config files (config_root)
+
+Per-plugin Lua config files can be placed under `options.config_root` using the `<host>/<owner>/<repo>/` hierarchy. Example: `~/.config/nvim/rc/plugins/github.com/nvim-telescope/telescope.nvim/`.
+
+| File | Timing | Typical use |
+|---|---|---|
+| `init.lua` | **Before RTP append** (the pre-rtp phase, common to all plugins) | Pre-set variables like `vim.g.xxx_setting = ...` |
+| `before.lua` | **Right after RTP append, before sourcing `plugin/*`** | Override setup, `require` lua/ modules, etc. |
+| `after.lua` | **After sourcing `plugin/*`** | Post-setup that calls plugin functions, keymap configuration |
+
+At generate time rvpm checks each file's existence and embeds `dofile(...)` in loader.lua only for ones that exist (pre-compiled).
+
+## Architecture overview
+
+`src/main.rs` is the entry point and command handler. Each command is implemented as a `run_*()` function and runs on the Tokio async runtime.
+
+```text
+src/
+  main.rs       — CLI definitions (clap), run_*() implementations for every command, helper functions
+  config.rs     — TOML config parsing (with Tera template expansion), MapSpec type, sort_plugins
+  doctor.rs     — `rvpm doctor` — 17 diagnostics × 4 categories + render (nerd/unicode/ascii)
+  git.rs        — async wrappers for git clone/pull/fetch/checkout (Repo struct) + GitChange recording
+  helptags.rs   — runs :helptags via nvim --headless to generate tags
+  link.rs       — file-level linking into the merged directory (hard link, first-wins on conflict); `placed` returns newly placed files for winner tracking
+  loader.rs     — logic that generates Neovim's loader.lua
+  merge_conflicts.rs — read/write of `<cache_root>/merge_conflicts.json` (most recent sync only; consumed by doctor)
+  lockfile.rs   — read/write of `<config_root>/rvpm.lock` (reproducible plugin versions; intended to be committed to dotfiles)
+  tui.rs        — ratatui-based progress / list display TUI
+  update_log.rs — read/append of `<cache_root>/update_log.json`, BREAKING detection, render
+```
+
+### Data flow
+
+1. `parse_config()` — reads the TOML, expands Tera templates, then deserializes into the `Config` struct
+2. `sort_plugins()` — topological sort based on the `depends` field (cycles produce only a warning)
+3. `run_sync()` — parallel git clone/pull via `JoinSet` + `Semaphore` → link into the merged directory via `merge_plugin()` → pre-glob via `build_plugin_scripts()` → generate loader.lua via `generate_loader()` (which also runs the eager→lazy dependency promotion pre-pass) → `build_helptags()` launches `nvim --headless` to run `:helptags` (only when `options.auto_helptags=true`)
+
+### loader.lua phase outline
+
+```text
+Pre-pass:  eager→lazy dependency promotion
+Phase 1:   vim.go.loadplugins = false
+Phase 2:   define load_lazy helper
+Phase 3:   global before.lua
+Phase 4:   init.lua of every plugin (in dep order, pre-rtp)
+Phase 5:   append merged/ to rtp once
+Phase 6:   process eager plugins (rtp append + before/plugin/ftdetect/after-plugin/after.lua + User rvpm_loaded_<name>)
+Phase 7:   register lazy plugin triggers (on_cmd / on_ft / on_map / on_event / on_path / on_source)
+Phase 8:   register ColorSchemePre handlers (auto-detected for lazy plugins)
+Phase 9:   global after.lua
+```
+
+See [`docs/architecture.md`](docs/architecture.md) for design rationale, lazy trigger details, and per-trigger mechanics.
+
+### Key invariants
+
+- **`vim.go.loadplugins = false`** is set in phase 1 — loader.lua is the single source of truth for plugin sourcing.
+- **Pre-glob at generate time** — files under `plugin/`, `ftdetect/`, `after/plugin/` are walked once at generate time and embedded as literal paths in loader.lua. Zero glob calls at startup.
+- **Lazy plugins stay off rtp** until their trigger fires — keeping `lua/` modules out of the rtp is what makes lazy meaningful.
+- **Resilience** — failures during sync / link / helptags emit warnings on stderr and let subsequent steps continue.
+
+### Lockfile priority order
+
+`rev` in config > `commit` in lockfile > latest HEAD. `rvpm sync --frozen` errors when an entry is missing; `--no-lock` skips lockfile entirely. Details in [`docs/architecture.md`](docs/architecture.md).
+
+### Merge strategy summary
+
+`decide_merge_mode(plugin.merge, plugin.lazy, plugin.merge_doc, options.merge_doc)` chooses one of three actions per plugin (#119):
+
+- **Full** (`merge=true && eager`) → all rtp dirs hard-linked into `<cache_root>/plugins/merged/`; rtp gets `merged/` once at startup.
+- **ViewWithDoc** (everything else, `merge_doc=false`) → all rtp dirs (incl. `doc/`) hard-linked into `<cache_root>/plugins/views/<plug>/`; rtp gets that view path (eager: startup; lazy: at trigger).
+- **ViewWithoutDoc** (everything else, `merge_doc=true`) → view tree minus `doc/`, plus the plugin's `doc/` files aggregated into `merged/doc/`. rtp gets the doc-stripped view; `:help` works through `merged/` from startup, no `:tselect` duplicate after trigger.
+
+`repos/<plug>/` is **never on rtp** — only `merged/` and `views/<plug>/` are. Conflicts are first-wins, recorded in `merge_conflicts.json` (self-conflicts filtered), surfaced by `rvpm doctor`. `cond` plugins get `merge=false` forced by `disable_merge_if_cond`, and `merge_doc=None` is forced to `Some(false)` (explicit per-plugin `Some(true)` survives — Windows-only-but-help-findable use case). Full rules in [`docs/architecture.md`](docs/architecture.md).
+
+### Path conventions
+
+Config / cache are **fixed at `~/.config/rvpm/` and `~/.cache/rvpm/` across all platforms** (no `%APPDATA%` on Windows — keeps dotfile layouts identical across WSL / Linux / Windows).
+
+- `cache_root` (override: `options.cache_root`) → default `~/.cache/rvpm/<appname>` — moves repos / merged / views / loader.lua together.
+- `config_root` (override: `options.config_root`) → default `~/.config/rvpm/<appname>/plugins` — per-plugin init/before/after.lua.
+- `<appname>` resolves as `$RVPM_APPNAME` → `$NVIM_APPNAME` → `"nvim"`.
+
+Always go through the `resolve_*` helpers in `src/main.rs` — never hardcode `.config/rvpm/...` or `.cache/rvpm/...` string literals. Full table of helpers and the directory layout in [`docs/architecture.md`](docs/architecture.md).
+
+### Windows support
+
+Plugin contents are merged with file-level hard links (`std::fs::hard_link`) on NTFS — no admin rights required. Falls back to `std::fs::copy` for cross-volume cases.
+
+The single exception is the per-view `.git` indirection: `views/<plug>/.git` is a directory junction (Windows; created via the `junction` crate, no `mklink` cmd-spawn) or symlink (Unix) pointing to the plugin's clone `.git` dir. Junctions also need no admin rights. This is required for plugins that detect their own git state from the rtp dir (e.g. blink.cmp's `vim.fs.root('.git')` + `git describe --tags`).
+
+## CLI commands
+
+`rvpm sync / generate / clean / add / tune / update / remove / edit / set / config / init / list / browse / doctor / profile / log / completion`. Full flag-by-flag reference and the contributor checklist for adding flags is in [`docs/cli.md`](docs/cli.md).
+
+## First-run support
+
+`rvpm sync` / `rvpm generate` call `print_init_lua_hint_if_missing()` at the end and print guidance when Neovim's `init.lua` (resolved with `$NVIM_APPNAME`) does not reference loader.lua (or has not been created yet). Running `rvpm init --write` then either creates init.lua if absent or appends to its end (idempotently). The insertion is annotated so it is clearly identifiable as "added by rvpm."
+
+<!-- kata:agents:base:begin -->
+## yukimemi/* shared conventions
+
+This file is the agent-agnostic source of truth (per the
+[agents.md](https://agents.md) convention). The matching
+`CLAUDE.md` and `GEMINI.md` files are thin shims that point back
+here so each tool's auto-load behaviour still finds something.
+**Edit AGENTS.md, not the shims.**
+
+### Git workflow
+
+- **No direct push to `main`.** Open a PR.
+  - Exception: trivial typo / whitespace / docs wording fixes.
+  - Exception: standalone version bumps.
+- Branch names: `feat/...`, `fix/...`, `chore/...`.
+- **PR titles + bodies in English. Commit messages in English.**
+- Tag-based releases: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+### PR review cycle
+
+- Every PR runs reviews from **Gemini Code Assist** and
+  **CodeRabbit**. Wait for both bots to post, address their
+  comments (push fixes to the PR branch), and merge only after
+  feedback is resolved.
+- **Reply to reviewers after pushing a fix.** Reply on the
+  corresponding review thread with an **@-mention**
+  (`@gemini-code-assist` / `@coderabbitai`). Silent fixes are
+  invisible to reviewers and cost the audit trail.
+- A review thread is **settled** the moment the latest bot reply
+  is ack-only ("Thank you" / "Understood" / a re-review summary
+  with no new findings) or 30 minutes elapse with no actionable
+  comment.
+- **Merge gate**: review bots quiet AND owner explicit approval.
+- Bot-authored PRs (Renovate / Dependabot) skip the bot-review
+  gate; CI green + owner approval is enough.
+
+### Worktree workflow
+
+Use [`renri`](https://github.com/yukimemi/renri) for any
+commit-bound change. From the main checkout:
+
+```sh
+renri add <branch-name>            # create a worktree (jj-first)
+renri --vcs git add <branch-name>  # force a git worktree
+renri remove <branch-name>         # cleanup after merge
+renri prune                        # GC stale worktrees
+```
+
+Read-only inspection can stay on the main checkout.
+
+### kata-managed sections
+
+Several files in this repo are managed by `kata apply` from the
+[`yukimemi/pj-presets`](https://github.com/yukimemi/pj-presets)
+templates — the bytes between `<!-- kata:*:begin -->` and
+`<!-- kata:*:end -->` markers, plus the overwrite-always files
+listed in `.kata/applied.toml`. **Editing those bytes locally
+won't survive the next `kata apply`** — push the change to the
+upstream template repo (`yukimemi/pj-base` / `yukimemi/pj-rust` /
+…) instead. The marker scopes are layered:
+
+- `kata:agents:base:*` — language-agnostic conventions (this section).
+- `kata:agents:rust:*` — added when `pj-rust` applies.
+- `kata:agents:rust-cli:*` — added when `pj-rust-cli` applies.
+<!-- kata:agents:base:end -->
+<!-- kata:agents:rust:begin -->
+### Rust workflow
+
+This repo follows the yukimemi/* Rust toolchain conventions. The
+language-agnostic conventions block above (`kata:agents:base:*`)
+covers git workflow, PR review cycle, and worktree usage.
+
+### Build / lint / test
+
+```sh
+cargo make check                    # fmt --check + clippy + test + lock-check (the pre-push gate)
+cargo make setup                    # one-time hook install + apm install
+cargo build                         # debug build
+cargo build --release               # release build
+cargo test                          # tests; add -- --nocapture for stdout
+```
+
+`cargo make check` is what `.github/workflows/ci.yml` runs and what
+the local pre-push hook calls — anything that passes locally
+should pass on CI and vice versa. Don't paper over a failing
+clippy by sprinkling `#[allow(clippy::...)]`; fix the underlying
+issue or push back on the lint with reasoning.
+
+### Toolchain pin
+
+The Rust toolchain is pinned via `rust-toolchain.toml` and the
+project compiles with the `stable` channel. Don't introduce
+nightly-only features without a real reason; if you do, document
+the reason in the relevant module.
+
+### Lint / format policy
+
+`rustfmt.toml` and `clippy.toml` are kata-managed (sourced from
+`yukimemi/pj-rust`). Edits to those files in this repo won't
+survive the next `kata apply`; if a setting is wrong, push the
+fix to `yukimemi/pj-rust` so every yukimemi/* Rust project picks
+it up.
+
+### CI workflow
+
+`.github/workflows/ci.yml` is also kata-managed. The source lives
+in `yukimemi/pj-rust/.github/workflows/ci.yml.template` (the
+`.template` suffix keeps GitHub Actions from running the source
+itself in pj-rust); each Rust project receives the rendered
+`ci.yml` via `kata apply`. Action versions are bumped centrally
+by Renovate at `yukimemi/pj-rust` and propagate down on the next
+apply, so don't bump them locally — Renovate is configured
+(via the kata-distributed `renovate.json`) to ignore
+`.github/workflows/ci.yml` and `.github/workflows/release.yml`
+in each PJ to avoid the bump→clobber loop.
+<!-- kata:agents:rust:end -->
+<!-- kata:agents:rust-cli:begin -->
+### Rust CLI release flow
+
+This is a Rust CLI crate, so the release pipeline is publish-aware.
+`yukimemi/pj-rust-cli` ships a tag-driven release workflow in
+`.github/workflows/release.yml` (rendered from
+`release.yml.template` for the same don't-auto-execute reason
+ci.yml uses).
+
+```sh
+# Bump `package.version` in Cargo.toml (run `cargo build` so
+# Cargo.lock follows), then:
+git commit -am "chore: bump version to X.Y.Z"
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin main vX.Y.Z
+```
+
+The workflow then:
+1. Cross-compiles binaries for x86_64 Linux / Windows / macOS,
+   plus aarch64 macOS (Apple Silicon) — full triples
+   `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`,
+   `x86_64-apple-darwin`, `aarch64-apple-darwin`.
+2. Uploads them as a GitHub Release with auto-generated notes.
+3. `cargo publish --locked` to crates.io using the
+   `CARGO_REGISTRY_TOKEN` repo secret.
+
+Set the `CARGO_REGISTRY_TOKEN` secret once per repo (`gh secret
+set CARGO_REGISTRY_TOKEN`) before the first tag push. If the
+crate is internal-only and shouldn't go to crates.io, either drop
+the `publish` job locally (release.yml is `when = "once"` so the
+edit survives subsequent applies) or set `package.publish = false`
+in `Cargo.toml`.
+
+The binary name is derived from the GitHub repo name at runtime
+(`${{ github.event.repository.name }}`), so the workflow is
+identical across yukimemi/* CLIs unless your `[[bin]] name` in
+`Cargo.toml` deliberately differs from the repo name — in that
+case override `BIN_NAME` in the workflow's `env:` block.
+<!-- kata:agents:rust-cli:end -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-# CLAUDE.md
+# GEMINI.md
 
 This repo's agent guidance lives in [AGENTS.md](./AGENTS.md). This
-file is a thin shim so Claude Code's per-repo entry point keeps
+file is a thin shim so the Gemini CLI's per-repo entry point keeps
 working — please read AGENTS.md for the actual instructions.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,8 +2,8 @@
 alias = "check"
 
 [tasks.check]
-description = "Run fmt + clippy + test (same as CI)"
-dependencies = ["fmt-check", "clippy", "test"]
+description = "Run fmt + clippy + test + lock-check (same as CI)"
+dependencies = ["fmt-check", "clippy", "test", "lock-check"]
 
 [tasks.fmt-check]
 description = "Check formatting"
@@ -18,17 +18,22 @@ args = ["fmt", "--all"]
 [tasks.clippy]
 description = "Run clippy with warnings as errors"
 command = "cargo"
-args = ["clippy", "--all-targets", "--", "-D", "warnings"]
+args = ["clippy", "--locked", "--all-targets", "--", "-D", "warnings"]
 
 [tasks.test]
 description = "Run all tests"
 command = "cargo"
-args = ["test"]
+args = ["test", "--locked"]
 
 [tasks.install]
 description = "Install rvpm from local source (respects Cargo.lock via --locked)"
 command = "cargo"
 args = ["install", "--path", ".", "--locked"]
+
+[tasks.lock-check]
+description = "Verify Cargo.lock is in sync with Cargo.toml"
+command = "cargo"
+args = ["check", "--locked", "--all-targets"]
 
 [tasks.publish-dry]
 description = "Dry-run crates.io publish"
@@ -44,22 +49,93 @@ hook_file = set "${hook_dir}/pre-push"
 mkdir ${hook_dir}
 hook_content = set "#!/bin/sh\n# Installed by: cargo make hook-install\ncargo make check"
 writefile ${hook_file} ${hook_content}
+# chmod +x is needed on Unix; on Windows the exec bit is a no-op
+# AND `chmod` may not be on PATH (it's only present when Git for
+# Windows / busybox is wired into the shell). Skip silently if
+# `chmod` isn't reachable so plain Windows shells don't fail this
+# task with `program not found`.
+chmod_path = which chmod
+if not is_empty ${chmod_path}
+    exec chmod +x ${hook_file}
+else
+    echo "chmod not on PATH; skipping exec-bit (no-op on Windows; on Unix this means the hook may not be executable)"
+end
 echo "Installed pre-push hook -> ${hook_file}"
 '''
 
 [tasks.apm-install]
-description = "Compile the renri skill into .claude/skills/ + .gemini/skills/ + .github/skills/ via APM"
-command = "apm"
-args = ["install", "-t", "copilot,claude,gemini"]
+description = "Install agent skills declared in apm.yml (Copilot / Claude / Gemini targets). Skipped silently when apm.yml or the apm CLI is absent."
+script_runner = "@duckscript"
+script = '''
+exists = is_path_exists "apm.yml"
+if not ${exists}
+    echo "no apm.yml; skipping apm-install"
+    exit 0
+end
+apm_path = which apm
+if is_empty ${apm_path}
+    echo "apm CLI not on PATH; skipping apm-install (install via aka.ms/apm-unix or your platform's package manager)"
+    exit 0
+end
+exec apm install -t copilot,claude,gemini
+'''
 
 [tasks.apm-install-update]
-description = "Refresh APM dependencies to upstream latest (used by on-add hook)"
-command = "apm"
-args = ["install", "--update", "-t", "copilot,claude,gemini"]
+description = "Refresh APM dependencies to upstream latest. Skipped when apm.yml/apm absent, or when apm.lock.yaml already records the current upstream renri HEAD (kicks in on every cargo make on-add after the first to keep worktree creation fast)."
+script_runner = "@duckscript"
+script = '''
+exists = is_path_exists "apm.yml"
+if not ${exists}
+    echo "no apm.yml; skipping apm-install-update"
+    exit 0
+end
+apm_path = which apm
+if is_empty ${apm_path}
+    echo "apm CLI not on PATH; skipping apm-install-update (install via aka.ms/apm-unix or your platform's package manager)"
+    exit 0
+end
+
+# Fast-path: if apm.lock.yaml already records the current
+# upstream HEAD of yukimemi/renri (the only APM dependency for
+# yukimemi/* projects), don't re-run `apm install --update` —
+# git ls-remote is ~100ms, an actual reinstall is several
+# seconds. This makes `cargo make on-add` cheap on every
+# `renri add` after the first.
+lock_exists = is_path_exists "apm.lock.yaml"
+if ${lock_exists}
+    ls_result = exec git ls-remote https://github.com/yukimemi/renri.git refs/heads/main
+    ls_ok = eq ${ls_result.code} 0
+    if ${ls_ok}
+        upstream_line = trim ${ls_result.stdout}
+        upstream_sha = substring ${upstream_line} 0 40
+        # Guard against empty / short upstream_sha. duckscript's
+        # `contains "haystack" ""` returns true (empty needle is
+        # always a substring), so without this check a successful-
+        # but-empty `git ls-remote` (deleted main ref, weird CI
+        # mirror, etc.) would incorrectly skip the install.
+        sha_len = length ${upstream_sha}
+        sha_valid = eq ${sha_len} 40
+        if ${sha_valid}
+            lock_body = readfile apm.lock.yaml
+            already_synced = contains ${lock_body} ${upstream_sha}
+            if ${already_synced}
+                echo "apm.lock.yaml already at upstream renri ${upstream_sha}; skipping apm install --update"
+                exit 0
+            end
+        end
+    end
+end
+
+exec apm install --update -t copilot,claude,gemini
+'''
+
+[tasks.setup]
+description = "One-time setup for new contributors: pre-push hook + APM install"
+dependencies = ["hook-install", "apm-install"]
 
 [tasks.vcs-fetch]
 description = "Fetch latest refs (jj when in a jj workspace, otherwise git)"
-# Best-effort: a missing `jj`/`git` binary, an unreachable remote, etc.
+# Best-effort: a missing `jj` / `git` binary, an unreachable remote, etc.
 # should log but not fail `cargo make on-add` and break `renri add`.
 ignore_errors = true
 script_runner = "@duckscript"
@@ -68,11 +144,8 @@ script = '''
 # fails there with "not a git repository". Prefer `jj git fetch`, which
 # works in pure-jj and colocated repos. Fall back to `git fetch` for
 # pure-git (no `.jj/`) worktrees.
-#
-# Best-effort: don't `--fail-on-error` because a transient network
-# failure during `renri add` shouldn't break the worktree; the user
-# can always `cargo make vcs-fetch` later.
-if is_path_exists .jj
+jj_present = is_path_exists ".jj"
+if ${jj_present}
     exec jj git fetch
 else
     exec git fetch
@@ -82,10 +155,6 @@ end
 [tasks.on-add]
 description = "Wired to renri's [[hooks.post_create]] — runs in a freshly created worktree"
 dependencies = ["apm-install-update", "vcs-fetch"]
-
-[tasks.setup]
-description = "One-time setup for new contributors: pre-push hook + APM install (requires `apm` CLI on PATH — see https://github.com/microsoft/apm)"
-dependencies = ["hook-install", "apm-install"]
 
 # ─── vhs / demo GIF regeneration ───────────────────────────────────────
 # Native vhs on Windows hangs on `Set Theme`, so we ship a Docker image

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,5 +1,5 @@
-# CLAUDE.md
+# OPENCODE.md
 
 This repo's agent guidance lives in [AGENTS.md](./AGENTS.md). This
-file is a thin shim so Claude Code's per-repo entry point keeps
+file is a thin shim so opencode's per-repo entry point keeps
 working — please read AGENTS.md for the actual instructions.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-05-04T11:07:29.746437+00:00'
+generated_at: '2026-05-10T01:43:47.507952+00:00'
 apm_version: 0.12.1
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 046926227ed077adb3bfc9a3086ef7dcf0f4f3fd
+  resolved_commit: 50c3ee2f9fadbe726fbe695cf1846b970feb62f0
   resolved_ref: main
   package_type: apm_package
   deployed_files:
   - .agents/skills/renri
   - .claude/skills/renri
-  content_hash: sha256:2fe1289262415236cbc6bc0445e2c3a857393fba40e5b9350a7f7e19f5f73007
+  content_hash: sha256:64f3babacb8a6d1fad43275d5617548239bf70762b108f94ec1865016cef6a96

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,9 @@
+# yukimemi/* Rust clippy policy. Centralised in
+# `yukimemi/pj-rust`; every Rust project picks this up via
+# `kata apply` (overwrite always). Local edits don't survive
+# `kata apply` — push the change here.
+
+# MSRV — keeps `cargo clippy` from suggesting features that are
+# stable on `stable` but not yet on the project's pinned MSRV.
+# Bumped together with `package.rust-version` in Cargo.toml.
+msrv = "1.85"

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/wt/**": "allow"
+    }
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "rangeStrategy": "bump",
+  "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on monday"]
+  },
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 8,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.+\\.template$"],
+      "matchStrings": [
+        "uses:\\s*[\"']?(?<depName>[\\w./-]+)@(?<currentValue>[\\w./-]+)[\"']?"
+      ],
+      "datasourceTemplate": "github-tags",
+      "description": "Pick up `uses:` action references inside .template workflow files (kata sources). Renovate's default github-actions manager only scans .yml/.yaml; .template is here so the source isn't auto-executed by GitHub Actions. Optional `[\"']?` wrappers around depName + currentValue accept bare, single-quoted, and double-quoted forms — all three are valid YAML for `uses:`."
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-merge patch / pin / digest bumps once CI passes",
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Group all GitHub Actions updates into one PR (covers both the built-in github-actions manager and the regex customManager that scans .template files). matchDatasources scopes this to github-tags so future customManagers for non-actions deps don't accidentally land in the github-actions group.",
+      "matchManagers": ["github-actions", "regex"],
+      "matchDatasources": ["github-tags"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "These workflow files are kata-managed (sourced from yukimemi/pj-rust* templates). Action bumps happen centrally there; local edits would be reverted by the next `kata apply`.",
+      "matchManagers": ["github-actions"],
+      "matchFileNames": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/renri.toml
+++ b/renri.toml
@@ -1,4 +1,19 @@
-# renri.toml
+# renri.toml — language-agnostic worktree config for yukimemi/* projects.
+# pj-base ships the minimum hook chain that any PJ benefits from
+# (refresh installed agent skills); language-specific layers
+# (pj-rust, pj-go, pj-bun) overwrite this file with a richer hook
+# that delegates to the project's build-system on-add task.
+
+[ui]
+# Surface the GitHub PR # next to each worktree in `renri list`.
+# renri batches `gh pr list` lookups (one call per `list` run
+# regardless of worktree count) and caches the result; pass
+# `renri list --refresh` to bypass the cache when a new PR has
+# just been opened or merged.
+show_pr = true
+# renri.toml — fresh worktrees run `cargo make on-add`, which
+# refreshes apm skills *and* fetches the upstream remote so the
+# new worktree is rebase-ready without a second command.
 # Schema and examples: https://github.com/yukimemi/renri
 
 [[hooks.post_create]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,6 @@
+# yukimemi/* Rust formatting policy. Centralised in
+# `yukimemi/pj-rust`; every Rust project picks this up via
+# `kata apply` (overwrite always). Local edits don't survive
+# `kata apply` — push the change here.
+
 edition = "2024"
-max_width = 100

--- a/src/git.rs
+++ b/src/git.rs
@@ -1105,6 +1105,52 @@ mod tests {
         cmd
     }
 
+    // Ensures the test process itself has a committer identity gix can find,
+    // for code paths (Repo::sync / Repo::update / Repo::checkout_locally) that
+    // create or mutate dst repos via gix-in-process — those don't go through
+    // `git_cmd`'s per-Command env, so they need either repo-local config or
+    // process-level env vars. We use env vars because dst repos are created
+    // *by* gix (sync) and we don't have a hook to write their .git/config.
+    //
+    // `Once` keeps this safe under the parallel test runner: env mutation
+    // happens exactly once, before any test reads the env.
+    fn ensure_committer_env() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            // SAFETY: called on first git_init_with_user, before any test
+            // gix-call. No other test code mutates these vars, so racing
+            // reads from gix are stable after this single write.
+            unsafe {
+                std::env::set_var("GIT_AUTHOR_NAME", "test");
+                std::env::set_var("GIT_AUTHOR_EMAIL", "test@test.com");
+                std::env::set_var("GIT_COMMITTER_NAME", "test");
+                std::env::set_var("GIT_COMMITTER_EMAIL", "test@test.com");
+            }
+        });
+    }
+
+    // `git init` + write `[user]` into the repo's local `.git/config` so that
+    // gix-based code paths (Repo::checkout_locally, sync_impl, …) running
+    // inside the test process can find a committer for reflog updates. The
+    // env vars set on `git_cmd` only reach the spawned `git` CLI; they do
+    // NOT propagate to the parent test process where gix actually executes —
+    // hence both the per-repo write and the process-level env var below.
+    async fn git_init_with_user(dir: &Path) {
+        ensure_committer_env();
+        git_cmd(dir).args(["init"]).output().await.unwrap();
+        git_cmd(dir)
+            .args(["config", "user.name", "test"])
+            .output()
+            .await
+            .unwrap();
+        git_cmd(dir)
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_get_status_not_installed() {
         let root = tempdir().unwrap();
@@ -1118,7 +1164,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "hello").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1136,7 +1182,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "hello").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1155,7 +1201,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "hello").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1196,7 +1242,7 @@ mod tests {
 
         // ローカル bare repo を作成
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "hello").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1226,7 +1272,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "hello").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1273,7 +1319,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("hello.txt"), "v1").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1318,7 +1364,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "v1").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1378,7 +1424,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1445,7 +1491,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1482,7 +1528,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&dst).unwrap();
-        git_cmd(&dst).args(["init"]).output().await.unwrap();
+        git_init_with_user(&dst).await;
         fs::write(dst.join("a.txt"), "v1").unwrap();
         git_cmd(&dst).args(["add", "."]).output().await.unwrap();
         git_cmd(&dst)
@@ -1626,7 +1672,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         // **最重要**: `git init` 直後の default branch を確定させる (CodeRabbit
         // PR #99 review 指摘)。後で v1 を作って checkout するので、この段階で
         // default を控えておかないと、setup 末尾で「現在の HEAD = v1」を
@@ -1701,7 +1747,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "only").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1729,7 +1775,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "a").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1784,7 +1830,7 @@ mod tests {
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
         fs::create_dir_all(src.join("doc")).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "v1\n").unwrap();
         fs::write(src.join("doc/intro.txt"), "hello\n").unwrap();
         fs::write(src.join("src.txt"), "code v1\n").unwrap();
@@ -1850,7 +1896,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "alpha\nbeta\ngamma\n").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1904,7 +1950,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "v1\n").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -1954,7 +2000,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         // null-byte を含む binary 風 blob (現実的には PNG / dat 等の `doc/` 内画像)。
         fs::create_dir_all(src.join("doc")).unwrap();
         fs::write(
@@ -2013,7 +2059,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "v1\n").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2065,7 +2111,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "alpha\nbeta\n").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2118,7 +2164,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("repo");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("README.md"), "v1\n").unwrap();
         fs::write(src.join("other.txt"), "stable\n").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
@@ -2253,7 +2299,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2275,7 +2321,7 @@ mod tests {
         let root = tempdir().unwrap();
         let src = root.path().join("src");
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2304,7 +2350,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2373,7 +2419,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)
@@ -2405,7 +2451,7 @@ mod tests {
         let dst = root.path().join("dst");
 
         fs::create_dir_all(&src).unwrap();
-        git_cmd(&src).args(["init"]).output().await.unwrap();
+        git_init_with_user(&src).await;
         fs::write(src.join("a.txt"), "seed").unwrap();
         git_cmd(&src).args(["add", "."]).output().await.unwrap();
         git_cmd(&src)


### PR DESCRIPTION
## Summary

Bootstrap rvpm into the kata-managed template ecosystem (`yukimemi/pj-presets:rust-cli` = `pj-base` + `pj-rust` + `pj-rust-cli`), aligning shared conventions with yui / kaishin / teravars / todoke / renri / kata.

- **CLAUDE.md → AGENTS.md migration.** rvpm-specific architecture / TOML schema / loader.lua phase outline / merge strategy documentation moves to `AGENTS.md` (the agents.md-spec source of truth). `CLAUDE.md` / `GEMINI.md` / `OPENCODE.md` are now thin shims pointing at `AGENTS.md`. Three `<!-- kata:agents:* -->` marker blocks at the bottom hold the shared base / rust / rust-cli conventions sourced from `pj-presets`.
- **kata-managed files written.** `Makefile.toml` (cargo make check now bundles `lock-check`; Windows-safe `hook-install` skips `chmod` when absent; APM `--update` fast-path skips on lockfile match), `renri.toml` (`[ui] show_pr = true`), `renovate.json`, `rustfmt.toml`, `clippy.toml`, `.gitignore`, `.editorconfig`, `rust-toolchain.toml`, `.gemini/settings.json`, `opencode.json`, `.github/workflows/ci.yml`.
- **`once`-managed adoptions.** `apm.yml`, `.github/workflows/release.yml`, and `LICENSE` are recorded as `once_applied = true` in `.kata/applied.toml` so existing rvpm-specific content survives subsequent applies.
- **Note on renri.toml drift.** `kata status` reports `update` on `renri.toml` immediately after apply — this is the known kata #34 (toml_edit decor non-idempotence) issue and is cosmetic-only; the merged content is structurally correct.

## Test plan

- [x] `cargo make check` (776 tests passing, 0 failures, lock-check green)
- [ ] CI workflow runs on PR
- [ ] Gemini Code Assist + CodeRabbit review
- [ ] Owner approval before merge
- [ ] After merge: re-register `rvpm` in kata from main checkout (`kata register --tag rust --tag cli --tag nvim`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CI/CD pipeline with multi-platform testing (Linux, Windows, macOS) and lockfile validation.
  * Expanded build tooling with configuration checks and improved task organization.

* **Chores**
  * Standardized development environment setup with editor and formatting configurations.
  * Added agent guidance documentation entry points.
  * Updated dependency management and automation configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/rvpm/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->