### PR TITLE
feat(config): add `when` field for compile-time plugin exclusion (#140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,13 @@ on_map = [
   { lhs = "<leader>g",  mode = ["n", "x"], desc = "Grep" },
   { lhs = "/^<Plug>\\(Chezmoi/", mode = ["n"] },           # bulk-lazy <Plug> family
 ]
-# Conditional loading (Lua expression)
+# Conditional loading (Lua expression, runtime)
 cond = "vim.fn.has('win32') == 1"
+# Compile-time exclusion (#140). Tera-rendered at generate/sync; a truthy
+# result ("true"/"1"/"yes"/"on", case-insensitive) keeps the plugin, anything
+# else drops it ENTIRELY — no clone, no merge, no loader.lua, no dep resolution.
+# `when` (compile-time) and `cond` (runtime) compose: when is checked first.
+# when = "{{ is_windows }}"            # or {{ env.RVPM_ENABLE_DEV }} / {{ vars.enable_custom }}
 # Per-plugin override of `options.merge_doc` (#119).
 # - Some(true)  → for this plugin, merge `doc/` into `merged/doc/` and route rtp through `views/<plug>/`
 # - Some(false) → opt out of doc-merge even when global default is true

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ separate, hand-maintained list and is not affected by this command.
 | `merge_doc` | `bool` | inherits `options.merge_doc` | Per-plugin override of the global `merge_doc`. `true` aggregates this plugin's `doc/` into `merged/doc/` and routes its rtp through a doc-stripped view (so `:help` works pre-trigger and `:tselect` doesn't dupe). `false` opts out even when the global default is `true`. Ignored for `Full` merge plugins (eager + `merge = true`) — those already include `doc/` in `merged/`. With `cond` set, an unset value is auto-forced `false` (only sweeps `cond` plugins out of the global default — explicit `true` is honored) |
 | `rev` | `string` | HEAD | Branch, tag, or commit hash to check out after clone/pull |
 | `depends` | `string[]` | none | Plugins that must be loaded before this one. Accepts `display_name` (e.g. `"snacks.nvim"`) or `url` (e.g. `"folke/snacks.nvim"`). Eager → lazy dep auto-promotes the dep to eager (with a warning); lazy → lazy dep loads dep first inside the trigger callback |
+| `when` | `string` | none | **Compile-time** exclusion condition, evaluated at `generate` / `sync` after Tera rendering. If the rendered string is truthy (`"true"` / `"1"` / `"yes"` / `"on"`, case-insensitive) the plugin is kept; anything else (`"false"` / `"0"` / empty) removes it **entirely** — no clone, no merge, no `loader.lua`, not in dependency resolution. Use Tera to gate on OS / env / vars: `when = "{{ is_windows }}"`, `when = "{{ env.RVPM_ENABLE_DEV }}"`, `when = "{{ vars.enable_custom }}"`. Contrast with `cond` (runtime). Both may be set: `when` is checked first, and if it passes, `cond` still wraps the generated Lua |
 | `cond` | `string` | none | Lua expression. When set, the plugin's loader code is wrapped in `if <cond> then ... end` |
 | `build` | `string` | none | Shell command to run after clone / update. Vim-style `:Cmd` is invoked via `nvim --headless` with the plugin and its transitive depends on `runtimepath`. 5-minute timeout. Failures are reported in the sync summary but don't stop other plugins (resilience) |
 | `build_lua` | `string` | none | Lua snippet to run after clone / update, **after** the shell `build` if both are set. Invoked via `nvim --headless -u NONE -l <tmp.lua>` with the plugin and its transitive depends appended to `runtimepath`. `vim.fn.stdpath("data")` etc. resolve to the user's real data dir (no `--clean`), so plugins like `blink.cmp` that install native libs into `{stdpath('data')}/site/lib/` work as expected. Both `build_lua = "require('blink.cmp').build():wait(60000)"` (statement form) and `build_lua = "function() require('blink.cmp').build():wait(60000) end"` (lazy.nvim function form, auto-unwrapped) are accepted |
@@ -586,12 +587,20 @@ url = "thinca/vim-winenv"
 [[plugins]]
 url = "folke/snacks.nvim"
 cond = "{{ is_windows }}"  # runtime cond: kept in loader but guarded
+
+[[plugins]]
+url = "owner/win-only.nvim"
+when = "{{ is_windows }}"  # compile-time: excluded entirely off Windows
 ```
 
-> **`{% if %}` vs `cond`**: `{% if %}` removes the plugin entirely at
-> generate time — no clone, no merge, not in `loader.lua`. `cond` keeps
-> the plugin in `loader.lua` but wraps it in `if <expr> then ... end`
-> for runtime evaluation.
+> **`{% if %}` vs `when` vs `cond`**: `{% if %}` and `when` both remove
+> the plugin entirely at generate time — no clone, no merge, not in
+> `loader.lua`. `when` is the per-`[[plugins]]` field form (no need to
+> wrap the whole block in template tags); it renders via Tera, then a
+> truthy result (`"true"` / `"1"` / `"yes"` / `"on"`) keeps the plugin.
+> `cond` instead keeps the plugin in `loader.lua` but wraps it in
+> `if <expr> then ... end` for runtime evaluation. `when` and `cond` can
+> be combined: `when` gates compile-time, `cond` gates runtime.
 
 </details>
 

--- a/src/ai/schema_prompt.md
+++ b/src/ai/schema_prompt.md
@@ -28,7 +28,8 @@ on_map = [
   { lhs = "/^<Plug>\\(Chezmoi/", mode = ["n"] },
 ]
 
-cond = "vim.fn.has('win32') == 1"   # optional Lua expression; load only when truthy
+cond = "vim.fn.has('win32') == 1"   # optional Lua expression; load only when truthy (runtime)
+when = "{{ is_windows }}"           # optional compile-time gate; Tera-rendered, falsy => plugin excluded entirely (no clone/loader)
 ```
 
 ## Hook file conventions
@@ -98,7 +99,7 @@ Rules for the merged variant:
 1. **Don't drop user-added content silently.** Keymaps, autocmds, custom helper functions, comments — preserve them unless they're clearly broken.
 2. **Don't duplicate.** If you'd add the same line that's already there, just keep it once.
 3. **Order matters for Lua hooks.** `vim.g.<plugin>_xxx = ...` must run before `require('plugin').setup({})` — keep the user's ordering or fix it if broken.
-4. **For `[[plugins]]` entry merged**: keep `name`, `url`, `rev`, `dev`, `dst`, `cond`, `build`, `build_lua`, `depends` intact unless you have a strong reason to change them. `on_*` triggers are where you'd typically refine.
+4. **For `[[plugins]]` entry merged**: keep `name`, `url`, `rev`, `dev`, `dst`, `cond`, `when`, `build`, `build_lua`, `depends` intact unless you have a strong reason to change them. `on_*` triggers are where you'd typically refine.
 5. **If there's nothing meaningful to merge** (existing is empty or unrelated), output `(none)` in the `_merged` tag and keep the fresh variant alone.
 
 When **no existing content is provided** for a section, omit the `_merged` tag entirely (or output `(none)` — both are accepted).

--- a/src/config.rs
+++ b/src/config.rs
@@ -418,10 +418,13 @@ where
 /// を truthy とみなす。env var フラグ (`RVPM_ENABLE_DEV=1` 等) を素直に扱える
 /// よう `"1"` 系も許容する。それ以外 (`"false"` / `"0"` / 空文字列など) は falsy。
 fn when_passes(rendered: &str) -> bool {
-    matches!(
-        rendered.trim().to_ascii_lowercase().as_str(),
-        "true" | "1" | "yes" | "on"
-    )
+    // 軽量性のため `to_ascii_lowercase()` のヒープ確保を避け、trim 済み slice に
+    // 直接 `eq_ignore_ascii_case` をかける (plugin ごとに呼ばれる)。
+    let trimmed = rendered.trim();
+    trimmed.eq_ignore_ascii_case("true")
+        || trimmed == "1"
+        || trimmed.eq_ignore_ascii_case("yes")
+        || trimmed.eq_ignore_ascii_case("on")
 }
 
 fn default_merge() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,6 +311,19 @@ pub struct Plugin {
     pub build_lua: Option<String>,
     pub rev: Option<String>,
     pub cond: Option<String>,
+    /// コンパイル時 (`rvpm generate` / `rvpm sync`) に評価される除外条件 (#140)。
+    /// Tera でレンダリングされた後の文字列が truthy (`"true"` / `"1"` / `"yes"` /
+    /// `"on"`、いずれも大小文字無視・前後空白許容) なら plugin を残し、それ以外
+    /// (`"false"` / `"0"` / 空文字列など) なら **config から完全に除外**する。
+    ///
+    /// `cond` (runtime に loader.lua へ埋め込む Lua 式) との違いは評価タイミング:
+    /// `when=false` の plugin は clone も link も loader.lua 生成も依存解決も
+    /// 一切行われない。両方指定した場合、`when` が先 (compile-time) に評価され、
+    /// 通過したら `cond` が従来どおり runtime guard として残る。
+    ///
+    /// 例: `when = "{{ is_windows }}"` / `when = "{{ env.RVPM_ENABLE_DEV }}"` /
+    /// `when = "{{ vars.enable_custom }}"`。
+    pub when: Option<String>,
     /// dev = true のプラグインは sync/update をスキップする。
     /// ローカル開発中のプラグインに使う。
     #[serde(default)]
@@ -398,6 +411,17 @@ where
             })
             .collect()
     }))
+}
+
+/// `when` フィールドの Tera レンダリング結果を真偽値として解釈する (#140)。
+/// 前後空白を除き大小文字を無視したうえで `"true"` / `"1"` / `"yes"` / `"on"`
+/// を truthy とみなす。env var フラグ (`RVPM_ENABLE_DEV=1` 等) を素直に扱える
+/// よう `"1"` 系も許容する。それ以外 (`"false"` / `"0"` / 空文字列など) は falsy。
+fn when_passes(rendered: &str) -> bool {
+    matches!(
+        rendered.trim().to_ascii_lowercase().as_str(),
+        "true" | "1" | "yes" | "on"
+    )
 }
 
 fn default_merge() -> bool {
@@ -602,7 +626,16 @@ pub fn parse_config(toml_str: &str) -> Result<Config> {
     // 9. TOML パース
     let mut config: Config = toml::from_str(&rendered)?;
 
-    // 9. lazy 自動解決: on_* トリガーがあれば lazy = true にする (明示 false は尊重)
+    // 10. `when` (compile-time exclusion) フィルタ (#140)。
+    //    Tera レンダリング後 (手順 7) の `when` 文字列が falsy な plugin を
+    //    config から完全に除外する。これより後段の lazy 解決・sort_plugins・
+    //    sync・loader.lua 生成は一切この plugin に触れない。`cond` (runtime
+    //    guard) と違い clone も link も発生しない。
+    config
+        .plugins
+        .retain(|p| p.when.as_deref().map(when_passes).unwrap_or(true));
+
+    // 11. lazy 自動解決: on_* トリガーがあれば lazy = true にする (明示 false は尊重)
     for plugin in config.plugins.iter_mut() {
         let has_trigger = plugin.on_cmd.is_some()
             || plugin.on_ft.is_some()
@@ -1508,6 +1541,181 @@ url = "owner/win-only"
         } else {
             assert_eq!(config.plugins.len(), 1);
         }
+    }
+
+    // ========================================================
+    // `when` (compile-time exclusion) テスト (#140)
+    // ========================================================
+
+    #[test]
+    fn test_when_passes_truthy_values() {
+        for v in ["true", "True", "TRUE", " true ", "1", "yes", "on", "ON"] {
+            assert!(when_passes(v), "{v:?} should be truthy");
+        }
+    }
+
+    #[test]
+    fn test_when_passes_falsy_values() {
+        for v in ["false", "False", "0", "no", "off", "", "  ", "maybe"] {
+            assert!(!when_passes(v), "{v:?} should be falsy");
+        }
+    }
+
+    #[test]
+    fn test_when_false_excludes_plugin() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+[[plugins]]
+url = "owner/gated"
+when = "false"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].url, "owner/always");
+    }
+
+    #[test]
+    fn test_when_true_includes_plugin() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+[[plugins]]
+url = "owner/gated"
+when = "true"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 2);
+        assert_eq!(config.plugins[1].url, "owner/gated");
+    }
+
+    #[test]
+    fn test_when_omitted_includes_plugin() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/repo"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].when, None);
+    }
+
+    #[test]
+    fn test_when_renders_is_windows() {
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/always"
+
+[[plugins]]
+url = "owner/win-only"
+when = "{{ is_windows }}"
+"#;
+        let config = parse_config(toml).unwrap();
+        if cfg!(windows) {
+            assert_eq!(config.plugins.len(), 2);
+        } else {
+            assert_eq!(config.plugins.len(), 1);
+            assert_eq!(config.plugins[0].url, "owner/always");
+        }
+    }
+
+    #[test]
+    fn test_when_renders_vars() {
+        let toml = r#"
+[vars]
+enable_custom = true
+
+[options]
+
+[[plugins]]
+url = "owner/custom"
+when = "{{ vars.enable_custom }}"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].url, "owner/custom");
+    }
+
+    #[test]
+    fn test_when_renders_vars_false() {
+        let toml = r#"
+[vars]
+enable_custom = false
+
+[options]
+
+[[plugins]]
+url = "owner/custom"
+when = "{{ vars.enable_custom }}"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 0);
+    }
+
+    #[test]
+    fn test_when_renders_env() {
+        unsafe {
+            std::env::set_var("RVPM_TEST_WHEN_FLAG", "1");
+        }
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/dev-tool"
+when = "{{ env.RVPM_TEST_WHEN_FLAG }}"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].url, "owner/dev-tool");
+    }
+
+    #[test]
+    fn test_when_false_plugin_excluded_from_deps() {
+        // when=false の plugin は依存解決にも参加しない
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/main"
+depends = ["gated"]
+
+[[plugins]]
+name = "gated"
+url = "owner/gated"
+when = "false"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(config.plugins[0].url, "owner/main");
+    }
+
+    #[test]
+    fn test_when_coexists_with_cond() {
+        // when が通れば cond は runtime 用にそのまま残る
+        let toml = r#"
+[options]
+
+[[plugins]]
+url = "owner/maybe-win"
+when = "true"
+cond = "vim.g.maybe_win == 1"
+"#;
+        let config = parse_config(toml).unwrap();
+        assert_eq!(config.plugins.len(), 1);
+        assert_eq!(
+            config.plugins[0].cond.as_deref(),
+            Some("vim.g.maybe_win == 1")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #140 — a per-`[[plugins]]` `when` field for **compile-time** plugin exclusion.

When `when` (Tera-rendered at `generate` / `sync`) evaluates falsy, the plugin is dropped from the config **entirely** — before dependency resolution, sync, and `loader.lua` generation. No clone, no link, no triggers, not in the lockfile. This complements the existing `cond` (runtime Lua guard) and is less verbose than wrapping a whole `[[plugins]]` block in Tera `{% if %}`.

## Behavior

- Truthy (case-insensitive, whitespace-trimmed): `"true"` / `"1"` / `"yes"` / `"on"` → plugin kept.
- Everything else (`"false"` / `"0"` / empty / arbitrary) → plugin excluded.
- Reuses the existing Tera context, so all of these work:
  - `when = "{{ is_windows }}"` — OS gating
  - `when = "{{ env.RVPM_ENABLE_DEV }}"` — feature flags
  - `when = "{{ vars.enable_custom }}"` — user toggles
- `when` (compile-time) and `cond` (runtime) compose: `when` is checked first; if it passes, `cond` still wraps the generated Lua.

## Implementation

- New `when: Option<String>` field on `Plugin` (`config.rs`).
- `when_passes()` helper interprets the rendered string.
- `parse_config()` filters falsy-`when` plugins with `retain` right after TOML parse, before lazy resolution — so excluded plugins never reach `sort_plugins`, sync, or loader generation.

## Tests

TDD: 11 new tests covering truthy/falsy parsing, `is_windows` / `env` / `vars` rendering, exclusion from dependency resolution, and `when` + `cond` coexistence. Full `cargo make check` green locally (`801 passed`).

## Docs

README field table + Tera section, `AGENTS.md` schema example, AI `schema_prompt.md`.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed all source code, configuration, and documentation from the repository.
  * Removed CI/CD workflows and build infrastructure.
  * Removed AI integration features, plugin browsing, and diagnostic tools.
  * Removed support for chezmoi integration and git operations.

* **Documentation**
  * Removed all project documentation and guidance files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->