### PR TITLE
chore: release v3.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,7 +3821,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.41.0"
+version = "3.42.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.41.0"
+version = "3.42.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.42.0.

Highlights (#284): `rvpm update` failures are now surfaced — an error summary is printed after the update completes, and `rvpm list` shows a dedicated `[UpdateFailed]` marker for plugins whose last update failed (persisted to `update_errors.json`, self-clearing on a successful update/sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)