### PR TITLE
chore(release): v3.40.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,7 +3802,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.40.0"
+version = "3.40.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.40.0"
+version = "3.40.1"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
## Release v3.40.1

Patch release cutting the robustness fixes from #231 (the only unreleased
change on top of v3.40.0). Bumps `Cargo.toml` / `Cargo.lock` to `3.40.1`.

Merging this to `main` triggers `auto-tag.yml` → `v3.40.1` tag → `release.yml`
(cross-compile + GitHub Release + crates.io publish).

### Included (#231)

- **build**: `run_build_shell` now drains stdout/stderr via `wait_with_output()`
  instead of leaving piped output unread — fixes a deadlock on builds emitting
  >64 KB (`cargo build`, `:TSUpdate`) and surfaces build stderr on failure. (#226)
- **auto-update**: `maybe_spawn_auto_update_check` reads config with `tokio::fs`,
  no longer blocking the async executor thread. (#226)
- **merge**: `ensure_absent` is type-aware (`remove_file` / `remove_dir` /
  `remove_dir_all`), so file/symlink residue is cleaned on Windows instead of
  bailing every run. (#223)

### Not included

- #224 (relocate test blocks) and #228 (split `commands.rs` into per-subcommand
  modules) remain open as follow-ups.

> Note: the lib.rs decomposition (#222/#225/#227) and the incremental-generate
> perf work (#229) already shipped in v3.40.0.


---
_Generated by [Claude Code](https://claude.ai/code/session_0184QcRqaPDjPjbVnfTTVHEp)_