### PR TITLE
fix(ci): download kata musl asset in kata-apply (gnu dropped in kata v0.12.0)

### DIFF
--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -64,7 +64,7 @@ jobs:
           set -euo pipefail
           KATA_VERSION="$(curl -fsSL https://api.github.com/repos/yukimemi/kata/releases/latest | jq -r .tag_name)"
           echo "Installing kata ${KATA_VERSION}"
-          curl -fsSL "https://github.com/yukimemi/kata/releases/download/${KATA_VERSION}/kata-x86_64-unknown-linux-gnu.tar.gz" \
+          curl -fsSL "https://github.com/yukimemi/kata/releases/download/${KATA_VERSION}/kata-x86_64-unknown-linux-musl.tar.gz" \
             | tar xz -C /tmp
           sudo mv /tmp/kata /usr/local/bin/kata
           kata --version


### PR DESCRIPTION
The daily kata-apply workflow 404s since kata v0.12.0 dropped the Linux `gnu` asset and ships only `kata-x86_64-unknown-linux-musl.tar.gz`. Switch the download to the musl asset.

Same fix as yukimemi/kanade#342; template fixed in yukimemi/pj-base#16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)