### PR TITLE
refactor(updater): drop local is_update_available filter, migrate to kaishin 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "kaishin"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c67a4da5995b60eac9904511d26cc49f03fd9b2103dce5c96d1d3313411bef"
+checksum = "337a1e0ca2d16f43e89e7f5009f4222401a3d2fcc365d11e10fd01e8e046f5c4"
 dependencies = [
  "anyhow",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ toml_edit = "0.25.12"
 which = "8.0.2"
 
 # Self-update (`rvpm self-update`, daily auto-check banner) — #125
-kaishin = "0.3.0"
+kaishin = "0.4.0"
 # Version 比較 (current `Cargo.toml` の version vs. 取得した `tag_name`)。
 semver = "1.0.28"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,13 +750,19 @@ async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
             // kaishin 0.4 で check_and_save が Option を返すようになったので、
             // ここでの is_update_available 重複チェックは不要 (Ok(None) = 更新無し)。
             let res = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
-            if let Ok(Ok(Ok(Some(latest)))) = res {
-                eprintln!("\n{}", checker.format_banner(&latest));
-            } else if !matches!(res, Ok(Ok(Ok(None)))) {
-                // タイムアウトやエラー時はキャッシュがあれば表示。
-                // Ok(None) は「fetch 成功で更新無し」なので fallback しない。
-                if let Some(latest) = cached_latest {
+            match res {
+                Ok(Ok(Ok(Some(latest)))) => {
                     eprintln!("\n{}", checker.format_banner(&latest));
+                }
+                Ok(Ok(Ok(None))) => {
+                    // fetch 成功 + 更新無し: cache へのフォールバックは不要
+                    // (最新が現在版に追いついた直後など、 cache は古いだけ)。
+                }
+                _ => {
+                    // タイムアウトや fetch エラー時のみ cache を試す。
+                    if let Some(latest) = cached_latest {
+                        eprintln!("\n{}", checker.format_banner(&latest));
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -670,7 +670,7 @@ enum AutoUpdateHandle {
     /// バックグラウンドで GitHub API を叩いてる。 join 結果に応じて状態保存 + banner。
     Pending {
         checker: kaishin::Checker,
-        handle: tokio::task::JoinHandle<Result<kaishin::LatestRelease, anyhow::Error>>,
+        handle: tokio::task::JoinHandle<Result<Option<kaishin::LatestRelease>, anyhow::Error>>,
         /// タイムアウト時のフォールバック用。
         cached_latest: Option<kaishin::LatestRelease>,
     },
@@ -747,16 +747,17 @@ async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
             cached_latest,
         } => {
             // 1 秒 timeout で結果を待つ。 タイムアウトは silent skip。
+            // kaishin 0.4 で check_and_save が Option を返すようになったので、
+            // ここでの is_update_available 重複チェックは不要 (Ok(None) = 更新無し)。
             let res = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
-            if let Ok(Ok(Ok(latest))) = res {
-                if kaishin::is_update_available(env!("CARGO_PKG_VERSION"), &latest.tag_name)
-                    .unwrap_or(false)
-                {
+            if let Ok(Ok(Ok(Some(latest)))) = res {
+                eprintln!("\n{}", checker.format_banner(&latest));
+            } else if !matches!(res, Ok(Ok(Ok(None)))) {
+                // タイムアウトやエラー時はキャッシュがあれば表示。
+                // Ok(None) は「fetch 成功で更新無し」なので fallback しない。
+                if let Some(latest) = cached_latest {
                     eprintln!("\n{}", checker.format_banner(&latest));
                 }
-            } else if let Some(latest) = cached_latest {
-                // タイムアウトやエラー時はキャッシュがあれば表示
-                eprintln!("\n{}", checker.format_banner(&latest));
             }
         }
     }


### PR DESCRIPTION
## Summary

- Bump kaishin 0.3.0 → 0.4.0 and adapt to the new `Result<Option<LatestRelease>>` signature on `Checker::check_and_save`.
- Drop the now-redundant local `kaishin::is_update_available` call in `finalize_auto_update_check` — that filter is now done by kaishin itself.

## Why

Unlike yui and renri, rvpm was **already filtering** the banner via a local `is_update_available` check ([`src/main.rs` around the old line 752](https://github.com/yukimemi/rvpm/blob/main/src/main.rs)). So this isn't a user-visible bug fix on rvpm — the banner already behaved correctly. It's pure cleanup riding on the kaishin 0.4 API move (filter goes into the type system).

The asymmetry in kaishin 0.3.x — `cached_update` filtered but `check_and_save` didn't — was bitten by yui (#105) and renri (#72) but caught by rvpm's defensive caller-side check. kaishin 0.4 removes the asymmetry, which removes the need for the caller-side check.

## Migration to 0.4

- `AutoUpdateHandle::Pending::handle` carries `Result<Option<_>, anyhow::Error>`.
- `finalize_auto_update_check` matches on `Ok(Ok(Ok(Some(latest))))` to show the banner, treats `Ok(Ok(Ok(None)))` as "no update" (no fallback to cache — the fresh fetch is authoritative), and falls back to the cached release only on timeout / fetch error.
- Drops the `kaishin::is_update_available(...)` call that used to gate the banner after `check_and_save` returned.

## Companion PRs

- kaishin: yukimemi/kaishin#30 (merged → v0.4.0 on crates.io)
- yui: yukimemi/yui#105 (merged, v0.7.21 released)
- renri: yukimemi/renri#72 (merged)

## Test plan
- [x] `cargo test --locked` — 777/777 PASS against kaishin 0.4.0 from crates.io
- [x] `cargo check --locked` clean
- [x] `cargo fmt --check` clean
- [x] No user-visible behavior change expected; the deleted `is_update_available` call was redundant with kaishin 0.4's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)