### PR TITLE
docs(readme): add DeepWiki and Code Wiki badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![CI](https://github.com/yukimemi/rvpm/actions/workflows/ci.yml/badge.svg)](https://github.com/yukimemi/rvpm/actions/workflows/ci.yml)
 [![Release](https://github.com/yukimemi/rvpm/actions/workflows/release.yml/badge.svg)](https://github.com/yukimemi/rvpm/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/yukimemi/rvpm)
+[![View Code Wiki](https://www.gstatic.com/_/boq-sdlc-agents-ui/_/r/YUi5dj2UWvE.svg)](https://codewiki.google/github.com/yukimemi/rvpm)
 
 rvpm clones plugins in parallel, links `merge = true` plugins into a single
 runtime-path entry, and ahead-of-time compiles a static `loader.lua` that

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://github.com/yukimemi/rvpm/actions/workflows/release.yml/badge.svg)](https://github.com/yukimemi/rvpm/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/yukimemi/rvpm)
-[![View Code Wiki](https://www.gstatic.com/_/boq-sdlc-agents-ui/_/r/YUi5dj2UWvE.svg)](https://codewiki.google/github.com/yukimemi/rvpm)
+[![View Code Wiki](https://img.shields.io/badge/View-Code_Wiki-4285F4?logo=google)](https://codewiki.google/github.com/yukimemi/rvpm)
 
 rvpm clones plugins in parallel, links `merge = true` plugins into a single
 runtime-path entry, and ahead-of-time compiles a static `loader.lua` that


### PR DESCRIPTION
## Summary
- Add **Ask DeepWiki** badge (deepwiki.com already indexes this repo) and **View Code Wiki** badge (codewiki.google) next to the existing CI / Release / License badges in the top of `README.md`.
- Both link to the corresponding AI-generated wiki pages so readers can chat-explore the codebase without cloning.

## Test plan
- [ ] GitHub renders both badges in the README preview
- [ ] DeepWiki link resolves to https://deepwiki.com/yukimemi/rvpm
- [ ] Code Wiki link resolves to https://codewiki.google/github.com/yukimemi/rvpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two documentation reference badges—"Ask DeepWiki" and "View Code Wiki"—to the project README header alongside existing project badges to improve quick access to help and code documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yukimemi/rvpm/pull/179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->