### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
+          persist-credentials: false
 
       - name: Install apm
         # aka.ms/apm-unix is the Unix one-liner installer published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,119 +2,100 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*.*.*"]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 env:
   CARGO_TERM_COLOR: always
+  # Cargo binary name derived from the GitHub repo so this template
+  # works unchanged for any CLI using these templates without per-PJ patching.
+  # If your `[[bin]] name` in Cargo.toml differs from the repo name,
+  # override this on the spot.
+  BIN_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build:
-    name: Build ${{ matrix.target }}
+    name: build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact_name: rvpm
-            archive_name: rvpm-x86_64-unknown-linux-gnu.tar.gz
-            archive_cmd: tar
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            artifact_name: rvpm
-            archive_name: rvpm-x86_64-apple-darwin.tar.gz
-            archive_cmd: tar
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact_name: rvpm
-            archive_name: rvpm-aarch64-apple-darwin.tar.gz
-            archive_cmd: tar
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            artifact_name: rvpm.exe
-            archive_name: rvpm-x86_64-pc-windows-msvc.zip
-            archive_cmd: zip
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
-
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
-
-      - name: Package (tar)
-        if: matrix.archive_cmd == 'tar'
-        shell: bash
+      - name: install musl toolchain
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y musl-tools
+      - run: cargo build --release --target ${{ matrix.target }}
+      # Run the `smoke` example on the same runner that produced the
+      # binary. The example's default body is a no-op (see
+      # `examples/smoke.rs` in the consumer crate); each crate is
+      # expected to override it with a real-world startup check
+      # (HTTPS handshake, I/O probe, etc.) so this step blocks a
+      # release before bad binaries reach users — `cargo test` runs
+      # only library code and missed shoka v0.10.0's rustls panic.
+      - name: smoke
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo run --release --target ${{ matrix.target }} --example smoke
+      - name: package (unix)
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/${{ matrix.artifact_name }} dist/
-          cp README.md LICENSE dist/
-          tar -C dist -czf ${{ matrix.archive_name }} ${{ matrix.artifact_name }} README.md LICENSE
-
-      - name: Package (zip)
-        if: matrix.archive_cmd == 'zip'
+          pkg=target/${{ matrix.target }}/release
+          tar czf "dist/${BIN_NAME}-${{ matrix.target }}.tar.gz" -C "$pkg" "${BIN_NAME}"
+      - name: package (windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist | Out-Null
-          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.artifact_name }}" "dist/"
-          Copy-Item "README.md" "dist/"
-          Copy-Item "LICENSE" "dist/"
-          Compress-Archive -Path "dist/*" -DestinationPath "${{ matrix.archive_name }}"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
+          New-Item -ItemType Directory -Force dist
+          $pkg = "target/${{ matrix.target }}/release"
+          Compress-Archive -Path "$pkg/$env:BIN_NAME.exe" `
+            -DestinationPath "dist/$env:BIN_NAME-${{ matrix.target }}.zip"
+      - uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.archive_name }}
-          path: ${{ matrix.archive_name }}
-          if-no-files-found: error
-          retention-days: 1
+          name: ${{ env.BIN_NAME }}-${{ matrix.target }}
+          path: dist/*
 
-  publish:
-    name: Publish to crates.io
+  release:
+    name: github release
     needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*
+          generate_release_notes: true
+
+  publish:
+    name: publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: Publish
-        run: cargo publish --allow-dirty
-        continue-on-error: true
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  release:
-    name: Create Release
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-
-      - name: Flatten artifact directory
-        run: |
-          mkdir -p release
-          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec cp {} release/ \;
-          ls -la release/
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: release/*
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+      # --locked keeps the committed Cargo.lock so the publish
+      # verification step cannot fail the dirty-git-state check by
+      # rewriting the lock.
+      - run: cargo publish --locked --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,20 +1,20 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-05-28T04:46:16.633075427Z"
+applied_at = "2026-05-31T04:50:21.102382617Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "3e3c7ee971897ae6cc71e78d597c838412974f19"
+rev = "98a48d8489551fffcf08e71da8b85d00d5e74dfd"
 version = "0.12.1"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "f78e190bac618fc3870b3c4a6e4187eb01c3cc42"
-version = "0.7.0"
+rev = "6ac24c5f06b08962ad3f55e5142606824846ec7a"
+version = "0.8.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust-cli"
-rev = "3cc89e5f11c2a83dc4cd3c10a56c49306b444975"
-version = "0.3.0"
+rev = "d6549f7d1333c1ce9e4ef9d061d5cd333433da4c"
+version = "0.4.1"
 
 [files.".agents/skills/renri/SKILL.md"]
 once_applied = true
@@ -32,7 +32,7 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "79b12afa028841f8bce3c0caffd60dfe491642dba685142e33ed22a8cfcb9f9d"
+content_hash = "f6f32f9e34c386faf21abfb786ffc1a81d76913be63d31b063e44517dcfb148d"
 
 [files.".github/workflows/auto-tag.yml"]
 content_hash = "0796dfb281c7447610035360622ddada137a8e2d89efa574aea89374676d768b"
@@ -44,6 +44,7 @@ content_hash = "594c14cf24dd2aa17d8c50d0db6d56321cb729ad4fc660888d7e6fbe36ca9211
 content_hash = "bc0e3def04b634949297d60322999a27f53bffc71b6cb662ae58ac8087e78bed"
 
 [files.".github/workflows/release.yml"]
+content_hash = "9bb2700bfdcf9036cd7f3c79a58f6e5b22fe0595706b27c6159f6c1b0c0da383"
 once_applied = true
 
 [files.".gitignore"]
@@ -86,6 +87,7 @@ once_applied = true
 content_hash = "2ada1cf4347db9e98fadd67ca72cd9e29042c5bf6ab719d666b5d71f97663e81"
 
 [files."renovate.json"]
+content_hash = "ea464978679041c69a3e18085f9a2ce846b9762ff02ab2801ed22cfbbf1487ae"
 once_applied = true
 
 [files."renri.toml"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,11 +437,11 @@ either way; using a PR also gives CI a chance to gate the
 release. Enable automerge so CI green = release start:
 
 ```sh
-git switch -c chore/bump-X.Y.Z
+git switch -c chore/release-vX.Y.Z
 # Edit `package.version` in Cargo.toml, then:
 cargo build                     # let Cargo.lock follow
-git commit -am "chore: bump version to X.Y.Z"
-git push -u origin chore/bump-X.Y.Z
+git commit -am "chore: release vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
 gh pr create --fill
 gh pr merge --auto --squash --delete-branch
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>yukimemi/pj-base"]
+  "extends": [
+    "github>yukimemi/pj-rust"
+  ]
 }


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->