### PR TITLE
chore: release v3.40.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,7 +3802,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.40.1"
+version = "3.40.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.40.1"
+version = "3.40.2"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.40.2.

Version-bump-only PR (Cargo.toml + Cargo.lock). Enables the auto-tag -> release pipeline.

Highlights since v3.40.1 — the #217 decomposition of the ~9.2k-line `src/lib.rs` into per-command modules (behaviour-preserving, 822 tests + plural doctest green throughout):
- #244 split commands.rs into per-subcommand modules (#228)
- #245 extract cli.rs (clap Cli/Commands + run_cli) (#233)
- #246 / #250 sweep sole-caller helpers into their command modules (#233)
- #248 / #249 relocate #[cfg(test)] blocks next to their modules (#224)

`src/lib.rs` is now ~1.8k lines.