### PR TITLE
chore: release v3.40.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,7 +3802,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.40.2"
+version = "3.40.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.40.2"
+version = "3.40.3"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.40.3.

Version-bump-only PR (Cargo.toml + Cargo.lock); triggers the auto-tag → release pipeline.

Fixes since v3.40.2:
- #254 — `rvpm list` could deadlock with >100 plugins (the status channel was fixed at capacity 100 while the consumer only drained after joining every task). The channel is now sized to the plugin count. (Closes #247)
- #255 — `find_plugin_line_in_toml` now matches single-quoted TOML urls (`url = 'owner/repo'`); `update_plugin_config` resolves the plugin table once. (Closes #251, #252)
