### PR TITLE
chore(release): v3.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,7 +3802,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.39.0"
+version = "3.40.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.39.0"
+version = "3.40.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,10 +1,10 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T05:37:50.602915+00:00'
-apm_version: 0.16.0
+generated_at: '2026-06-07T02:40:38.147336+00:00'
+apm_version: 0.12.1
 dependencies:
 - repo_url: yukimemi/renri
   host: github.com
-  resolved_commit: 1bc5976892f4200280b6227ca71deead6c40a574
+  resolved_commit: 05495f7d8f0dd2534807a6c77186c4cf183885f1
   resolved_ref: main
   package_type: apm_package
   deployed_files:


### PR DESCRIPTION
## v3.40.0

### perf

- **Incremental stamp-based generate rebuilds** (#229): `views/<plug>/.rvpm-stamp.json` (clone HEAD + merge mode) and `merged/.rvpm-stamp.json` skip the hard-link rebuild — and the helptags pass — for unchanged plugins. No-op `rvpm generate` drops from **~27s to ~1.4s** on a 252-plugin config (Windows/NTFS).
- Parallel per-plugin view builds + parallel `build_plugin_scripts` under `options.concurrency`.
- Replaced `*.rvpm-old` trees are deleted on background threads (`DirReaper` + RAII `ReapGuard`).
- New escape hatch: `rvpm generate --force`; `sync --rebuild [QUERY]` also forces view rebuilds in scope.
- `RVPM_TIMING=1` prints per-phase laps for `run_generate`.

On merge, auto-tag.yml pushes `v3.40.0` and release.yml builds binaries + publishes to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)