### PR TITLE
chore: bump version to 3.34.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,7 +3813,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.34.1"
+version = "3.34.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.34.1"
+version = "3.34.2"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `package.version` in `Cargo.toml` from `3.34.1` → `3.34.2` following the fix in #158 (atomic view dir replace fails with ENOTEMPTY on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 3.34.2

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/rvpm/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->