### PR TITLE
fix: skip self-update banner when latest == current version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -749,8 +749,11 @@ async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
             // 1 秒 timeout で結果を待つ。 タイムアウトは silent skip。
             let res = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
             if let Ok(Ok(Ok(latest))) = res {
-                // banner 出力
-                eprintln!("\n{}", checker.format_banner(&latest));
+                if kaishin::is_update_available(env!("CARGO_PKG_VERSION"), &latest.tag_name)
+                    .unwrap_or(false)
+                {
+                    eprintln!("\n{}", checker.format_banner(&latest));
+                }
             } else if let Some(latest) = cached_latest {
                 // タイムアウトやエラー時はキャッシュがあれば表示
                 eprintln!("\n{}", checker.format_banner(&latest));


### PR DESCRIPTION
## Summary

- `check_and_save()` returns `LatestRelease` unconditionally (without comparing versions), so the `Pending` branch in `finalize_auto_update_check` was calling `format_banner` even when the remote tag matched the running binary.
- Added a `kaishin::is_update_available` guard before `format_banner` in the `Pending` branch to match the behaviour of `cached_update()`, which already performs this check.

## Root cause

```
// Before (Pending branch)
if let Ok(Ok(Ok(latest))) = res {
    eprintln!("\n{}", checker.format_banner(&latest));  // always prints!
```

`cached_update()` filters with `is_update_available`, but the live-fetch path did not.

## Test plan

- [ ] Run `rvpm sync` when already on the latest version — no update banner should appear
- [ ] Run `rvpm sync` when a newer version exists — banner should still appear
- [ ] `cargo make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-update banner now displays only when updates are actually available, reducing unnecessary notifications. Timeout and error handling behavior remains unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/rvpm/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->