### PR TITLE
chore(release): v3.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,7 +3735,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.37.0"
+version = "3.38.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
## Release v3.38.0

Version bump only — `[package].version` `3.37.0` → `3.38.0` plus the matching `Cargo.lock` entry.

### Included since v3.37.0

- **feat(config): `when` field for compile-time plugin exclusion (#140, #210)** — a per-`[[plugins]]` `when` field, Tera-rendered at generate/sync; falsy result excludes the plugin entirely (no clone / merge / loader / dep resolution).

On merge to `main`, `auto-tag.yml` pushes `v3.38.0`, which fires `release.yml` (cross-platform binaries + crates.io publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)