### PR TITLE
chore(release): v3.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,7 +3735,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.36.0"
+version = "3.37.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.36.0"
+version = "3.37.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release **v3.37.0**.

Version-bump-only PR: the diff is just `[package].version` + the matching `Cargo.lock` entry. On merge to `main`, `auto-tag.yml` pushes the `v3.37.0` tag, which fires `release.yml` (binary builds + crates.io publish).

## Included since v3.36.0

- #206 — `doctor`: colorize report with per-category icons and a verdict line (severity colors, Nerd/emoji/ascii category icons, banner header, closing verdict; config read/parse errors routed through the styled renderer with failure-faithful hints).

Minor bump since #206 is a user-facing feature addition.

https://claude.ai/code/session_01A9W5HxxJeRJuvmz98gTDkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9W5HxxJeRJuvmz98gTDkn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release version updated to 3.37.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->