### PR TITLE
chore(release): v3.42.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.42.0"
+version = "3.42.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.42.0"
+version = "3.42.1"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump only (`Cargo.toml` + `Cargo.lock`), 3.42.0 → 3.42.1. On merge, `auto-tag.yml` pushes `v3.42.1` and `release.yml` builds binaries + publishes to crates.io.

## Included since v3.42.0

- **refactor:** migrate `[vars]` + Tera templating to [teravars](https://github.com/yukimemi/teravars), dropping the direct **tera 1.x** dependency for **teravars 0.2.0 / tera 2.0** (#286)

## Patch bump rationale

Internal engine swap only — `config.rs`'s two `Tera::one_off(.., false)` calls became a reused `teravars::Engine::new_minimal().render(..)`, with `is_windows`/`env` still passed as context values and rvpm's own `[vars]` extraction/resolution untouched. No config-syntax or behaviour change (`{{ is_windows }}`, `{% if %}`, `{{ vars.* }}`, `{{ env.* }}` all render identically; a regression test now pins autoescape-off), so this is a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)