### PR TITLE
chore: release v3.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,7 +3802,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.40.3"
+version = "3.41.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.40.3"
+version = "3.41.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump to v3.41.0 for the supply-chain cooldown feature (#257).

On merge, `auto-tag.yml` pushes `v3.41.0`, which fires `release.yml` (binary builds + crates.io publish).

https://claude.ai/code/session_01ARTfRiP2NjUd4nxm66XyDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARTfRiP2NjUd4nxm66XyDr)_