### PR TITLE
chore(release): v3.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,7 +3734,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.35.1"
+version = "3.36.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.35.1"
+version = "3.36.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.36.0 (minor — includes a new feature).

Since v3.35.1:
- #201 feat(plugin_scan): augment commands from doc help-tags — `on_cmd` regex entries now resolve commands defined indirectly (e.g. wrapper around `nvim_create_user_command`) via `doc/*.txt` `*:Cmd*` tags.
- #202 fix(generate): fail loudly instead of merging onto stale tmp residue — `ensure_absent` removes the `<unknown>`-winner merge-conflict class at its source.

Version-bump-only PR (Cargo.toml + Cargo.lock); skips the bot-review gate per AGENTS.md. On merge, auto-tag.yml pushes `v3.36.0` → release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)