### PR TITLE
feat(cli): sync missing plugins automatically in run_update

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,10 +1,10 @@
 lockfile_version: '1'
-generated_at: '2026-05-25T05:32:59.220649+00:00'
-apm_version: 0.14.2
+generated_at: '2026-05-27T13:41:20.681471+00:00'
+apm_version: 0.12.1
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 1e3f96e071ea49c3bd44bde5671016b60e6aa58f
+  resolved_commit: 34789eaebc5d0d1a6ee339152c09402d7792080c
   resolved_ref: main
   package_type: apm_package
   deployed_files:

--- a/src/git.rs
+++ b/src/git.rs
@@ -2484,4 +2484,50 @@ mod tests {
             "pattern が解決→commit SHA",
         );
     }
+
+    #[tokio::test]
+    async fn test_update_single_plugin_syncs_missing() {
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        fs::write(src.join("hello.txt"), "hello").unwrap();
+        git_cmd(&src).args(["add", "."]).output().await.unwrap();
+        git_cmd(&src)
+            .args(["commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+
+        let plugin = crate::config::Plugin {
+            url: src.to_str().unwrap().to_string(),
+            dst: Some(dst.to_str().unwrap().to_string()),
+            ..Default::default()
+        };
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+        let cache_root = root.path().join("cache");
+
+        let res = crate::update_single_plugin(&plugin, &cache_root, tx).await;
+
+        // TDD: This will fail on the current codebase because the plugin is missing and not synced yet.
+        assert!(
+            res.is_ok(),
+            "Expected update_single_plugin to succeed by syncing the missing plugin, but got: {:?}",
+            res
+        );
+
+        assert!(dst.join("hello.txt").exists());
+        assert_eq!(fs::read_to_string(dst.join("hello.txt")).unwrap(), "hello");
+
+        let mut statuses = Vec::new();
+        while let Ok((_, status)) = rx.try_recv() {
+            statuses.push(status);
+        }
+        assert_eq!(statuses.len(), 2);
+        assert!(matches!(statuses[0], crate::PluginStatus::Syncing(ref m) if m == "Syncing..."));
+        assert!(matches!(statuses[1], crate::PluginStatus::Finished));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2731,6 +2731,48 @@ async fn run_list(no_tui: bool) -> Result<bool> {
     Ok(goto_browse)
 }
 
+pub(crate) async fn update_single_plugin(
+    plugin: &crate::config::Plugin,
+    cache_root: &Path,
+    tx: mpsc::Sender<(String, PluginStatus)>,
+) -> Result<(
+    crate::config::Plugin,
+    Option<crate::git::GitChange>,
+    Option<String>,
+)> {
+    let dst_path = resolve_plugin_dst(plugin, cache_root);
+    let is_missing = !dst_path.exists();
+    let _ = tx
+        .send((
+            plugin.url.clone(),
+            PluginStatus::Syncing(if is_missing {
+                "Syncing...".to_string()
+            } else {
+                "Updating...".to_string()
+            }),
+        ))
+        .await;
+    let repo = Repo::new(&plugin.url, &dst_path, plugin.rev.as_deref());
+    let res = if is_missing {
+        repo.sync().await
+    } else {
+        repo.update().await
+    };
+    match res {
+        Ok(change) => {
+            let head_commit = repo.head_commit().await.ok();
+            let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
+            Ok((plugin.clone(), change, head_commit))
+        }
+        Err(e) => {
+            let _ = tx
+                .send((plugin.url.clone(), PluginStatus::Failed(e.to_string())))
+                .await;
+            Err(e)
+        }
+    }
+}
+
 async fn run_update(query: Option<String>) -> Result<()> {
     let config_path = rvpm_config_path();
     let toml_content = std::fs::read_to_string(&config_path)
@@ -2796,28 +2838,7 @@ async fn run_update(query: Option<String>) -> Result<()> {
 
         set.spawn(async move {
             let _permit = sem.acquire_owned().await.unwrap();
-            let dst_path = resolve_plugin_dst(&plugin, &cache_root);
-            let _ = tx
-                .send((
-                    plugin.url.clone(),
-                    PluginStatus::Syncing("Updating...".to_string()),
-                ))
-                .await;
-            let repo = Repo::new(&plugin.url, &dst_path, plugin.rev.as_deref());
-            let res = repo.update().await;
-            match res {
-                Ok(change) => {
-                    let head_commit = repo.head_commit().await.ok();
-                    let _ = tx.send((plugin.url.clone(), PluginStatus::Finished)).await;
-                    Ok((plugin, change, head_commit))
-                }
-                Err(e) => {
-                    let _ = tx
-                        .send((plugin.url.clone(), PluginStatus::Failed(e.to_string())))
-                        .await;
-                    Err(e)
-                }
-            }
+            update_single_plugin(&plugin, &cache_root, tx).await
         });
     }
 


### PR DESCRIPTION
When attempting to update a plugin that is not yet installed (Missing), automatically fallback to sync (clone/checkout) instead of failing immediately with a 'Plugin not installed' error. This allows users to resolve missing plugins by simply pressing 'u' in the list TUI or running 'rvpm update'.

Add \	est_update_single_plugin_syncs_missing\ to verify this behavior.