### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,108 @@
+name: claude-review
+
+# Automatic Claude Code review on every human-authored PR.
+#
+# Replaces the Gemini Code Assist free-tier PR review (free tier
+# discontinued upstream). Runs anthropics/claude-code-action in
+# agent mode: the workflow supplies a review prompt, Claude reads
+# the diff (and the repo's AGENTS.md conventions) and posts inline
+# comments plus a top-level summary.
+#
+# Review-skip policy — mirrors the AGENTS.md "PR review cycle"
+# rules so the workflow and the docs agree on which PRs skip the
+# bot-review gate:
+# - `chore/release-*` version-bump PRs: nothing for a reviewer to
+#   find in a version bump, and the release pipeline downstream of
+#   merge (auto-tag → release.yml, shipped by language layers like
+#   pj-rust-cli) is time-sensitive.
+# - `kata-apply/auto` / `apm-bump/auto` rolling branches: rendered
+#   template / lock refreshes, auto-merged when CI passes.
+# - Renovate / Dependabot PRs: bot-authored dependency bumps skip
+#   the bot-review gate per AGENTS.md.
+# - Draft PRs: review fires once marked ready (`ready_for_review`).
+#
+# `.tera` suffix: same dual purpose as the other workflow templates
+# here — keeps GHA from auto-running the source inside pj-base, and
+# opts the file into kata's Tera rendering for the
+# `{{ vars.actions.* }}` action-version pins.
+#
+# Setup requirement on every consumer (one-time):
+# 1. Install the Claude GitHub App (github.com/apps/claude) on the
+#    repo (or org) — the action exchanges an OIDC token against it.
+# 2. `CLAUDE_CODE_OAUTH_TOKEN` repo secret — generate locally with
+#    `claude setup-token` (requires a Claude Pro/Max subscription).
+#    Pay-as-you-go alternative: store `ANTHROPIC_API_KEY` instead
+#    and swap the input below to `anthropic_api_key`.
+#
+# `when = "always"` (in template.toml): every consumer wants
+# identical review behaviour; fixes to the workflow itself flow
+# automatically on next apply.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  # One review per PR at a time; a new push supersedes the
+  # in-flight review (reviewing a stale diff is wasted tokens).
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip release bumps, rolling bot branches, bot authors and
+    # drafts — see the header comment for the per-line rationale.
+    if: |
+      !github.event.pull_request.draft &&
+      !startsWith(github.head_ref, 'chore/release-') &&
+      github.head_ref != 'kata-apply/auto' &&
+      github.head_ref != 'apm-bump/auto' &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    # The action's SDK caps runs at 10 agent turns, but has no
+    # wall-clock timeout of its own; bound a hung run well below
+    # GHA's 360-minute default.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 1
+          # The action exchanges its own App token for git/API
+          # access; the checkout-persisted credential is unused.
+          # Same hardening as apm-bump.yml.tera.
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Tracking comment with progress checkboxes; also pulls
+          # full PR context (comments, attachments) into the run.
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for correctness bugs first,
+            then code quality. Follow the repository's AGENTS.md
+            conventions where they apply.
+
+            Focus areas, in priority order:
+            - Correctness: logic errors, edge cases, error handling
+            - Security: input validation, secrets handling
+            - Maintainability: readability, duplication, dead code
+            - Tests: coverage for the changed behaviour
+
+            Post specific issues as inline comments on the relevant
+            lines. Use one top-level comment for the overall
+            summary. Be concise — no praise padding; if the PR is
+            clean, say so briefly.
+          # Scope Claude to read-the-PR + comment tools only; the
+          # review job must not push code.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,76 @@
+name: claude
+
+# Interactive @claude responder — mention `@claude` in a PR / issue
+# comment (or an issue body/title) and Claude Code picks the task
+# up: answer questions, implement requested changes on the PR
+# branch, triage the issue, etc. Companion to the automatic
+# `claude-review.yml`; this one only fires on explicit mentions, so
+# it needs no review-skip policy.
+#
+# `.tera` suffix: same dual purpose as the other workflow templates
+# here — keeps GHA from auto-running the source inside pj-base, and
+# opts the file into kata's Tera rendering for the
+# `{{ vars.actions.* }}` action-version pins.
+#
+# Setup requirement on every consumer (one-time): same pair as
+# claude-review.yml.tera — the Claude GitHub App
+# (github.com/apps/claude) installed on the repo, plus the
+# `CLAUDE_CODE_OAUTH_TOKEN` secret from `claude setup-token`
+# (Claude Pro/Max subscription). Pay-as-you-go alternative: store
+# `ANTHROPIC_API_KEY` and swap the input below.
+#
+# `when = "always"` (in template.toml): every consumer wants the
+# same responder; fixes to the workflow flow automatically.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  # contents/pull-requests/issues write: Claude may push fix
+  # commits to the PR branch and reply on threads. id-token for
+  # the action's OIDC exchange; actions read so it can inspect CI
+  # results when asked about failures.
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+concurrency:
+  # Serialise responder runs per PR / issue — parallel @claude
+  # mentions on the same thread could race pushing commits to the
+  # same branch. No cancel: let the earlier request finish.
+  group: claude-respond-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    # Same rationale as claude-review.yml.tera: the action has no
+    # wall-clock timeout of its own; bound a hung run well below
+    # GHA's 360-minute default.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 1
+          # The action exchanges its own App token for git/API
+          # access; the checkout-persisted credential is unused.
+          # Same hardening as apm-bump.yml.tera.
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,10 +1,10 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-06-07T04:52:54.114994463Z"
+applied_at = "2026-06-07T06:34:35.64841426Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "3e03ea70c4c70ea601e6ea5e1a273fe99122c0b8"
-version = "0.12.1"
+rev = "54360f67db62bc84413c451e4eb86a7d91cbe0cb"
+version = "0.13.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
@@ -40,6 +40,12 @@ content_hash = "5c5c9592fb47120e5278d77af38d38e0657e39841509f000a84561a0a62ea29f
 [files.".github/workflows/ci.yml"]
 content_hash = "7969eab018580d42ee36d5e1a295ef4ad3474604eaad6fb6190846fc6eed5e68"
 
+[files.".github/workflows/claude-review.yml"]
+content_hash = "e8e99a82d2ddb3e7a7e7daa4e26ad7a9a0627abdf99db6f79177d1a2fcfebbf4"
+
+[files.".github/workflows/claude.yml"]
+content_hash = "13b455ea1b225e23c9c36906b88df3ad8b9601102593f231b38f4cba5432ef59"
+
 [files.".github/workflows/kata-apply.yml"]
 content_hash = "a63f0e30f6c010e497ab3c3feb7061cfc59ca397ffef2c4ecec356ff99253641"
 
@@ -51,6 +57,7 @@ once_applied = true
 content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef"
 
 [files.".kata/vars.toml"]
+content_hash = "393b2b94540e792790ef9357e46e5bc259eb3064605794ca2373ae458999cb23"
 once_applied = true
 
 [files."AGENTS.md"]

--- a/.kata/vars.toml
+++ b/.kata/vars.toml
@@ -19,3 +19,4 @@ checkout = "v6.0.3"
 create_pull_request = "v8.1.1"
 # renovate: datasource=github-tags depName=Swatinem/rust-cache
 swatinem_rust_cache = "v2.9.1"
+claude_code_action = "v1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,10 +274,15 @@ here so each tool's auto-load behaviour still finds something.
 
 ### PR review cycle
 
-- Every PR runs reviews from **Gemini Code Assist** and
+- Every PR runs reviews from **Claude Code**
+  (`.github/workflows/claude-review.yml`, kata-managed) and
   **CodeRabbit**. Wait for both bots to post, address their
   comments (push fixes to the PR branch), and merge only after
-  feedback is resolved.
+  feedback is resolved. The claude-review workflow skips
+  review-exempt PRs by itself (its job-level `if:` excludes
+  `chore/release-*`, `kata-apply/auto`, `apm-bump/auto`, and
+  Renovate / Dependabot authors) — a missing Claude review on
+  those PRs is expected, not a failure.
 - **After opening a PR, immediately enter the review-monitoring
   loop — do not ask the user whether to start it.** Drive the
   cadence with `/loop` — fixed-interval mode (e.g.
@@ -291,8 +296,8 @@ here so each tool's auto-load behaviour still finds something.
   watchers (background `gh` polls, file watchers, hooks) cannot
   trigger active follow-up, so they are not a substitute —
   without an active wake-up the agent never re-reads the PR.
-- **Default polling interval: 60s.** Gemini Code Assist /
-  CodeRabbit historically reply within ~1–3 minutes of a push or
+- **Default polling interval: 60s.** Claude Code review /
+  CodeRabbit typically reply within ~1–5 minutes of a push or
   thread reply, so a 60s tick catches them on the next wake-up
   without burning cache: 60s sits well inside the 5-minute
   prompt-cache TTL, so the conversation context stays cached
@@ -319,8 +324,13 @@ here so each tool's auto-load behaviour still finds something.
   the rate-limit exception below.)
 - **Reply to reviewers after pushing a fix.** Reply on the
   corresponding review thread with an **@-mention**
-  (`@gemini-code-assist` / `@coderabbitai`). Silent fixes are
-  invisible to reviewers and cost the audit trail.
+  (`@claude` / `@coderabbitai`). Silent fixes are invisible to
+  reviewers and cost the audit trail. Note `@claude` also
+  triggers the interactive responder
+  (`.github/workflows/claude.yml`, kata-managed) — it will
+  re-check the fix and reply on the thread; that re-check is the
+  point, but don't @-mention it for pure FYI notes that need no
+  verification.
 - A review thread is **settled** the moment the latest bot reply
   is ack-only ("Thank you" / "Understood" / a re-review summary
   with no new findings) or 30 minutes elapse with no actionable


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->