### PR TITLE
chore(release): v3.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3746,7 +3746,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.38.0"
+version = "3.39.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.38.0"
+version = "3.39.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.39.0.

Bumps `package.version` 3.38.0 → 3.39.0. Minor bump: #213 added background silent auto-update (`auto_update = "off" | "notify" | "install"`, default `install`) on top of kaishin 0.5.0.

On merge to `main`, `auto-tag.yml` pushes the `v3.39.0` tag, which fires `release.yml` (binary builds + crates.io publish).

Version-bump-only PR — skips the bot-review gate per AGENTS.md.