### PR TITLE
refactor(tests): relocate the completion test into cli.rs (#224)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -646,3 +646,36 @@ async fn run_cli() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_completion_generation_succeeds_for_all_shells() {
+        // `rvpm completion <SHELL>` が clap_complete に渡る CLI 定義を毎回 panic
+        // 無く読めることを確認 (#114)。 出力内容自体は clap_complete の責務なので
+        // 中身は assert しないが、 何かしら出力されることだけは確認する。
+        use clap::CommandFactory;
+        use clap_complete::Shell;
+
+        let shells = [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ];
+        for shell in shells {
+            let mut cmd = Cli::command();
+            let bin = cmd.get_name().to_string();
+            let mut out: Vec<u8> = Vec::new();
+            clap_complete::generate(shell, &mut cmd, bin, &mut out);
+            assert!(
+                !out.is_empty(),
+                "completion output for {:?} should not be empty",
+                shell
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2114,34 +2114,6 @@ url = "owner/repo"
     }
 
     #[test]
-    fn test_completion_generation_succeeds_for_all_shells() {
-        // `rvpm completion <SHELL>` が clap_complete に渡る CLI 定義を毎回 panic
-        // 無く読めることを確認 (#114)。 出力内容自体は clap_complete の責務なので
-        // 中身は assert しないが、 何かしら出力されることだけは確認する。
-        use clap::CommandFactory;
-        use clap_complete::Shell;
-
-        let shells = [
-            Shell::Bash,
-            Shell::Zsh,
-            Shell::Fish,
-            Shell::PowerShell,
-            Shell::Elvish,
-        ];
-        for shell in shells {
-            let mut cmd = Cli::command();
-            let bin = cmd.get_name().to_string();
-            let mut out: Vec<u8> = Vec::new();
-            clap_complete::generate(shell, &mut cmd, bin, &mut out);
-            assert!(
-                !out.is_empty(),
-                "completion output for {:?} should not be empty",
-                shell
-            );
-        }
-    }
-
-    #[test]
     fn test_resolve_concurrency_uses_config_value() {
         let result = resolve_concurrency(Some(5));
         assert_eq!(result, 5);


### PR DESCRIPTION
## What

Relocates the last `#217`-extraction test that was still living in `lib.rs`:
`test_completion_generation_succeeds_for_all_shells` moves into a new
`#[cfg(test)] mod tests` in **`cli.rs`**, next to the `Cli` it exercises
(extracted in #233).

This finishes the `#224` test-relocation: `paths` / `merge` / `url` /
`plugin_build` landed in #248, and `cli` is the remaining one.

## How (behaviour-preserving)

Pure relocation — no assertion changes. The test keeps its local
`use clap::CommandFactory` / `use clap_complete::Shell` and resolves `Cli`
through `use super::*`.

## Not in scope

The `parse_config` tests still in `lib.rs` test `config.rs`, which is a
foundational module that predates the #217 extractions (it was never split out
*of* `lib.rs`), so they're outside `#224`'s "tests left behind by an extraction"
scope. They can be tidied into `config.rs` separately if wanted.

## Verification

`cargo make check` green:

- **822 tests pass**, 0 failed (1 ignored)
- `plural` doctest preserved
- `clippy -D warnings --all-targets` clean
- `cargo fmt --check` clean
- lock-check ok

## Refs

- Closes #224
- Parent: #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
