### PR TITLE
fix(update): surface update errors after completion and in `rvpm list`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ src/
   merge_conflicts.rs — read/write of `<cache_root>/merge_conflicts.json` (most recent sync only; consumed by doctor)
   lockfile.rs   — read/write of `<config_root>/rvpm.lock` (reproducible plugin versions; intended to be committed to dotfiles)
   tui.rs        — ratatui-based progress / list display TUI
+  update_errors.rs — read/write of `<cache_root>/update_errors.json` (per-plugin last-failed `rvpm update`; surfaced by `rvpm list` as `UpdateFailed`, cleared by a later successful update/sync)
   update_log.rs — read/append of `<cache_root>/update_log.json`, BREAKING detection, render
 ```
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -26,6 +26,9 @@ pub(crate) async fn run_list(no_tui: bool) -> Result<bool> {
                     println!("  [Modified]  {}", url)
                 }
                 PluginStatus::Syncing(msg) => println!("  [Outdated]  {} ({})", url, msg),
+                PluginStatus::UpdateFailed(msg) => {
+                    println!("  [UpdateFailed] {} ({})", url, msg)
+                }
                 PluginStatus::Failed(msg) => println!("  [Error]     {} ({})", url, msg),
                 PluginStatus::Waiting => println!("  [Waiting]   {}", url),
             }
@@ -404,26 +407,62 @@ fn spawn_status_check(
     // drains `rx` — that combination deadlocked once a config had >100 plugins
     // (#247). The TUI path drains progressively, so it was never affected.
     let (tx, rx) = mpsc::channel::<(String, PluginStatus)>(config.plugins.len().max(1));
+    // 前回 update が失敗した plugin を overlay 表示するため、記録を読み込む
+    // (#update-error-visibility)。missing / malformed は empty fallback (resilience)。
+    let update_errors =
+        crate::update_errors::UpdateErrors::load(&resolve_update_errors_path(cache_root));
+    // name → &UpdateErrorEntry の lookup を先に組んで per-plugin の find を O(1) に
+    // する (sync.rs の fetch_lookup と同じ流儀。素朴に find すると N plugin × M entry
+    // の線形スキャンになる)。
+    let error_lookup: std::collections::HashMap<&str, &crate::update_errors::UpdateErrorEntry> =
+        update_errors
+            .entries
+            .iter()
+            .map(|e| (e.name.as_str(), e))
+            .collect();
     let mut set = JoinSet::new();
     for plugin in config.plugins.iter() {
         let plugin = plugin.clone();
         let cache_root = cache_root.to_path_buf();
         let tx = tx.clone();
+        // この plugin の update エラー記録 (URL 一致時のみ有効 — 同名で別 repo に
+        // 差し替えられたケースは別物なので無視する。lockfile / fetch_state と同思想)。
+        let update_err_msg = error_lookup
+            .get(plugin.display_name().as_str())
+            .filter(|e| urls_match(&e.url, &plugin.url))
+            .map(|e| e.message.clone());
         set.spawn(async move {
             let dst_path = resolve_plugin_dst(&plugin, &cache_root);
             let repo = Repo::new(&plugin.url, &dst_path, plugin.rev.as_deref());
             let git_status = repo.get_status().await;
-            let plugin_status = match git_status {
-                crate::git::RepoStatus::Clean => PluginStatus::Finished,
-                crate::git::RepoStatus::NotInstalled => PluginStatus::Failed("Missing".to_string()),
-                crate::git::RepoStatus::Modified => PluginStatus::Syncing("Modified".to_string()),
-                crate::git::RepoStatus::Error(e) => PluginStatus::Failed(e),
-            };
+            let plugin_status = status_from_git(git_status, update_err_msg);
             let _ = tx.send((plugin.url.clone(), plugin_status)).await;
         });
     }
     drop(tx);
     (rx, set)
+}
+
+/// git status と「前回 update 失敗記録」から表示用の `PluginStatus` を決める
+/// pure function (#update-error-visibility)。
+///
+/// git の実状態が優先: `NotInstalled` / `Modified` / `Error` はそのまま返す
+/// (これらは今まさに actionable な状態で、過去の update 失敗より重要)。
+/// `Clean` のときだけ、update 失敗記録があれば `UpdateFailed` に overlay する
+/// (clone は健全だが「前回 update がコケた」痕跡を list に残す)。
+fn status_from_git(
+    git_status: crate::git::RepoStatus,
+    update_err_msg: Option<String>,
+) -> PluginStatus {
+    match git_status {
+        crate::git::RepoStatus::Clean => match update_err_msg {
+            Some(msg) => PluginStatus::UpdateFailed(msg),
+            None => PluginStatus::Finished,
+        },
+        crate::git::RepoStatus::NotInstalled => PluginStatus::Failed("Missing".to_string()),
+        crate::git::RepoStatus::Modified => PluginStatus::Syncing("Modified".to_string()),
+        crate::git::RepoStatus::Error(e) => PluginStatus::Failed(e),
+    }
 }
 
 async fn fetch_plugin_statuses(
@@ -442,6 +481,47 @@ async fn fetch_plugin_statuses(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git::RepoStatus;
+
+    // ─── status_from_git: update エラー overlay の決定表 ──────────────────
+
+    #[test]
+    fn test_status_from_git_clean_without_error_is_finished() {
+        assert!(matches!(
+            status_from_git(RepoStatus::Clean, None),
+            PluginStatus::Finished
+        ));
+    }
+
+    #[test]
+    fn test_status_from_git_clean_with_error_overlays_update_failed() {
+        // clone は健全 (Clean) でも、前回 update の失敗記録があれば
+        // UpdateFailed として list に痕跡を残す。
+        let got = status_from_git(RepoStatus::Clean, Some("boom".to_string()));
+        assert!(matches!(got, PluginStatus::UpdateFailed(m) if m == "boom"));
+    }
+
+    #[test]
+    fn test_status_from_git_missing_ignores_update_error() {
+        // git の実状態 (未インストール) が優先。過去の update 失敗より重要。
+        let got = status_from_git(RepoStatus::NotInstalled, Some("boom".to_string()));
+        assert!(matches!(got, PluginStatus::Failed(m) if m == "Missing"));
+    }
+
+    #[test]
+    fn test_status_from_git_modified_ignores_update_error() {
+        let got = status_from_git(RepoStatus::Modified, Some("boom".to_string()));
+        assert!(matches!(got, PluginStatus::Syncing(m) if m.contains("Modified")));
+    }
+
+    #[test]
+    fn test_status_from_git_error_ignores_update_error() {
+        let got = status_from_git(
+            RepoStatus::Error("git blew up".to_string()),
+            Some("boom".to_string()),
+        );
+        assert!(matches!(got, PluginStatus::Failed(m) if m == "git blew up"));
+    }
 
     #[tokio::test]
     async fn fetch_plugin_statuses_does_not_deadlock_above_channel_capacity() {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -623,6 +623,15 @@ pub(crate) async fn run_sync(
         }
     }
 
+    // 残留した status メッセージを drain してから status_map を参照する。
+    // tokio::select! は 1 iteration で rx.recv か join_next の片方しか進めないので、
+    // 最後に完了したタスクの Failed 通知がまだ channel に残ったままループを抜けて
+    // いる可能性がある。これを取りこぼすと下の失敗サマリと update_errors 整合が
+    // その plugin を誤って成功扱いにして、実際の失敗を握り潰してしまう。
+    while let Ok((url, status)) = rx.try_recv() {
+        tui_state.update_status(&url, status);
+    }
+
     // JoinSet は完了順で返すので plugin_scripts が依存順になっていない。
     // config.plugins の順序 (sort_plugins 済み) に合わせて re-sort する。
     plugin_scripts.sort_by_key(|ps| {
@@ -850,6 +859,46 @@ pub(crate) async fn run_sync(
         eprintln!(
             "\u{26a0} failed to save {}: {} (fetch cache may be stale)",
             fetch_state_path.display(),
+            e
+        );
+    }
+
+    // update 失敗マーカーの整合 (#update-error-visibility): sync が成功した plugin は
+    // 記録を消し込み、失敗した plugin は記録する。これで `rvpm update` 失敗後に
+    // `rvpm sync` で復旧すれば `rvpm list` のマーカーも消え、逆に sync でコケたら
+    // 記録が残る。config.toml から外された plugin の entry は retain で drop。
+    // 変化が無ければファイルに触らない (dirty guard)。
+    let update_errors_path = resolve_update_errors_path(&cache_root);
+    let mut update_errors = crate::update_errors::UpdateErrors::load(&update_errors_path);
+    let now_ts = crate::fetch_state::now_rfc3339();
+    let mut errors_dirty = false;
+    for plugin in config.plugins.iter().filter(|p| !p.dev) {
+        match tui_state.status_map.get(&plugin.url) {
+            Some(PluginStatus::Failed(msg)) => {
+                update_errors.upsert(crate::update_errors::UpdateErrorEntry {
+                    name: plugin.display_name(),
+                    url: plugin.url.clone(),
+                    message: msg.clone(),
+                    timestamp: now_ts.clone(),
+                });
+                errors_dirty = true;
+            }
+            _ => {
+                if update_errors.remove_by_name(&plugin.display_name()) {
+                    errors_dirty = true;
+                }
+            }
+        }
+    }
+    let before_retain = update_errors.entries.len();
+    update_errors.retain_by_names(&active_names);
+    if update_errors.entries.len() != before_retain {
+        errors_dirty = true;
+    }
+    if errors_dirty && let Err(e) = update_errors.save(&update_errors_path) {
+        eprintln!(
+            "\u{26a0} failed to save {}: {} (rvpm list may not reflect update errors)",
+            update_errors_path.display(),
             e
         );
     }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -172,6 +172,59 @@ pub(crate) async fn run_update(query: Option<String>, no_cooldown: bool) -> Resu
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
     let _ = terminal.show_cursor();
 
+    // 残留した status メッセージを drain してから失敗を集計する。tokio::select! は
+    // 1 iteration で rx.recv か join_next のどちらか片方しか進めないので、最後の
+    // Failed 通知が status_map に反映される前に while ループを抜けている可能性がある。
+    while let Ok((url, status)) = rx.try_recv() {
+        tui_state.update_status(&url, status);
+    }
+
+    // update 失敗の記録と表示 (#update-error-visibility):
+    //  - TUI を閉じた後にエラーサマリを stderr へ出す (sync と同じ流儀)。これが
+    //    無いと「update したのにエラーがどこにも出ない」罠になる。
+    //  - 併せて <cache_root>/update_errors.json を更新し、`rvpm list` から前回の
+    //    update 失敗が見えるようにする。失敗 → upsert、成功 → 消し込み (stale な
+    //    マーカーを残さない)。query で絞った部分 update では対象 plugin だけ触る
+    //    (更新対象外の記録を消さない — lockfile と同思想)。
+    let update_errors_path = resolve_update_errors_path(&cache_root);
+    let mut update_errors = crate::update_errors::UpdateErrors::load(&update_errors_path);
+    let now_ts = crate::fetch_state::now_rfc3339();
+    let mut failed: Vec<(&str, &str)> = Vec::new();
+    let mut errors_dirty = false;
+    for plugin in &target_plugins {
+        match tui_state.status_map.get(&plugin.url) {
+            Some(PluginStatus::Failed(msg)) => {
+                failed.push((plugin.url.as_str(), msg.as_str()));
+                update_errors.upsert(crate::update_errors::UpdateErrorEntry {
+                    name: plugin.display_name(),
+                    url: plugin.url.clone(),
+                    message: msg.clone(),
+                    timestamp: now_ts.clone(),
+                });
+                errors_dirty = true;
+            }
+            // Finished (成功) など失敗以外 → 過去のエラー記録を消し込む。
+            _ => {
+                if update_errors.remove_by_name(&plugin.display_name()) {
+                    errors_dirty = true;
+                }
+            }
+        }
+    }
+    if !failed.is_empty() {
+        eprintln!("\n{} error(s):", failed.len());
+        for (url, msg) in &failed {
+            eprintln!("  \u{2717} {}: {}", url, msg);
+        }
+    }
+    if errors_dirty && let Err(e) = update_errors.save(&update_errors_path) {
+        eprintln!(
+            "\u{26a0} failed to save {}: {} (rvpm list may not reflect update errors)",
+            update_errors_path.display(),
+            e
+        );
+    }
+
     // cooldown held-back サマリ (#supply-chain): tip 適用を見送った plugin を
     // 明示する。黙って古いままだと「update したのに進まない」罠になるため。
     if !held_by_cooldown.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod profile;
 mod profile_tui;
 mod self_update;
 mod tui;
+mod update_errors;
 mod update_log;
 mod url;
 mod view_stamp;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -200,6 +200,13 @@ pub(crate) fn resolve_cooldown_state_path(cache_root: &Path) -> PathBuf {
     cache_root.join("cooldown_state.json")
 }
 
+/// `rvpm update` が失敗した plugin の記録先 (#update-error-visibility)。
+/// `<cache_root>/update_errors.json` 固定 (fetch_state / cooldown_state と同じ場所)。
+/// `rvpm list` が overlay 表示に使い、成功した update / sync で消し込まれる。
+pub(crate) fn resolve_update_errors_path(cache_root: &Path) -> PathBuf {
+    cache_root.join("update_errors.json")
+}
+
 /// `Plugin` + `GitChange` から永続化向けの `ChangeRecord` を組み立てる小ヘルパー。
 /// run_sync / run_update / run_add で共通利用。
 pub(crate) fn change_record_from(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -84,6 +84,11 @@ pub enum PluginStatus {
     Syncing(String),
     Finished,
     Failed(String),
+    /// clone は健全だが「前回の `rvpm update` が失敗した」状態
+    /// (#update-error-visibility)。`rvpm list` が update_errors.json から
+    /// overlay して表示する専用マーカー。git status 上は Clean なので
+    /// Failed とは別扱いにして、赤 [Error] と混同させない。
+    UpdateFailed(String),
 }
 
 pub struct TuiState {
@@ -497,6 +502,17 @@ impl TuiState {
                         e.clone(),
                         Color::Red,
                     ),
+                    // 進捗 TUI (sync/update 実行中) では発生しないが exhaustive
+                    // match のため。万一渡っても update 失敗として黄色で見せる。
+                    PluginStatus::UpdateFailed(e) => (
+                        icons.failed,
+                        Color::Yellow,
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                        e.clone(),
+                        Color::Yellow,
+                    ),
                 };
                 Row::new(vec![
                     Cell::from(format!(" {} ", icon))
@@ -714,6 +730,9 @@ impl TuiState {
                 PluginStatus::Finished => (icons.installed, Color::Green),
                 PluginStatus::Failed(m) if m == "Missing" => (icons.missing, Color::Red),
                 PluginStatus::Failed(_) => (icons.failed, Color::Red),
+                // update 失敗マーカー: clone は健全なので赤 [Error] とは別に、
+                // 黄色い failed アイコンで「前回 update がコケた」ことを示す。
+                PluginStatus::UpdateFailed(_) => (icons.failed, Color::Yellow),
                 PluginStatus::Syncing(m) if m.contains("Modified") => {
                     (icons.modified, Color::Yellow)
                 }
@@ -746,6 +765,7 @@ impl TuiState {
                     (trg.join(" "), Color::DarkGray)
                 }
                 PluginStatus::Failed(msg) => (msg.clone(), Color::Red),
+                PluginStatus::UpdateFailed(msg) => (format!("update failed: {msg}"), Color::Yellow),
                 PluginStatus::Syncing(msg) => (msg.clone(), Color::Yellow),
                 PluginStatus::Waiting => ("Checking...".to_string(), Color::DarkGray),
             };

--- a/src/update_errors.rs
+++ b/src/update_errors.rs
@@ -1,0 +1,279 @@
+//! `<cache_root>/update_errors.json` の read/write。
+//!
+//! 背景:
+//! - `rvpm update` が失敗しても、clone 自体は健全なまま (古い commit に留まる)
+//!   なので `rvpm list` の git status は `Clean` を返し、`[Clean]` と表示される。
+//!   結果「update がコケたのにどこにも痕跡が残らない」罠になっていた。
+//! - そこで **plugin 単位で「最後の update が失敗した」事実を記録** して、
+//!   `rvpm list` がそれを overlay 表示する。成功した `update` / `sync` で
+//!   該当エントリを消し込む (stale なマーカーを残さない)。
+//!
+//! スキーマ:
+//! ```json
+//! { "version": 1,
+//!   "entries": [
+//!     { "name": "snacks.nvim", "url": "folke/snacks.nvim",
+//!       "message": "failed to fetch: ...", "timestamp": "2026-07-09T12:34:56Z" }
+//!   ] }
+//! ```
+//!
+//! - **場所**: `<cache_root>/update_errors.json` (ephemeral cache 側。fetch_state /
+//!   cooldown_state と同じ場所・同じ流儀)。
+//! - **resilience**: malformed / missing → empty state にフォールバック。ユーザー
+//!   操作は止めない。
+//! - **schema version**: 未対応バージョンは empty 扱い (fetch_state と同じパターン)。
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// 現行スキーマバージョン。壊すときは bump + migration を足す。
+pub const CURRENT_VERSION: u32 = 1;
+
+/// update_errors のルート構造。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateErrors {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub entries: Vec<UpdateErrorEntry>,
+}
+
+fn default_version() -> u32 {
+    CURRENT_VERSION
+}
+
+impl Default for UpdateErrors {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// 1 プラグイン分の「最後に失敗した update」エントリ。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateErrorEntry {
+    /// `Plugin::display_name()` 由来の lookup キー。
+    pub name: String,
+    /// config.toml に書かれた URL。同じ name で別 repo に差し替えられた時の検知用
+    /// (lockfile / fetch_state と同じ思想)。
+    pub url: String,
+    /// 失敗理由 (git エラーメッセージ等)。
+    pub message: String,
+    /// 失敗を記録した時刻。RFC3339 UTC (`YYYY-MM-DDTHH:MM:SSZ`)。
+    pub timestamp: String,
+}
+
+impl UpdateErrors {
+    /// `path` から読み出す。
+    /// - 存在しない → `Default` (empty)
+    /// - パース失敗 / version mismatch → warn を出して `Default`
+    pub fn load(path: &Path) -> Self {
+        let content = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(e) => {
+                eprintln!(
+                    "\u{26a0} update_errors: failed to read {}: {} (treating as empty)",
+                    path.display(),
+                    e
+                );
+                return Self::default();
+            }
+        };
+        match serde_json::from_str::<UpdateErrors>(&content) {
+            Ok(s) if s.version == CURRENT_VERSION => s,
+            Ok(s) => {
+                eprintln!(
+                    "\u{26a0} update_errors: unsupported version {} in {} (expected {}; treating as empty)",
+                    s.version,
+                    path.display(),
+                    CURRENT_VERSION
+                );
+                Self::default()
+            }
+            Err(e) => {
+                eprintln!(
+                    "\u{26a0} update_errors: failed to parse {}: {} (treating as empty)",
+                    path.display(),
+                    e
+                );
+                Self::default()
+            }
+        }
+    }
+
+    /// `path` に atomic write する。書き出し前に `entries` を name で安定 sort
+    /// して、同じ内容なら同じバイト列になるようにする。
+    pub fn save(&mut self, path: &Path) -> Result<()> {
+        self.entries.sort_by(|a, b| a.name.cmp(&b.name));
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create_dir_all {}", parent.display()))?;
+        }
+        let body = serde_json::to_string_pretty(self).context("serialize update_errors")?;
+        let parent = path.parent().unwrap_or(Path::new("."));
+        let tmp = tempfile::Builder::new()
+            .prefix(".rvpm-update-errors-")
+            .suffix(".tmp")
+            .tempfile_in(parent)
+            .with_context(|| format!("create tempfile in {}", parent.display()))?;
+        std::fs::write(tmp.path(), body.as_bytes())
+            .with_context(|| format!("write tempfile {}", tmp.path().display()))?;
+        tmp.persist(path)
+            .map_err(|e| anyhow::anyhow!("rename tempfile to {}: {}", path.display(), e))?;
+        Ok(())
+    }
+
+    /// 単発検索 API。本番の list は事前に `HashMap` lookup を組んで O(N) で回す
+    /// ので使っていないが、将来の consumer と tests 用に残す (fetch_state と同じ)。
+    #[allow(dead_code)]
+    pub fn find(&self, name: &str) -> Option<&UpdateErrorEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+
+    pub fn upsert(&mut self, entry: UpdateErrorEntry) {
+        if let Some(slot) = self.entries.iter_mut().find(|e| e.name == entry.name) {
+            *slot = entry;
+        } else {
+            self.entries.push(entry);
+        }
+    }
+
+    /// `name` のエントリを消し込む (update / sync が成功したとき)。エントリが
+    /// あって実際に削除したら `true`、無ければ `false` を返す (呼び出し側が
+    /// dirty 判定に使えるように)。
+    pub fn remove_by_name(&mut self, name: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| e.name != name);
+        self.entries.len() != before
+    }
+
+    /// `names` に無い entry を drop する (config.toml から外されたプラグイン)。
+    pub fn retain_by_names(&mut self, names: &std::collections::HashSet<String>) {
+        self.entries.retain(|e| names.contains(&e.name));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn mk(name: &str, message: &str) -> UpdateErrorEntry {
+        UpdateErrorEntry {
+            name: name.to_string(),
+            url: format!("owner/{}", name),
+            message: message.to_string(),
+            timestamp: "2026-07-09T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_load_missing_returns_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        let state = UpdateErrors::load(&path);
+        assert_eq!(state.version, CURRENT_VERSION);
+        assert!(state.entries.is_empty());
+    }
+
+    #[test]
+    fn test_load_malformed_returns_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, "not valid json =====").unwrap();
+        let state = UpdateErrors::load(&path);
+        assert!(state.entries.is_empty());
+    }
+
+    #[test]
+    fn test_save_then_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("update_errors.json");
+        let mut state = UpdateErrors::default();
+        state.upsert(mk("a", "boom"));
+        state.upsert(mk("b", "network down"));
+        state.save(&path).unwrap();
+
+        let loaded = UpdateErrors::load(&path);
+        assert_eq!(loaded.version, CURRENT_VERSION);
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.find("a").map(|e| e.message.as_str()), Some("boom"));
+        assert_eq!(
+            loaded.find("b").map(|e| e.message.as_str()),
+            Some("network down")
+        );
+    }
+
+    #[test]
+    fn test_save_sorts_entries_by_name_for_stable_diffs() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("update_errors.json");
+        let mut state = UpdateErrors::default();
+        state.upsert(mk("zeta", "z"));
+        state.upsert(mk("alpha", "a"));
+        state.upsert(mk("mid", "m"));
+        state.save(&path).unwrap();
+
+        let loaded = UpdateErrors::load(&path);
+        let names: Vec<_> = loaded.entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn test_upsert_replaces_existing_entry() {
+        let mut state = UpdateErrors::default();
+        state.upsert(mk("a", "old"));
+        state.upsert(mk("a", "new"));
+        assert_eq!(state.entries.len(), 1);
+        assert_eq!(state.entries[0].message, "new");
+    }
+
+    #[test]
+    fn test_remove_by_name_clears_and_reports() {
+        let mut state = UpdateErrors::default();
+        state.upsert(mk("a", "boom"));
+        state.upsert(mk("b", "boom"));
+        assert!(state.remove_by_name("a"));
+        assert!(state.find("a").is_none());
+        assert_eq!(state.entries.len(), 1);
+        // 存在しない name の削除は false
+        assert!(!state.remove_by_name("missing"));
+    }
+
+    #[test]
+    fn test_retain_by_names_drops_orphans() {
+        let mut state = UpdateErrors::default();
+        state.upsert(mk("a", "x"));
+        state.upsert(mk("b", "x"));
+        state.upsert(mk("c", "x"));
+        let mut keep = std::collections::HashSet::new();
+        keep.insert("a".to_string());
+        keep.insert("c".to_string());
+        state.retain_by_names(&keep);
+        let names: Vec<_> = state.entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"c"));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn test_load_rejects_future_schema_version() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("future.json");
+        std::fs::write(
+            &path,
+            r#"{"version":99,"entries":[{"name":"x","url":"o/x","message":"m","timestamp":"2026-07-09T00:00:00Z"}]}"#,
+        )
+        .unwrap();
+        let state = UpdateErrors::load(&path);
+        assert!(
+            state.entries.is_empty(),
+            "future schema must degrade to empty state"
+        );
+        assert_eq!(state.version, CURRENT_VERSION);
+    }
+}


### PR DESCRIPTION
## Problem

`rvpm update` reported per-plugin failures in the progress TUI, but once the alternate screen closed the errors vanished — the completion screen showed nothing. Worse, the subsequent `rvpm list` also gave no hint: it derives status purely from local git state, so a plugin whose update failed (fetch/checkout error) stays `Clean` at its old commit and rendered as `[Clean]`. The failure left no trace anywhere.

## Fix

- **update completion summary**: `run_update` now drains residual status messages and prints an error summary to stderr after TUI teardown, mirroring `run_sync`.
- **persistence**: new `update_errors` module backing `<cache_root>/update_errors.json` (load/save/upsert/remove_by_name/retain_by_names), same resilience + schema-version conventions as `fetch_state` / `cooldown_state`.
- **`rvpm list` marker**: a dedicated `PluginStatus::UpdateFailed` marker (yellow, distinct from red `[Error]`) is overlaid onto Clean plugins that have a recorded update failure; `--no-tui` prints `[UpdateFailed]`.
- **self-clearing**: a later successful `update` / `sync` clears the marker. Partial (query-scoped) update only touches its target plugins; sync reconciles all plugins and retains active names.

## Tests

- `update_errors`: load/save roundtrip, malformed/missing → empty, future-schema rejection, upsert/remove/retain (8 tests).
- `status_from_git`: pure decision-table for the overlay (git truth wins for Missing/Modified/Error; overlay only on Clean) (5 tests).
- Manually verified end-to-end with a local bare-repo remote: failed update prints the summary + records the error, `rvpm list` shows `[UpdateFailed]`, and a recovered successful update clears it back to `[Clean]`.

`cargo make check` green (888 tests + doctests + clippy + fmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “update failed” status in plugin lists and the TUI, with clearer messaging and highlighting.
  * Failed update results are now remembered and shown later in the plugin list, even after the main status returns to normal.

* **Bug Fixes**
  * Improved status handling so late-arriving update failures are captured and displayed reliably.
  * Update failure indicators are now cleared automatically after a later successful update or sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->