### PR TITLE
refactor(lib): extract plugin_build + self_update modules from lib.rs (#217)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod lockfile;
 mod merge;
 mod merge_conflicts;
 mod paths;
+mod plugin_build;
 mod plugin_scan;
 mod profile;
 mod profile_tui;
@@ -37,6 +38,8 @@ pub use crate::merge::PluginMergeMode;
 use crate::merge::*;
 // GitHub URL normalization helpers now live in `url` (#217).
 use crate::url::*;
+// Plugin build-step runners + loader script pre-glob now live in `plugin_build`.
+use crate::plugin_build::*;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
@@ -900,7 +903,7 @@ fn disable_merge_if_cond(plugin: &mut crate::config::Plugin) {
 
 /// プラグインの clone 先パスを解決する。
 /// `plugin.dst` が `~/...` 形式の場合は home dir に展開する (dev プラグインで頻出)。
-fn resolve_plugin_dst(plugin: &crate::config::Plugin, cache_root: &Path) -> PathBuf {
+pub(crate) fn resolve_plugin_dst(plugin: &crate::config::Plugin, cache_root: &Path) -> PathBuf {
     if let Some(d) = &plugin.dst {
         expand_tilde(d)
     } else {
@@ -963,232 +966,6 @@ fn select_plugin_url(
             .items(&urls)
             .interact_opt()?;
         Ok(selection.map(|idx| urls[idx].clone()))
-    }
-}
-
-/// プラグインの build ステップを実行する。`build` (shell) と `build_lua` の両方が
-/// 設定されていれば、shell → lua の順に実行する。どちらか一方でも失敗したら
-/// 即座にエラー文字列を返す。両方未設定なら `None`。
-async fn execute_build_command(
-    plugin: &crate::config::Plugin,
-    dst_path: &Path,
-    config: &crate::config::Config,
-    cache_root: &Path,
-) -> Option<String> {
-    // 早期 return: build step が一つも無ければ rtp 計算自体スキップ (Gemini #99
-    // 指摘の short-circuit。大きな depends グラフでの無駄走査を避ける)。
-    if plugin.build.is_none() && plugin.build_lua.is_none() {
-        return None;
-    }
-
-    let rtp_dirs = collect_build_rtp(plugin, dst_path, config, cache_root);
-
-    // 1. shell コマンド (従来挙動)。失敗時は即 return。
-    if let Some(err) = run_build_shell(plugin, dst_path, &rtp_dirs).await {
-        return Some(err);
-    }
-
-    // 2. Lua callable (#97)。例: blink.cmp v2 の `require('blink.cmp').build():wait(...)`。
-    if let Some(err) = run_build_lua(plugin, dst_path, &rtp_dirs).await {
-        return Some(err);
-    }
-
-    None
-}
-
-/// build 実行時の rtp 候補一覧 (対象プラグイン + transitive depends パス)。
-/// 既存の shell build もこれを使ってきたので、Lua build 側も同じ rtp で揃える。
-fn collect_build_rtp(
-    plugin: &crate::config::Plugin,
-    dst_path: &Path,
-    config: &crate::config::Config,
-    cache_root: &Path,
-) -> Vec<PathBuf> {
-    let mut rtp_dirs = vec![dst_path.to_path_buf()];
-    let mut visited = std::collections::HashSet::new();
-    let mut stack: Vec<String> = plugin.depends.iter().flatten().cloned().collect();
-    while let Some(dep) = stack.pop() {
-        if !visited.insert(dep.clone()) {
-            continue;
-        }
-        if let Some(dep_plugin) = config
-            .plugins
-            .iter()
-            .find(|p| p.display_name() == dep || p.url == dep)
-        {
-            let dep_path = resolve_plugin_dst(dep_plugin, cache_root);
-            rtp_dirs.push(dep_path);
-            if let Some(deeper) = &dep_plugin.depends {
-                stack.extend(deeper.clone());
-            }
-        }
-    }
-    rtp_dirs
-}
-
-/// shell `build` を実行する。未設定 / 成功なら `None`、失敗なら error message。
-async fn run_build_shell(
-    plugin: &crate::config::Plugin,
-    dst_path: &Path,
-    rtp_dirs: &[PathBuf],
-) -> Option<String> {
-    let build_cmd = plugin.build.as_ref()?;
-    let (prog, args) = parse_build_command(build_cmd, rtp_dirs);
-    let build_timeout = std::time::Duration::from_secs(300); // 5 minutes
-    let mut child = match tokio::process::Command::new(&prog)
-        .args(&args)
-        .current_dir(dst_path)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return Some(format!("build spawn failed: {}", e));
-        }
-    };
-    match tokio::time::timeout(build_timeout, child.wait()).await {
-        Ok(Ok(status)) if !status.success() => {
-            Some(format!("build failed (exit code: {:?})", status.code()))
-        }
-        Ok(Err(e)) => Some(format!("build error: {}", e)),
-        Err(_) => {
-            let _ = child.kill().await;
-            Some(format!("build timed out ({}s)", build_timeout.as_secs()))
-        }
-        _ => None,
-    }
-}
-
-/// `build_lua` に **lazy.nvim 流の `function() ... end` で囲まれた匿名関数式** が
-/// 渡された場合、その body だけを取り出して返す。
-///
-/// なぜ必要か: rvpm は `build_lua` の文字列を **statement context の Lua スニペット**
-/// として exec する (`-l <tmp.lua>`)。素の `function() ... end` は statement では
-/// 「function NAME() ... end」と解釈されるので名前必須 (E5112) になる。
-/// user は lazy.nvim の `build = function() require(...).build():wait(...) end` から
-/// 流用しがちなので、その形を検出して body へ unwrap する。
-///
-/// **対応する記述**:
-/// - 1 行 / 複数行どちらも (regex `(?s)` で `.` が改行マッチ)
-/// - `function()` 直後・`end` 直前の任意の空白/改行
-/// - `end` の後ろの trailing line コメント (`-- ...`) と空白
-/// - 入れ子の `function() ... end` は body 内に **そのまま保持** (lazy quantifier
-///   `.*?` + 末尾 anchor `$` で「最後の一番外の `end`」を拾うため)
-///
-/// **マッチしない**:
-/// - `function name() ... end` (named function 宣言は valid statement なので unwrap 不要)
-/// - 末尾に statement や `;` が続くケース (lazy.nvim 流ではない)
-fn unwrap_anonymous_lua_function(code: &str) -> Option<String> {
-    use regex::Regex;
-    use std::sync::OnceLock;
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        // (?s): . が \n にマッチする dot-all モード。
-        // (.*?): lazy match で末尾 anchor `$` と組み合わせて「最後の `end`」を拾う。
-        // 末尾の trailing line コメント (`-- ...`) は optional。
-        Regex::new(r"(?s)^\s*function\s*\(\s*\)\s*(.*?)\s*end\s*(?:--[^\n\r]*)?\s*$").unwrap()
-    });
-    re.captures(code)
-        .map(|c| c.get(1).map_or("", |m| m.as_str()).trim().to_string())
-}
-
-/// Lua callable `build_lua` を実行する (#97)。
-///
-/// `nvim --headless -u NONE -l <tmp.lua>` で起動し、rtp に対象プラグイン +
-/// transitive deps を append した上で user の Lua スニペットを呼ぶ。
-///
-/// `-u NONE` で user init.lua はスキップするが、`vim.fn.stdpath("data")` 等の
-/// real env は維持されるので blink.cmp v2 のように `~/.local/share/nvim/site/lib/`
-/// 等にファイルを置きたいケースでも期待通りの場所に届く。
-///
-/// nvim が PATH に無ければ warn + skip (resilience、helptags と同じ方針)。
-async fn run_build_lua(
-    plugin: &crate::config::Plugin,
-    dst_path: &Path,
-    rtp_dirs: &[PathBuf],
-) -> Option<String> {
-    let raw_lua_code = plugin.build_lua.as_ref()?;
-
-    // user は lazy.nvim の `build = function() ... end` 流れで
-    // `build_lua = "function() ... end"` と書きがちだが、Lua の statement context
-    // で `function()` (匿名) は名前必須なので E5112 エラーになる。
-    // → `function() X end` の wrapping を検出したら body だけを残す。
-    let lua_code = unwrap_anonymous_lua_function(raw_lua_code)
-        .map(std::borrow::Cow::Owned)
-        .unwrap_or(std::borrow::Cow::Borrowed(raw_lua_code.as_str()));
-
-    // rtp_dirs を `vim.opt.rtp:append(...)` の連続で前置する。生のパスを Lua
-    // 文字列リテラルに埋め込むので、backslash は `/` に正規化、引用符は escape。
-    let mut script = String::new();
-    for dir in rtp_dirs {
-        let p = dir
-            .to_string_lossy()
-            .replace('\\', "/")
-            .replace('"', "\\\"");
-        script.push_str(&format!("vim.opt.rtp:append(\"{p}\")\n"));
-    }
-    script.push_str(&lua_code);
-    script.push('\n');
-
-    // tempfile crate に temp ファイル管理を委ねる (Gemini #99 指摘): manual な
-    // SystemTime + process::id 組立ては、process が中断された場合にゴミが残る。
-    // `NamedTempFile` は drop で自動削除 + プラットフォームに合った安全な命名を行う。
-    let tmp_file = match tempfile::Builder::new()
-        .prefix("rvpm-build-")
-        .suffix(".lua")
-        .tempfile()
-    {
-        Ok(f) => f,
-        Err(e) => return Some(format!("build_lua: failed to create temp script: {e}")),
-    };
-    let tmp_path = tmp_file.path().to_path_buf();
-    // async 経路なので blocking な std::fs::write は tokio::fs::write に置換
-    // (Gemini #99 review): executor を塞いで他プラグインの並列 build を妨げないように。
-    if let Err(e) = tokio::fs::write(&tmp_path, &script).await {
-        return Some(format!("build_lua: failed to write temp script: {e}"));
-    }
-
-    let build_timeout = std::time::Duration::from_secs(300);
-    let child = match tokio::process::Command::new("nvim")
-        .args(["--headless", "-u", "NONE", "-l"])
-        .arg(&tmp_path)
-        .current_dir(dst_path)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        // tokio Command の default は `kill_on_drop = false` なので、timeout 時に
-        // future が drop されても child の nvim は走り続けてしまう (Gemini High
-        // 指摘の resource leak)。`true` で drop = kill 連動させる。
-        .kill_on_drop(true)
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return Some(format!(
-                "build_lua: failed to spawn `nvim --headless` ({e}); install nvim or remove `build_lua` from this plugin"
-            ));
-        }
-    };
-
-    let wait_result = tokio::time::timeout(build_timeout, child.wait_with_output()).await;
-    // tmp_file は scope を抜ける時 drop で自動削除されるので明示削除は不要。
-    drop(tmp_file);
-
-    match wait_result {
-        Ok(Ok(out)) if !out.status.success() => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            Some(format!(
-                "build_lua failed (exit code: {:?}): {}",
-                out.status.code(),
-                stderr.trim()
-            ))
-        }
-        Ok(Ok(_)) => None,
-        Ok(Err(e)) => Some(format!("build_lua error: {e}")),
-        Err(_) => Some(format!(
-            "build_lua timed out ({}s)",
-            build_timeout.as_secs()
-        )),
     }
 }
 
@@ -5133,186 +4910,12 @@ fn file_with_icon(dir: &Path, name: &str) -> String {
     format!("{} {}", icon, name)
 }
 
-fn find_lua(dir: &Path, name: &str) -> Option<String> {
+pub(crate) fn find_lua(dir: &Path, name: &str) -> Option<String> {
     let path = dir.join(name);
     if path.exists() {
         Some(path.to_string_lossy().to_string())
     } else {
         None
-    }
-}
-
-/// 指定ディレクトリ配下を再帰的に walk し、`.vim` / `.lua` ファイルをソートして返す。
-/// lazy.nvim の Util.walk + source_runtime のフィルタと同等。
-/// ディレクトリが存在しない場合は空配列を返す (Resilience)。
-/// `colors/` ディレクトリからカラースキーム名 (ファイル名から拡張子を除去) を収集する。
-/// 例: `colors/catppuccin.lua` → `"catppuccin"`, `colors/catppuccin-latte.vim` → `"catppuccin-latte"`
-/// build コマンドを解析して (実行プログラム, 引数リスト) を返す。
-/// `:` で始まる場合は Neovim コマンドとして実行。rtp_dirs (自身 + 依存先) を
-/// rtp に追加してコマンドや autoload 関数を使えるようにする。
-/// それ以外はシェルコマンドとして `sh -c "..."` (Windows: `cmd /C "..."`) に変換。
-fn parse_build_command(build_cmd: &str, rtp_dirs: &[PathBuf]) -> (String, Vec<String>) {
-    if let Some(vim_cmd) = build_cmd.strip_prefix(':') {
-        let rtp_cmds: Vec<String> = rtp_dirs
-            .iter()
-            .map(|d| format!("set rtp+={}", d.to_string_lossy().replace('\\', "/")))
-            .collect();
-        let rtp_cmd = rtp_cmds.join(" | ");
-        (
-            "nvim".to_string(),
-            vec![
-                "--headless".to_string(),
-                "--cmd".to_string(),
-                rtp_cmd,
-                "-c".to_string(),
-                vim_cmd.to_string(),
-                "-c".to_string(),
-                "qa!".to_string(),
-            ],
-        )
-    } else if cfg!(windows) {
-        (
-            "cmd".to_string(),
-            vec!["/C".to_string(), build_cmd.to_string()],
-        )
-    } else {
-        (
-            "sh".to_string(),
-            vec!["-c".to_string(), build_cmd.to_string()],
-        )
-    }
-}
-
-fn collect_colorschemes(plugin_path: &Path) -> Vec<String> {
-    let dir = plugin_path.join("colors");
-    if !dir.exists() {
-        return Vec::new();
-    }
-    let mut names: Vec<String> = std::fs::read_dir(&dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
-        .filter_map(|e| {
-            let path = e.path();
-            let ext = path.extension()?.to_str()?;
-            if ext == "lua" || ext == "vim" {
-                Some(path.file_stem()?.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        })
-        .collect();
-    names.sort();
-    names.dedup();
-    names
-}
-
-/// `<plugin_path>/denops/<name>/main.{ts,js}` を走査して denops プラグイン情報を返す。
-/// denops.vim は main.ts を優先的に discover するため、存在すれば main.ts、
-/// なければ main.js を採用する (どちらも無ければ対象外)。
-fn collect_denops_plugins(plugin_path: &Path) -> Vec<crate::loader::DenopsPlugin> {
-    let dir = plugin_path.join("denops");
-    if !dir.exists() {
-        return Vec::new();
-    }
-    let mut plugins: Vec<crate::loader::DenopsPlugin> = std::fs::read_dir(&dir)
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        // `Path::is_dir()` は symlink を follow するので、dev plugin や
-        // mono-repo で symlink された `denops/<name>/` も拾える。
-        // `DirEntry::file_type()` だと symlink 自体を見てしまい skip される。
-        .filter(|e| e.path().is_dir())
-        .filter_map(|e| {
-            let sub = e.path();
-            let name = sub.file_name()?.to_string_lossy().to_string();
-            for candidate in ["main.ts", "main.js"] {
-                let script = sub.join(candidate);
-                if script.is_file() {
-                    return Some(crate::loader::DenopsPlugin {
-                        name,
-                        main_script: script.to_string_lossy().replace('\\', "/"),
-                    });
-                }
-            }
-            None
-        })
-        .collect();
-    plugins.sort_by(|a, b| a.name.cmp(&b.name));
-    plugins
-}
-
-fn collect_source_files(plugin_path: &Path, subdir: &str) -> Vec<String> {
-    let dir = plugin_path.join(subdir);
-    if !dir.exists() {
-        return Vec::new();
-    }
-    let mut files: Vec<String> = walkdir::WalkDir::new(&dir)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().is_file())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| ext == "lua" || ext == "vim")
-                .unwrap_or(false)
-        })
-        .map(|e| e.path().to_string_lossy().replace('\\', "/"))
-        .collect();
-    files.sort();
-    files
-}
-
-/// Plugin の実ディスク情報から PluginScripts を構築するヘルパー。
-/// run_sync / run_generate で重複していたロジックを集約。
-///
-/// `view_path` は `views/<host>/<owner>/<repo>/` (#119)。 Full merge 対象 (eager+merge=true)
-/// では loader 側で `merged/` を rtp:append するのでこの値は使われないが、 後段で
-/// MergeMode を見て分岐するためにレコードに保持しておく。
-fn build_plugin_scripts(
-    plugin: &crate::config::Plugin,
-    plugin_path: &Path,
-    plugin_config_dir: &Path,
-    view_path: &Path,
-    mode: PluginMergeMode,
-) -> crate::loader::PluginScripts {
-    // on_cmd / on_map / on_event の /regex/ 展開用に 1 回だけ静的スキャン (#85, #88)。
-    // 対象は plugin/, ftplugin/, after/plugin/, lua/ 配下の .vim / .lua のみで、
-    // load 経路に影響しないので dead plugin でもコストは小さい。
-    let scan = crate::plugin_scan::scan_plugin(plugin_path);
-    let uses_merged = matches!(
-        mode,
-        PluginMergeMode::Full | PluginMergeMode::ViewWithoutDoc
-    );
-    crate::loader::PluginScripts {
-        name: plugin.display_name(),
-        path: plugin_path.to_string_lossy().replace('\\', "/"),
-        view_path: view_path.to_string_lossy().replace('\\', "/"),
-        merge: plugin.merge,
-        merge_doc: plugin.merge_doc,
-        uses_merged,
-        init: find_lua(plugin_config_dir, "init.lua"),
-        before: find_lua(plugin_config_dir, "before.lua"),
-        after: find_lua(plugin_config_dir, "after.lua"),
-        plugin_files: collect_source_files(plugin_path, "plugin"),
-        ftdetect_files: collect_source_files(plugin_path, "ftdetect"),
-        after_plugin_files: collect_source_files(plugin_path, "after/plugin"),
-        lazy: plugin.lazy,
-        on_cmd: plugin.on_cmd.clone(),
-        on_ft: plugin.on_ft.clone(),
-        on_map: plugin.on_map.clone(),
-        on_event: plugin.on_event.clone(),
-        on_path: plugin.on_path.clone(),
-        on_source: plugin.on_source.clone(),
-        depends: plugin.depends.clone(),
-        colorschemes: collect_colorschemes(plugin_path),
-        denops_plugins: collect_denops_plugins(plugin_path),
-        defined_commands: scan.commands,
-        defined_plug_maps: scan.plug_maps,
-        defined_user_events: scan.user_events,
-        cond: plugin.cond.clone(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod plugin_build;
 mod plugin_scan;
 mod profile;
 mod profile_tui;
+mod self_update;
 mod tui;
 mod update_log;
 mod url;
@@ -40,6 +41,8 @@ use crate::merge::*;
 use crate::url::*;
 // Plugin build-step runners + loader script pre-glob now live in `plugin_build`.
 use crate::plugin_build::*;
+// `self-update` command + background auto-update check now live in `self_update`.
+use crate::self_update::*;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
@@ -689,190 +692,6 @@ fn run_completion(shell: clap_complete::Shell) {
     let mut cmd = <Cli as clap::CommandFactory>::command();
     let bin = cmd.get_name().to_string();
     clap_complete::generate(shell, &mut cmd, bin, &mut std::io::stdout());
-}
-
-/// 自動 update の handle。 結果は `finalize_auto_update_check` で消費する。
-enum AutoUpdateHandle {
-    /// notify mode: throttle window 内で fetch skip、 過去の cache が新版を示して
-    /// いるので banner だけ出す。
-    CachedAvailable {
-        checker: kaishin::Checker,
-        latest: kaishin::LatestRelease,
-    },
-    /// notify mode: バックグラウンドで GitHub API を叩いてる。 join 結果に応じて
-    /// 状態保存 + banner。
-    Pending {
-        checker: kaishin::Checker,
-        handle: tokio::task::JoinHandle<Result<Option<kaishin::LatestRelease>, anyhow::Error>>,
-        /// タイムアウト時のフォールバック用。
-        cached_latest: Option<kaishin::LatestRelease>,
-    },
-    /// install mode: バックグラウンドで check + download + 差し替えを silent 実行。
-    /// 完了して新版を入れたら 1 行だけ通知する (走行中プロセスは旧バイナリのまま、
-    /// 反映は次回起動)。
-    Installing {
-        handle: tokio::task::JoinHandle<Result<Option<kaishin::LatestRelease>, anyhow::Error>>,
-    },
-}
-
-/// `RVPM_NO_AUTOUPDATE` が「有効」な値で設定されているか。 `0` / `false` / 空白は
-/// 無効扱い (= 自動更新を止めない)。 config の `auto_update` より優先する kill-switch。
-fn auto_update_disabled_by_env() -> bool {
-    match std::env::var("RVPM_NO_AUTOUPDATE") {
-        Ok(v) => {
-            let v = v.trim();
-            !(v.is_empty() || v == "0" || v.eq_ignore_ascii_case("false"))
-        }
-        Err(_) => false,
-    }
-}
-
-/// config の `auto_update` (旧 `auto_update_check`) に応じて background 処理を起動する。
-///
-/// - `off` (または env `RVPM_NO_AUTOUPDATE`): 何もせず `None`。
-/// - `notify`: GitHub API を叩いて新版があれば banner で案内する (install しない)。
-///   throttle 内でも cache が新版を示していれば banner 用 handle を返す。
-/// - `install`: `Checker::auto_update` を spawn し、 silent に download + 差し替え。
-///   完了したら finalize で 1 行通知する。
-///
-/// 失敗時 (config 読めない等) は `None` を返して silent skip (resilience)。
-async fn maybe_spawn_auto_update_check() -> Option<AutoUpdateHandle> {
-    use crate::config::AutoUpdateMode;
-
-    // config が読めない / 失敗するケースもあるので resilience。 panic は絶対にしない。
-    let config_path = config_path_for_auto_check()?;
-    let toml_str = std::fs::read_to_string(&config_path).ok()?;
-    let cfg = parse_config(&toml_str).ok()?;
-
-    // env kill-switch は config より優先。
-    let mode = if auto_update_disabled_by_env() {
-        AutoUpdateMode::Off
-    } else {
-        cfg.options.update_mode()
-    };
-    if mode == AutoUpdateMode::Off {
-        return None;
-    }
-
-    let interval = cfg
-        .options
-        .update_check_interval
-        .as_deref()
-        .and_then(|s| kaishin::parse_interval(s).ok())
-        .unwrap_or_else(kaishin::default_interval);
-
-    let cache_root = resolve_cache_root(cfg.options.cache_root.as_deref());
-    let opts = kaishin::KaishinOptions::new(
-        "yukimemi",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
-    );
-    let checker = kaishin::Checker::new(env!("CARGO_PKG_NAME"), opts)
-        .interval(interval)
-        .state_path(cache_root.join("last_update_check.json"));
-
-    match mode {
-        // 上で early-return 済みだが、 網羅性のため。
-        AutoUpdateMode::Off => None,
-        AutoUpdateMode::Notify => {
-            if !checker.should_check() {
-                // throttle 内 — cache から判定
-                if let Some(latest) = checker.cached_update() {
-                    return Some(AutoUpdateHandle::CachedAvailable { checker, latest });
-                }
-                return None;
-            }
-            // fetch を spawn
-            let cached_latest = checker.cached_update();
-            let checker_clone = checker.clone();
-            let handle = tokio::spawn(async move { checker_clone.check_and_save().await });
-            Some(AutoUpdateHandle::Pending {
-                checker,
-                handle,
-                cached_latest,
-            })
-        }
-        AutoUpdateMode::Install => {
-            // `auto_update` は self-throttle + cross-process lock + silent install
-            // まで面倒を見る。 due でなければ即 Ok(None)。 dev build は no-op。
-            let handle = tokio::spawn(async move { checker.auto_update().await });
-            Some(AutoUpdateHandle::Installing { handle })
-        }
-    }
-}
-
-/// `rvpm` の config file の path を解決する (auto-check 用)。
-/// 既存の `rvpm_config_path()` ヘルパに委譲して、 `.config/rvpm/...` のハードコードを
-/// 避ける (CodeRabbit PR #126 指摘の coding guideline 整合)。
-fn config_path_for_auto_check() -> Option<std::path::PathBuf> {
-    let p = rvpm_config_path();
-    p.exists().then_some(p)
-}
-
-/// background fetch を join + banner 出力 (#125)。
-/// timeout は 1 秒 — fetch が遅ければ次回に回す。
-async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
-    match handle {
-        AutoUpdateHandle::CachedAvailable { checker, latest } => {
-            eprintln!("\n{}", checker.format_banner(&latest));
-        }
-        AutoUpdateHandle::Pending {
-            checker,
-            handle,
-            cached_latest,
-        } => {
-            // 1 秒 timeout で結果を待つ。 タイムアウトは silent skip。
-            // kaishin 0.4 で check_and_save が Option を返すようになったので、
-            // ここでの is_update_available 重複チェックは不要 (Ok(None) = 更新無し)。
-            let res = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
-            match res {
-                Ok(Ok(Ok(Some(latest)))) => {
-                    eprintln!("\n{}", checker.format_banner(&latest));
-                }
-                Ok(Ok(Ok(None))) => {
-                    // fetch 成功 + 更新無し: cache へのフォールバックは不要
-                    // (最新が現在版に追いついた直後など、 cache は古いだけ)。
-                }
-                _ => {
-                    // タイムアウトや fetch エラー時のみ cache を試す。
-                    if let Some(latest) = cached_latest {
-                        eprintln!("\n{}", checker.format_banner(&latest));
-                    }
-                }
-            }
-        }
-        AutoUpdateHandle::Installing { handle } => {
-            // 実際に download が走るのは新版がある時 (= throttle ごとに高々 1 回)
-            // だけで、 大半の起動では `auto_update` が即 Ok(None) を返すのでこの待ちは
-            // 一瞬で抜ける。 download 中の稀な起動でも `rvpm list` 等を長時間ブロック
-            // しないよう、 待ちは短い上限 (5 秒) に留める。 download は起動時から
-            // コマンド本体と並行で走っているので、 大抵はこの時点で完了済み。
-            // タイムアウト時は黙って次回に回す — 中断しても self_replace は atomic
-            // なのでバイナリは壊れない (遅い回線では次の機会か手動 self-update に委ねる)。
-            let res = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
-            if let Ok(Ok(Ok(Some(latest)))) = res {
-                let v = latest.tag_name.trim_start_matches('v');
-                eprintln!("\n\u{2713} rvpm {v} installed in the background — restart to apply.");
-            }
-        }
-    }
-}
-
-/// `rvpm self-update` (#125)。
-async fn run_self_update(yes: bool, check_only: bool) -> Result<()> {
-    let opts = kaishin::KaishinOptions::new(
-        "yukimemi",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
-    );
-    let upd_opts = kaishin::UpdateOptions::new()
-        .yes(yes)
-        .check_only(check_only);
-    // non_interactive フラグは rvpm ではまだ CmdCtx に持っていないため、デフォルト false。
-    // (必要になれば CmdCtx に追加して伝搬させる)
-    kaishin::run_self_update(&opts, upd_opts).await
 }
 
 use crate::tui::{PluginStatus, TuiState};

--- a/src/plugin_build.rs
+++ b/src/plugin_build.rs
@@ -1,0 +1,412 @@
+//! Plugin build-step execution + loader script pre-glob (#217).
+//!
+//! Two related build-time concerns extracted verbatim from the monolithic
+//! lib.rs:
+//! - Running a plugin's `build` / `build_lua` step after sync / update
+//!   (`execute_build_command` and the shell / lua / rtp helpers).
+//! - Pre-globbing each plugin's `plugin/` `ftdetect/` `colors/` `denops/` …
+//!   into a [`crate::loader::PluginScripts`] at generate time
+//!   (`build_plugin_scripts` + the `collect_*` helpers, `parse_build_command`).
+
+use crate::PluginMergeMode;
+use std::path::{Path, PathBuf};
+
+/// プラグインの build ステップを実行する。`build` (shell) と `build_lua` の両方が
+/// 設定されていれば、shell → lua の順に実行する。どちらか一方でも失敗したら
+/// 即座にエラー文字列を返す。両方未設定なら `None`。
+pub(crate) async fn execute_build_command(
+    plugin: &crate::config::Plugin,
+    dst_path: &Path,
+    config: &crate::config::Config,
+    cache_root: &Path,
+) -> Option<String> {
+    // 早期 return: build step が一つも無ければ rtp 計算自体スキップ (Gemini #99
+    // 指摘の short-circuit。大きな depends グラフでの無駄走査を避ける)。
+    if plugin.build.is_none() && plugin.build_lua.is_none() {
+        return None;
+    }
+
+    let rtp_dirs = collect_build_rtp(plugin, dst_path, config, cache_root);
+
+    // 1. shell コマンド (従来挙動)。失敗時は即 return。
+    if let Some(err) = run_build_shell(plugin, dst_path, &rtp_dirs).await {
+        return Some(err);
+    }
+
+    // 2. Lua callable (#97)。例: blink.cmp v2 の `require('blink.cmp').build():wait(...)`。
+    if let Some(err) = run_build_lua(plugin, dst_path, &rtp_dirs).await {
+        return Some(err);
+    }
+
+    None
+}
+
+/// build 実行時の rtp 候補一覧 (対象プラグイン + transitive depends パス)。
+/// 既存の shell build もこれを使ってきたので、Lua build 側も同じ rtp で揃える。
+pub(crate) fn collect_build_rtp(
+    plugin: &crate::config::Plugin,
+    dst_path: &Path,
+    config: &crate::config::Config,
+    cache_root: &Path,
+) -> Vec<PathBuf> {
+    let mut rtp_dirs = vec![dst_path.to_path_buf()];
+    let mut visited = std::collections::HashSet::new();
+    let mut stack: Vec<String> = plugin.depends.iter().flatten().cloned().collect();
+    while let Some(dep) = stack.pop() {
+        if !visited.insert(dep.clone()) {
+            continue;
+        }
+        if let Some(dep_plugin) = config
+            .plugins
+            .iter()
+            .find(|p| p.display_name() == dep || p.url == dep)
+        {
+            let dep_path = crate::resolve_plugin_dst(dep_plugin, cache_root);
+            rtp_dirs.push(dep_path);
+            if let Some(deeper) = &dep_plugin.depends {
+                stack.extend(deeper.clone());
+            }
+        }
+    }
+    rtp_dirs
+}
+
+/// shell `build` を実行する。未設定 / 成功なら `None`、失敗なら error message。
+pub(crate) async fn run_build_shell(
+    plugin: &crate::config::Plugin,
+    dst_path: &Path,
+    rtp_dirs: &[PathBuf],
+) -> Option<String> {
+    let build_cmd = plugin.build.as_ref()?;
+    let (prog, args) = parse_build_command(build_cmd, rtp_dirs);
+    let build_timeout = std::time::Duration::from_secs(300); // 5 minutes
+    let mut child = match tokio::process::Command::new(&prog)
+        .args(&args)
+        .current_dir(dst_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(format!("build spawn failed: {}", e));
+        }
+    };
+    match tokio::time::timeout(build_timeout, child.wait()).await {
+        Ok(Ok(status)) if !status.success() => {
+            Some(format!("build failed (exit code: {:?})", status.code()))
+        }
+        Ok(Err(e)) => Some(format!("build error: {}", e)),
+        Err(_) => {
+            let _ = child.kill().await;
+            Some(format!("build timed out ({}s)", build_timeout.as_secs()))
+        }
+        _ => None,
+    }
+}
+
+/// `build_lua` に **lazy.nvim 流の `function() ... end` で囲まれた匿名関数式** が
+/// 渡された場合、その body だけを取り出して返す。
+///
+/// なぜ必要か: rvpm は `build_lua` の文字列を **statement context の Lua スニペット**
+/// として exec する (`-l <tmp.lua>`)。素の `function() ... end` は statement では
+/// 「function NAME() ... end」と解釈されるので名前必須 (E5112) になる。
+/// user は lazy.nvim の `build = function() require(...).build():wait(...) end` から
+/// 流用しがちなので、その形を検出して body へ unwrap する。
+///
+/// **対応する記述**:
+/// - 1 行 / 複数行どちらも (regex `(?s)` で `.` が改行マッチ)
+/// - `function()` 直後・`end` 直前の任意の空白/改行
+/// - `end` の後ろの trailing line コメント (`-- ...`) と空白
+/// - 入れ子の `function() ... end` は body 内に **そのまま保持** (lazy quantifier
+///   `.*?` + 末尾 anchor `$` で「最後の一番外の `end`」を拾うため)
+///
+/// **マッチしない**:
+/// - `function name() ... end` (named function 宣言は valid statement なので unwrap 不要)
+/// - 末尾に statement や `;` が続くケース (lazy.nvim 流ではない)
+pub(crate) fn unwrap_anonymous_lua_function(code: &str) -> Option<String> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // (?s): . が \n にマッチする dot-all モード。
+        // (.*?): lazy match で末尾 anchor `$` と組み合わせて「最後の `end`」を拾う。
+        // 末尾の trailing line コメント (`-- ...`) は optional。
+        Regex::new(r"(?s)^\s*function\s*\(\s*\)\s*(.*?)\s*end\s*(?:--[^\n\r]*)?\s*$").unwrap()
+    });
+    re.captures(code)
+        .map(|c| c.get(1).map_or("", |m| m.as_str()).trim().to_string())
+}
+
+/// Lua callable `build_lua` を実行する (#97)。
+///
+/// `nvim --headless -u NONE -l <tmp.lua>` で起動し、rtp に対象プラグイン +
+/// transitive deps を append した上で user の Lua スニペットを呼ぶ。
+///
+/// `-u NONE` で user init.lua はスキップするが、`vim.fn.stdpath("data")` 等の
+/// real env は維持されるので blink.cmp v2 のように `~/.local/share/nvim/site/lib/`
+/// 等にファイルを置きたいケースでも期待通りの場所に届く。
+///
+/// nvim が PATH に無ければ warn + skip (resilience、helptags と同じ方針)。
+pub(crate) async fn run_build_lua(
+    plugin: &crate::config::Plugin,
+    dst_path: &Path,
+    rtp_dirs: &[PathBuf],
+) -> Option<String> {
+    let raw_lua_code = plugin.build_lua.as_ref()?;
+
+    // user は lazy.nvim の `build = function() ... end` 流れで
+    // `build_lua = "function() ... end"` と書きがちだが、Lua の statement context
+    // で `function()` (匿名) は名前必須なので E5112 エラーになる。
+    // → `function() X end` の wrapping を検出したら body だけを残す。
+    let lua_code = unwrap_anonymous_lua_function(raw_lua_code)
+        .map(std::borrow::Cow::Owned)
+        .unwrap_or(std::borrow::Cow::Borrowed(raw_lua_code.as_str()));
+
+    // rtp_dirs を `vim.opt.rtp:append(...)` の連続で前置する。生のパスを Lua
+    // 文字列リテラルに埋め込むので、backslash は `/` に正規化、引用符は escape。
+    let mut script = String::new();
+    for dir in rtp_dirs {
+        let p = dir
+            .to_string_lossy()
+            .replace('\\', "/")
+            .replace('"', "\\\"");
+        script.push_str(&format!("vim.opt.rtp:append(\"{p}\")\n"));
+    }
+    script.push_str(&lua_code);
+    script.push('\n');
+
+    // tempfile crate に temp ファイル管理を委ねる (Gemini #99 指摘): manual な
+    // SystemTime + process::id 組立ては、process が中断された場合にゴミが残る。
+    // `NamedTempFile` は drop で自動削除 + プラットフォームに合った安全な命名を行う。
+    let tmp_file = match tempfile::Builder::new()
+        .prefix("rvpm-build-")
+        .suffix(".lua")
+        .tempfile()
+    {
+        Ok(f) => f,
+        Err(e) => return Some(format!("build_lua: failed to create temp script: {e}")),
+    };
+    let tmp_path = tmp_file.path().to_path_buf();
+    // async 経路なので blocking な std::fs::write は tokio::fs::write に置換
+    // (Gemini #99 review): executor を塞いで他プラグインの並列 build を妨げないように。
+    if let Err(e) = tokio::fs::write(&tmp_path, &script).await {
+        return Some(format!("build_lua: failed to write temp script: {e}"));
+    }
+
+    let build_timeout = std::time::Duration::from_secs(300);
+    let child = match tokio::process::Command::new("nvim")
+        .args(["--headless", "-u", "NONE", "-l"])
+        .arg(&tmp_path)
+        .current_dir(dst_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        // tokio Command の default は `kill_on_drop = false` なので、timeout 時に
+        // future が drop されても child の nvim は走り続けてしまう (Gemini High
+        // 指摘の resource leak)。`true` で drop = kill 連動させる。
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(format!(
+                "build_lua: failed to spawn `nvim --headless` ({e}); install nvim or remove `build_lua` from this plugin"
+            ));
+        }
+    };
+
+    let wait_result = tokio::time::timeout(build_timeout, child.wait_with_output()).await;
+    // tmp_file は scope を抜ける時 drop で自動削除されるので明示削除は不要。
+    drop(tmp_file);
+
+    match wait_result {
+        Ok(Ok(out)) if !out.status.success() => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            Some(format!(
+                "build_lua failed (exit code: {:?}): {}",
+                out.status.code(),
+                stderr.trim()
+            ))
+        }
+        Ok(Ok(_)) => None,
+        Ok(Err(e)) => Some(format!("build_lua error: {e}")),
+        Err(_) => Some(format!(
+            "build_lua timed out ({}s)",
+            build_timeout.as_secs()
+        )),
+    }
+}
+
+/// 指定ディレクトリ配下を再帰的に walk し、`.vim` / `.lua` ファイルをソートして返す。
+/// lazy.nvim の Util.walk + source_runtime のフィルタと同等。
+/// ディレクトリが存在しない場合は空配列を返す (Resilience)。
+/// `colors/` ディレクトリからカラースキーム名 (ファイル名から拡張子を除去) を収集する。
+/// 例: `colors/catppuccin.lua` → `"catppuccin"`, `colors/catppuccin-latte.vim` → `"catppuccin-latte"`
+/// build コマンドを解析して (実行プログラム, 引数リスト) を返す。
+/// `:` で始まる場合は Neovim コマンドとして実行。rtp_dirs (自身 + 依存先) を
+/// rtp に追加してコマンドや autoload 関数を使えるようにする。
+/// それ以外はシェルコマンドとして `sh -c "..."` (Windows: `cmd /C "..."`) に変換。
+pub(crate) fn parse_build_command(build_cmd: &str, rtp_dirs: &[PathBuf]) -> (String, Vec<String>) {
+    if let Some(vim_cmd) = build_cmd.strip_prefix(':') {
+        let rtp_cmds: Vec<String> = rtp_dirs
+            .iter()
+            .map(|d| format!("set rtp+={}", d.to_string_lossy().replace('\\', "/")))
+            .collect();
+        let rtp_cmd = rtp_cmds.join(" | ");
+        (
+            "nvim".to_string(),
+            vec![
+                "--headless".to_string(),
+                "--cmd".to_string(),
+                rtp_cmd,
+                "-c".to_string(),
+                vim_cmd.to_string(),
+                "-c".to_string(),
+                "qa!".to_string(),
+            ],
+        )
+    } else if cfg!(windows) {
+        (
+            "cmd".to_string(),
+            vec!["/C".to_string(), build_cmd.to_string()],
+        )
+    } else {
+        (
+            "sh".to_string(),
+            vec!["-c".to_string(), build_cmd.to_string()],
+        )
+    }
+}
+
+pub(crate) fn collect_colorschemes(plugin_path: &Path) -> Vec<String> {
+    let dir = plugin_path.join("colors");
+    if !dir.exists() {
+        return Vec::new();
+    }
+    let mut names: Vec<String> = std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+        .filter_map(|e| {
+            let path = e.path();
+            let ext = path.extension()?.to_str()?;
+            if ext == "lua" || ext == "vim" {
+                Some(path.file_stem()?.to_string_lossy().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// `<plugin_path>/denops/<name>/main.{ts,js}` を走査して denops プラグイン情報を返す。
+/// denops.vim は main.ts を優先的に discover するため、存在すれば main.ts、
+/// なければ main.js を採用する (どちらも無ければ対象外)。
+pub(crate) fn collect_denops_plugins(plugin_path: &Path) -> Vec<crate::loader::DenopsPlugin> {
+    let dir = plugin_path.join("denops");
+    if !dir.exists() {
+        return Vec::new();
+    }
+    let mut plugins: Vec<crate::loader::DenopsPlugin> = std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        // `Path::is_dir()` は symlink を follow するので、dev plugin や
+        // mono-repo で symlink された `denops/<name>/` も拾える。
+        // `DirEntry::file_type()` だと symlink 自体を見てしまい skip される。
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let sub = e.path();
+            let name = sub.file_name()?.to_string_lossy().to_string();
+            for candidate in ["main.ts", "main.js"] {
+                let script = sub.join(candidate);
+                if script.is_file() {
+                    return Some(crate::loader::DenopsPlugin {
+                        name,
+                        main_script: script.to_string_lossy().replace('\\', "/"),
+                    });
+                }
+            }
+            None
+        })
+        .collect();
+    plugins.sort_by(|a, b| a.name.cmp(&b.name));
+    plugins
+}
+
+pub(crate) fn collect_source_files(plugin_path: &Path, subdir: &str) -> Vec<String> {
+    let dir = plugin_path.join(subdir);
+    if !dir.exists() {
+        return Vec::new();
+    }
+    let mut files: Vec<String> = walkdir::WalkDir::new(&dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext == "lua" || ext == "vim")
+                .unwrap_or(false)
+        })
+        .map(|e| e.path().to_string_lossy().replace('\\', "/"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Plugin の実ディスク情報から PluginScripts を構築するヘルパー。
+/// run_sync / run_generate で重複していたロジックを集約。
+///
+/// `view_path` は `views/<host>/<owner>/<repo>/` (#119)。 Full merge 対象 (eager+merge=true)
+/// では loader 側で `merged/` を rtp:append するのでこの値は使われないが、 後段で
+/// MergeMode を見て分岐するためにレコードに保持しておく。
+pub(crate) fn build_plugin_scripts(
+    plugin: &crate::config::Plugin,
+    plugin_path: &Path,
+    plugin_config_dir: &Path,
+    view_path: &Path,
+    mode: PluginMergeMode,
+) -> crate::loader::PluginScripts {
+    // on_cmd / on_map / on_event の /regex/ 展開用に 1 回だけ静的スキャン (#85, #88)。
+    // 対象は plugin/, ftplugin/, after/plugin/, lua/ 配下の .vim / .lua のみで、
+    // load 経路に影響しないので dead plugin でもコストは小さい。
+    let scan = crate::plugin_scan::scan_plugin(plugin_path);
+    let uses_merged = matches!(
+        mode,
+        PluginMergeMode::Full | PluginMergeMode::ViewWithoutDoc
+    );
+    crate::loader::PluginScripts {
+        name: plugin.display_name(),
+        path: plugin_path.to_string_lossy().replace('\\', "/"),
+        view_path: view_path.to_string_lossy().replace('\\', "/"),
+        merge: plugin.merge,
+        merge_doc: plugin.merge_doc,
+        uses_merged,
+        init: crate::find_lua(plugin_config_dir, "init.lua"),
+        before: crate::find_lua(plugin_config_dir, "before.lua"),
+        after: crate::find_lua(plugin_config_dir, "after.lua"),
+        plugin_files: collect_source_files(plugin_path, "plugin"),
+        ftdetect_files: collect_source_files(plugin_path, "ftdetect"),
+        after_plugin_files: collect_source_files(plugin_path, "after/plugin"),
+        lazy: plugin.lazy,
+        on_cmd: plugin.on_cmd.clone(),
+        on_ft: plugin.on_ft.clone(),
+        on_map: plugin.on_map.clone(),
+        on_event: plugin.on_event.clone(),
+        on_path: plugin.on_path.clone(),
+        on_source: plugin.on_source.clone(),
+        depends: plugin.depends.clone(),
+        colorschemes: collect_colorschemes(plugin_path),
+        denops_plugins: collect_denops_plugins(plugin_path),
+        defined_commands: scan.commands,
+        defined_plug_maps: scan.plug_maps,
+        defined_user_events: scan.user_events,
+        cond: plugin.cond.clone(),
+    }
+}

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,0 +1,192 @@
+//! `rvpm self-update` + the background auto-update check (#125, #217).
+//!
+//! `run_self_update` drives the explicit command; `maybe_spawn_auto_update_check`
+//! / `finalize_auto_update_check` run the throttled background version probe that
+//! prints the update banner after a command completes. Extracted verbatim from
+//! the monolithic lib.rs.
+
+use anyhow::Result;
+
+/// 自動 update の handle。 結果は `finalize_auto_update_check` で消費する。
+pub(crate) enum AutoUpdateHandle {
+    /// notify mode: throttle window 内で fetch skip、 過去の cache が新版を示して
+    /// いるので banner だけ出す。
+    CachedAvailable {
+        checker: kaishin::Checker,
+        latest: kaishin::LatestRelease,
+    },
+    /// notify mode: バックグラウンドで GitHub API を叩いてる。 join 結果に応じて
+    /// 状態保存 + banner。
+    Pending {
+        checker: kaishin::Checker,
+        handle: tokio::task::JoinHandle<Result<Option<kaishin::LatestRelease>, anyhow::Error>>,
+        /// タイムアウト時のフォールバック用。
+        cached_latest: Option<kaishin::LatestRelease>,
+    },
+    /// install mode: バックグラウンドで check + download + 差し替えを silent 実行。
+    /// 完了して新版を入れたら 1 行だけ通知する (走行中プロセスは旧バイナリのまま、
+    /// 反映は次回起動)。
+    Installing {
+        handle: tokio::task::JoinHandle<Result<Option<kaishin::LatestRelease>, anyhow::Error>>,
+    },
+}
+
+/// `RVPM_NO_AUTOUPDATE` が「有効」な値で設定されているか。 `0` / `false` / 空白は
+/// 無効扱い (= 自動更新を止めない)。 config の `auto_update` より優先する kill-switch。
+pub(crate) fn auto_update_disabled_by_env() -> bool {
+    match std::env::var("RVPM_NO_AUTOUPDATE") {
+        Ok(v) => {
+            let v = v.trim();
+            !(v.is_empty() || v == "0" || v.eq_ignore_ascii_case("false"))
+        }
+        Err(_) => false,
+    }
+}
+
+/// config の `auto_update` (旧 `auto_update_check`) に応じて background 処理を起動する。
+///
+/// - `off` (または env `RVPM_NO_AUTOUPDATE`): 何もせず `None`。
+/// - `notify`: GitHub API を叩いて新版があれば banner で案内する (install しない)。
+///   throttle 内でも cache が新版を示していれば banner 用 handle を返す。
+/// - `install`: `Checker::auto_update` を spawn し、 silent に download + 差し替え。
+///   完了したら finalize で 1 行通知する。
+///
+/// 失敗時 (config 読めない等) は `None` を返して silent skip (resilience)。
+pub(crate) async fn maybe_spawn_auto_update_check() -> Option<AutoUpdateHandle> {
+    use crate::config::AutoUpdateMode;
+
+    // config が読めない / 失敗するケースもあるので resilience。 panic は絶対にしない。
+    let config_path = config_path_for_auto_check()?;
+    let toml_str = std::fs::read_to_string(&config_path).ok()?;
+    let cfg = crate::config::parse_config(&toml_str).ok()?;
+
+    // env kill-switch は config より優先。
+    let mode = if auto_update_disabled_by_env() {
+        AutoUpdateMode::Off
+    } else {
+        cfg.options.update_mode()
+    };
+    if mode == AutoUpdateMode::Off {
+        return None;
+    }
+
+    let interval = cfg
+        .options
+        .update_check_interval
+        .as_deref()
+        .and_then(|s| kaishin::parse_interval(s).ok())
+        .unwrap_or_else(kaishin::default_interval);
+
+    let cache_root = crate::paths::resolve_cache_root(cfg.options.cache_root.as_deref());
+    let opts = kaishin::KaishinOptions::new(
+        "yukimemi",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    let checker = kaishin::Checker::new(env!("CARGO_PKG_NAME"), opts)
+        .interval(interval)
+        .state_path(cache_root.join("last_update_check.json"));
+
+    match mode {
+        // 上で early-return 済みだが、 網羅性のため。
+        AutoUpdateMode::Off => None,
+        AutoUpdateMode::Notify => {
+            if !checker.should_check() {
+                // throttle 内 — cache から判定
+                if let Some(latest) = checker.cached_update() {
+                    return Some(AutoUpdateHandle::CachedAvailable { checker, latest });
+                }
+                return None;
+            }
+            // fetch を spawn
+            let cached_latest = checker.cached_update();
+            let checker_clone = checker.clone();
+            let handle = tokio::spawn(async move { checker_clone.check_and_save().await });
+            Some(AutoUpdateHandle::Pending {
+                checker,
+                handle,
+                cached_latest,
+            })
+        }
+        AutoUpdateMode::Install => {
+            // `auto_update` は self-throttle + cross-process lock + silent install
+            // まで面倒を見る。 due でなければ即 Ok(None)。 dev build は no-op。
+            let handle = tokio::spawn(async move { checker.auto_update().await });
+            Some(AutoUpdateHandle::Installing { handle })
+        }
+    }
+}
+
+/// `rvpm` の config file の path を解決する (auto-check 用)。
+/// 既存の `crate::paths::rvpm_config_path()` ヘルパに委譲して、 `.config/rvpm/...` のハードコードを
+/// 避ける (CodeRabbit PR #126 指摘の coding guideline 整合)。
+pub(crate) fn config_path_for_auto_check() -> Option<std::path::PathBuf> {
+    let p = crate::paths::rvpm_config_path();
+    p.exists().then_some(p)
+}
+
+/// background fetch を join + banner 出力 (#125)。
+/// timeout は 1 秒 — fetch が遅ければ次回に回す。
+pub(crate) async fn finalize_auto_update_check(handle: AutoUpdateHandle) {
+    match handle {
+        AutoUpdateHandle::CachedAvailable { checker, latest } => {
+            eprintln!("\n{}", checker.format_banner(&latest));
+        }
+        AutoUpdateHandle::Pending {
+            checker,
+            handle,
+            cached_latest,
+        } => {
+            // 1 秒 timeout で結果を待つ。 タイムアウトは silent skip。
+            // kaishin 0.4 で check_and_save が Option を返すようになったので、
+            // ここでの is_update_available 重複チェックは不要 (Ok(None) = 更新無し)。
+            let res = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
+            match res {
+                Ok(Ok(Ok(Some(latest)))) => {
+                    eprintln!("\n{}", checker.format_banner(&latest));
+                }
+                Ok(Ok(Ok(None))) => {
+                    // fetch 成功 + 更新無し: cache へのフォールバックは不要
+                    // (最新が現在版に追いついた直後など、 cache は古いだけ)。
+                }
+                _ => {
+                    // タイムアウトや fetch エラー時のみ cache を試す。
+                    if let Some(latest) = cached_latest {
+                        eprintln!("\n{}", checker.format_banner(&latest));
+                    }
+                }
+            }
+        }
+        AutoUpdateHandle::Installing { handle } => {
+            // 実際に download が走るのは新版がある時 (= throttle ごとに高々 1 回)
+            // だけで、 大半の起動では `auto_update` が即 Ok(None) を返すのでこの待ちは
+            // 一瞬で抜ける。 download 中の稀な起動でも `rvpm list` 等を長時間ブロック
+            // しないよう、 待ちは短い上限 (5 秒) に留める。 download は起動時から
+            // コマンド本体と並行で走っているので、 大抵はこの時点で完了済み。
+            // タイムアウト時は黙って次回に回す — 中断しても self_replace は atomic
+            // なのでバイナリは壊れない (遅い回線では次の機会か手動 self-update に委ねる)。
+            let res = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+            if let Ok(Ok(Ok(Some(latest)))) = res {
+                let v = latest.tag_name.trim_start_matches('v');
+                eprintln!("\n\u{2713} rvpm {v} installed in the background — restart to apply.");
+            }
+        }
+    }
+}
+
+/// `rvpm self-update` (#125)。
+pub(crate) async fn run_self_update(yes: bool, check_only: bool) -> Result<()> {
+    let opts = kaishin::KaishinOptions::new(
+        "yukimemi",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    let upd_opts = kaishin::UpdateOptions::new()
+        .yes(yes)
+        .check_only(check_only);
+    // non_interactive フラグは rvpm ではまだ CmdCtx に持っていないため、デフォルト false。
+    // (必要になれば CmdCtx に追加して伝搬させる)
+    kaishin::run_self_update(&opts, upd_opts).await
+}


### PR DESCRIPTION
## Summary

Second stage of the #217 decomposition (after #222 extracted paths / merge /
url). Two more cohesive clusters move out of `src/lib.rs` as pure,
behaviour-preserving code motion:

| Commit | New module | Moved |
|---|---|---|
| `f5898ba` | `src/plugin_build.rs` (412) | **build-step runner** (`execute_build_command`, `collect_build_rtp`, `run_build_shell`, `unwrap_anonymous_lua_function`, `run_build_lua`, `parse_build_command`) + **loader script pre-glob** (`build_plugin_scripts`, `collect_colorschemes`, `collect_denops_plugins`, `collect_source_files`) |
| `1c203e5` | `src/self_update.rs` (192) | `rvpm self-update` command + the background auto-update probe (`AutoUpdateHandle`, `auto_update_disabled_by_env`, `maybe_spawn_auto_update_check`, `config_path_for_auto_check`, `finalize_auto_update_check`) |

`src/lib.rs`: **8585 → 8007 lines** (−578).

## Approach / visibility

- Moved items are `pub(crate)`; `lib.rs` glob-imports each module
  (`use crate::plugin_build::*`, `use crate::self_update::*`) so the bare call
  sites are unchanged.
- `resolve_plugin_dst` and `find_lua` stay in `lib.rs` (used widely elsewhere)
  and are now `pub(crate)` so `plugin_build` calls them via `crate::`.
- `self_update` qualifies its `paths` / `config` helper calls
  (`crate::paths::*`, `crate::config::parse_config`).
- Tests still live in `lib.rs`'s `mod tests` (tracked for relocation in #224).

## Verification

`cargo make check`-equivalent after **every** commit, all green:

| step | result |
|---|---|
| `cargo fmt --all -- --check` | ✓ |
| `cargo clippy --locked --all-targets -- -D warnings` | ✓ clean |
| `cargo test --locked` | ✓ 805 passed |
| `cargo test --locked --doc` | ✓ |

## Scope / follow-up

Helper/leaf extractions only. The clap `Cli`/`Commands` definitions and the
remaining `run_*()` command handlers (`run_sync` ~760 lines, `run_add`,
`run_list`, `run_browse`, …) are the next and largest stage — they'll land in a
follow-up PR. #217 stays open until the command layer is split. Test relocation
is tracked in #224.

Refs #217


---
_Generated by [Claude Code](https://claude.ai/code/session_0184QcRqaPDjPjbVnfTTVHEp)_