### PR TITLE
chore(release): v3.35.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,7 +3734,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.35.0"
+version = "3.35.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.35.0"
+version = "3.35.1"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Patch release shipping #199 (refactor(updater): drop local is_update_available filter, migrate to kaishin 0.4). Pure refactor — no user-visible behavior change. CI green → auto-tag.yml → release.yml.