### PR TITLE
feat(ai): add `agy` (Antigravity CLI) backend, deprecate `gemini`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,10 @@ concurrency = 16
 # auto_lazy = "ask"
 # Backend used to delegate `rvpm add` to an AI CLI (#93).
 #   "off" (default) — use the static scan + auto_lazy flow
-#   "claude" / "gemini" / "codex" / "opencode" — spawn the corresponding CLI as a subprocess
+#   "claude" / "agy" / "codex" / "opencode" — spawn the corresponding CLI as a subprocess
+#   "gemini" — deprecated; Gemini CLI was retired for Free / AI Pro / Ultra
+#              personal accounts on 2026-06-18 and "agy" (Antigravity CLI) is
+#              its successor. Still works with paid Google Cloud API keys.
 # Errors out if the CLI is not installed. `auto_lazy` is ignored.
 # CLI flags `--ai claude` / `--no-ai` allow per-call overrides.
 # ai = "claude"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ regex = "1.13.1"
 toml = "1.1.3"
 toml_edit = "0.25.13"
 
-# CLI subprocess discovery (`claude` / `gemini` / `codex` on PATH for AI add #93).
+# CLI subprocess discovery (`claude` / `agy` / `codex` on PATH for AI add #93).
 which = "8.0.5"
 
 # Self-update (`rvpm self-update`, background auto-update / check banner) — #125
@@ -59,7 +59,11 @@ unicode-width = "0.2.2"
 ansi-to-tui = "8.0.1"
 # `[options.store.readme_command]` で spawn する外部プロセスのタイムアウト。
 wait-timeout = "0.2.1"
-# 外部 renderer に `{file_path}` を渡す場合の一時ファイル作成。
+# 一時ファイル作成: 外部 renderer に `{file_path}` を渡す場合と、agy backend の
+# prompt 受け渡し (`agy -p "@<path>"`)。後者は prompt に user の config.toml と
+# plugin README がそのまま載るので、名前が当てられる temp file だと symlink を
+# 先回りで張られて無関係なファイルを潰されうるし、default perms のままだと
+# 同一ホストの他 user から読める。生成は tempfile に任せて両方塞ぐ。
 tempfile = "3.27.0"
 
 # HTTP client (for store)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ for fully isolated test configs.
 | `fetch_interval` | duration string (`"6h"`, `"30m"`, `"45s"`, `"1d"`, `"0"`) | `"6h"` | Per-plugin fetch cache window. `sync` skips `git fetch` for plugins pulled within the last *fetch_interval*. Accepted units: `s` / `m` / `h` / `d`. Set to `"0"` to disable caching (pre-v3.19 behavior). Override per-run with `rvpm sync --refresh` / `--no-refresh` |
 | `cooldown` | duration string (`"1d"`, `"12h"`, `"0"`) | `"1d"` (**on by default**) | **Supply-chain cooldown** (minimum release age): `rvpm update` won't advance a plugin to a commit until rvpm has *first observed* it for at least this long (or the commit itself is older than the window). Malicious commits are typically detected and reverted within hours-to-days, so even `"1d"` skips most attack windows — same idea as npm/pnpm `minimumReleaseAge` (pnpm 11 also defaults to 1 day). While the tip is too fresh, update advances to the newest already-matured observed commit instead, so active plugins still move forward (delayed by the cooldown). Set `"0"` to disable. Explicit `rev` pins, `dev` plugins, and first installs are exempt. Per-plugin override: `[[plugins]] cooldown = "..."` (`"0"` opts a plugin out). Bypass once with `rvpm update --no-cooldown`. See [Advanced → Supply-chain cooldown](#advanced) |
 | `auto_lazy` | `"ask"` \| `"always"` \| `"never"` | `"ask"` | How `rvpm add` (and `rvpm browse → Enter`) handles the post-clone scan that looks for `nvim_create_user_command` / keymaps in the plugin's `plugin/` + `ftplugin/` + `after/plugin/` + `lua/` dirs. `"ask"` (default) prompts interactively on TTY and skips silently on non-TTY. `"always"` accepts the suggestion unconditionally. `"never"` skips the scan entirely. Per-call override via `--auto-lazy` / `--no-lazy` on `rvpm add`. Accepted suggestions cluster commands by 3-char LCP (3+ char shared prefix becomes `/^Prefix/` regex so future commands in that family auto-load) and enumerate keymaps (maps don't LCP well). **Ignored when `ai != "off"`** — the AI handles the design end-to-end |
-| `ai` | `"off"` \| `"claude"` \| `"gemini"` \| `"codex"` \| `"opencode"` | `"off"` | Use an AI CLI to design the full `[[plugins]]` block (plus per-plugin hook files) on `rvpm add`. The chosen CLI must already be installed and authenticated (`claude login`, `gemini auth`, etc.) — rvpm doesn't manage API keys. When set, the static-scan + auto-lazy path is skipped entirely. After the AI proposes, you can apply, refine via chat, hand off to the native CLI for free-form follow-up, or skip. Per-call override via `--ai <backend>` / `--no-ai` on `rvpm add` |
+| `ai` | `"off"` \| `"claude"` \| `"gemini"` \| `"agy"` \| `"codex"` \| `"opencode"` | `"off"` | Use an AI CLI to design the full `[[plugins]]` block (plus per-plugin hook files) on `rvpm add`. The chosen CLI must already be installed and authenticated (`claude login`, `agy` sign-in, etc.) — rvpm doesn't manage API keys. `"gemini"` is **deprecated** (Google retired Gemini CLI for personal accounts on 2026-06-18); use `"agy"` (Antigravity CLI, its successor). When set, the static-scan + auto-lazy path is skipped entirely. After the AI proposes, you can apply, refine via chat, hand off to the native CLI for free-form follow-up, or skip. Per-call override via `--ai <backend>` / `--no-ai` on `rvpm add` |
 | `ai_language` | string | `"en"` | Natural language for the AI's `<rvpm:explanation>` body and chat replies. The XML tag structure itself is always English so parsing stays predictable. Accepts BCP-47-ish codes (`"en"`, `"ja"`, `"zh"`, `"de"`) or free-form names |
 | `auto_update` | `"off"` \| `"notify"` \| `"install"` | `"install"` | Background self-update behaviour, run at the start of every command. `"install"` (default) silently downloads and swaps in a newer rvpm binary; the running process keeps the old binary and the new version takes effect on the next launch (a one-line `✓ rvpm X installed — restart to apply.` is printed to stderr when an update lands). `"notify"` only prints a banner pointing at `rvpm self-update` (never installs). `"off"` disables it entirely. Updates are serialised across processes by an OS advisory lock; dev builds are never overwritten; network failures / rate limits are silently swallowed (resilience). The env var `RVPM_NO_AUTOUPDATE=1` force-disables it regardless of config. **Deprecated:** the old `auto_update_check` boolean still works as an alias (`true` → `"notify"`, `false` → `"off"`) but emits a warning — migrate to `auto_update` |
 | `auto_update_check` | `boolean` | *(deprecated)* | Deprecated alias for `auto_update`. `true` maps to `"notify"`, `false` maps to `"off"`. Ignored (with a warning) when `auto_update` is also set. Kept so configs that disabled updates don't silently flip to auto-installing |
@@ -404,16 +404,22 @@ on_map = [
 </details>
 
 <details>
-<summary><b>AI-powered <code>rvpm add</code> (claude / gemini / codex / opencode)</b></summary>
+<summary><b>AI-powered <code>rvpm add</code> (claude / agy / codex / opencode)</b></summary>
 
 Set `options.ai` to a CLI you have installed and authenticated, and `rvpm add`
 delegates the design of the `[[plugins]]` entry to the AI:
 
 ```toml
 [options]
-ai = "claude"           # "off" (default) | "claude" | "gemini" | "codex" | "opencode"
+ai = "claude"           # "off" (default) | "claude" | "agy" | "codex" | "opencode" | "gemini" (deprecated)
 ai_language = "en"      # explanation language; structural output stays English
 ```
+
+> **`gemini` is deprecated.** Google retired Gemini CLI for Free / AI Pro /
+> Ultra personal accounts on 2026-06-18 in favour of **Antigravity CLI**
+> (`agy`). The backend is kept because paid Google Cloud API keys and
+> Enterprise licences still work against it, but rvpm prints a one-time
+> migration notice when you select it. Use `ai = "agy"` instead.
 
 Or per-call: `rvpm add owner/repo --ai claude`. The flag overrides the config
 value for that one invocation; `--no-ai` forces the static-scan path.
@@ -424,7 +430,11 @@ What it does:
 2. Builds a prompt from rvpm's TOML schema, the plugin's `README` + `doc/`,
    your current `config.toml` + `plugins/` tree, and any **existing
    per-plugin hook files** already on disk.
-3. Invokes the chosen CLI one-shot (`claude -p` / `gemini -p` / `codex exec` / `opencode -p`).
+3. Invokes the chosen CLI one-shot (`claude -p` / `codex exec` / `opencode run`,
+   all reading the prompt from stdin). `agy` is the exception: its `-p` takes the
+   prompt as a flag value and never reads stdin, so rvpm writes the prompt to a
+   temp file and passes `agy -p "@<path>"` (the prompt grows past the Windows
+   32 KB command-line limit, so it can't be inlined as an argument).
 4. Parses the response (XML tags `<rvpm:plugin_entry>`, `<rvpm:init_lua>`,
    `<rvpm:before_lua>`, `<rvpm:after_lua>`, `<rvpm:explanation>`, plus
    `<rvpm:..._merged>` variants when existing content was provided).
@@ -484,7 +494,7 @@ flow to an existing entry:
 ```bash
 rvpm tune                       # interactive picker
 rvpm tune telescope             # fuzzy match on URL
-rvpm tune folke/snacks.nvim --ai gemini
+rvpm tune folke/snacks.nvim --ai agy
 ```
 
 The AI sees your **current `[[plugins]]` block**, the cloned plugin's

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -1,11 +1,11 @@
 // AI-assisted `rvpm add` (#93).
 //
 // このモジュールは静的 scan (#90, plugin_scan.rs) の代わりに外部 AI CLI
-// (claude / gemini / codex) を呼んで `[[plugins]]` 全体 + 必要な hook ファイル
-// を提案させる。設計トレードオフ:
+// (claude / agy / codex / opencode) を呼んで `[[plugins]]` 全体 + 必要な hook
+// ファイルを提案させる。設計トレードオフ:
 //
-//   - **CLI subprocess 経由**: API key 管理を user の `claude login` / `gemini auth`
-//     に委ねる。SDK 直叩きより薄く保ち、3 ツール統一インターフェース。
+//   - **CLI subprocess 経由**: API key 管理を user の `claude login` / `agy` の
+//     sign-in に委ねる。SDK 直叩きより薄く保ち、全ツール統一インターフェース。
 //   - **構造化出力**: AI 出力は `<rvpm:plugin_entry>` 等の XML tag で囲ませ、
 //     code fence や前置きが混ざっても robust に regex 抽出する。
 //   - **Mode A (内蔵 chat loop)** がメイン路: rvpm が会話履歴を保持し毎ターン
@@ -31,7 +31,16 @@ pub use chat::{ChatOutcome, run_ai_add, run_ai_tune};
 #[serde(rename_all = "lowercase")]
 pub enum Backend {
     Claude,
+    /// **Deprecated**: Google は 2026-06-18 に Free / AI Pro / Ultra の個人
+    /// アカウント向け Gemini CLI 提供を終了し、後継を Antigravity CLI
+    /// (`agy`, [`Backend::Agy`]) とした。有料 Google Cloud API key と
+    /// Enterprise ライセンスでは引き続き動くので backend 自体は残すが、
+    /// 選択時に一度だけ移行を促す (`warn_if_deprecated`)。
     Gemini,
+    /// Antigravity CLI (`agy`) — Gemini CLI の後継。Go 実装で、`-p` は
+    /// **stdin を読まない** ため prompt 受け渡しだけ他 backend と異なる
+    /// ([`PromptDelivery::FileRef`])。
+    Agy,
     Codex,
     Opencode,
 }
@@ -47,6 +56,7 @@ impl TryFrom<crate::config::AiBackend> for Backend {
         match value {
             crate::config::AiBackend::Claude => Ok(Backend::Claude),
             crate::config::AiBackend::Gemini => Ok(Backend::Gemini),
+            crate::config::AiBackend::Agy => Ok(Backend::Agy),
             crate::config::AiBackend::Codex => Ok(Backend::Codex),
             crate::config::AiBackend::Opencode => Ok(Backend::Opencode),
             crate::config::AiBackend::Off => Err(()),
@@ -60,6 +70,7 @@ impl Backend {
         match self {
             Backend::Claude => "claude",
             Backend::Gemini => "gemini",
+            Backend::Agy => "agy",
             Backend::Codex => "codex",
             Backend::Opencode => "opencode",
         }
@@ -77,9 +88,28 @@ impl Backend {
         match self {
             Backend::Claude => "Claude",
             Backend::Gemini => "Gemini",
+            Backend::Agy => "Antigravity",
             Backend::Codex => "Codex",
             Backend::Opencode => "OpenCode",
         }
+    }
+}
+
+/// 廃止予定の backend を選んだ user に一度だけ移行を促す。
+///
+/// `ensure_cli_installed` が oneshot / handoff 双方の入口なのでそこから呼ぶ。
+/// chat loop は毎ターン `invoke_oneshot` を呼ぶため、`Once` で 1 プロセス
+/// 1 回に絞らないと会話中ずっと同じ警告が出続ける。
+fn warn_if_deprecated(backend: Backend) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    if matches!(backend, Backend::Gemini) {
+        WARNED.call_once(|| {
+            eprintln!(
+                "\u{26a0}\u{fe0f}  `gemini` is deprecated: Google retired Gemini CLI for Free / \
+                 AI Pro / Ultra personal accounts on 2026-06-18. Paid Google Cloud API keys and \
+                 Enterprise licences still work. Switch with `--ai agy` (or `ai = \"agy\"`)."
+            );
+        });
     }
 }
 
@@ -197,6 +227,7 @@ pub struct Proposal {
 
 /// AI CLI が PATH に無いときのエラー (install hint 込み)。
 pub fn ensure_cli_installed(backend: Backend) -> Result<()> {
+    warn_if_deprecated(backend);
     if backend.is_available() {
         return Ok(());
     }
@@ -204,6 +235,7 @@ pub fn ensure_cli_installed(backend: Backend) -> Result<()> {
     let hint = match backend {
         Backend::Claude => "https://docs.claude.com/claude-code",
         Backend::Gemini => "https://ai.google.dev/gemini-api/docs/cli",
+        Backend::Agy => "https://antigravity.google/cli",
         Backend::Codex => "https://github.com/openai/codex",
         Backend::Opencode => "https://opencode.ai",
     };
@@ -212,8 +244,115 @@ pub fn ensure_cli_installed(backend: Backend) -> Result<()> {
     ))
 }
 
+/// prompt を CLI にどう渡すか。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptDelivery {
+    /// stdin に書いて close する (claude / gemini / codex / opencode)。
+    Stdin,
+    /// temp file に書き、`@<path>` 参照を引数で渡す (agy)。
+    FileRef,
+}
+
+/// backend ごとの prompt 受け渡し方式。
+///
+/// agy (Antigravity CLI) だけ `FileRef`。Go 実装なので `-p` は値必須で、
+/// `-p -` は `-` という **literal な prompt** として解釈され stdin は読まれない
+/// (v1.1.7 で実測)。かといって prompt を引数へ直に載せると、chat 2 turn 目以降は
+/// 50-100KB に育つ一方 Windows の `CreateProcess` は command line 全体で 32767
+/// 文字が上限なので破綻する。そこで temp file に書き、agy の `@<path>` context
+/// 構文で参照させる。agy は v1.1.6 から system temp dir への読み取りを既定で
+/// 許可しているので、非対話実行の途中で permission prompt に捕まることはない。
+fn prompt_delivery(backend: Backend) -> PromptDelivery {
+    match backend {
+        Backend::Agy => PromptDelivery::FileRef,
+        Backend::Claude | Backend::Gemini | Backend::Codex | Backend::Opencode => {
+            PromptDelivery::Stdin
+        }
+    }
+}
+
+/// 「one-shot non-interactive で prompt を投げ、結果を stdout に出す」起動引数。
+///
+/// `prompt_path` は [`PromptDelivery::FileRef`] backend では **必須**、
+/// [`PromptDelivery::Stdin`] backend では無視される。
+///
+/// FileRef で path を渡し忘れた場合に空参照 `-p @` を組み立ててしまうと、agy は
+/// 「`@` というファイルが無い」とは言わず **文脈の無い prompt として普通に応答
+/// する** ため、rvpm 側は tag 抽出に失敗するまで異常に気付けない。この不変条件
+/// 自体は `invoke_oneshot` が守っているが、FileRef backend が増えたときや
+/// `prompt_file` の構築順を動かしたときに黙って壊れないよう、ここで明示的に
+/// エラーにしておく。
+fn oneshot_args(backend: Backend, prompt_path: Option<&Path>) -> Result<Vec<String>> {
+    let args = match backend {
+        // claude / gemini: `-p -` で stdin から prompt を読む
+        Backend::Claude | Backend::Gemini => vec!["-p".into(), "-".into()],
+        // codex: `codex exec -` (ver 依存で `codex -p` のこともある)
+        Backend::Codex => vec!["exec".into(), "-".into()],
+        // opencode: `opencode run` で stdin から読み取り
+        Backend::Opencode => vec!["run".into()],
+        // agy: `agy -p "@<path>"` — `@` が agy の file-context 参照構文
+        Backend::Agy => {
+            let path = prompt_path.ok_or_else(|| {
+                anyhow!(
+                    "internal error: backend `{}` delivers its prompt by file reference \
+                     but no prompt path was provided",
+                    backend.cli_name()
+                )
+            })?;
+            vec!["-p".into(), format!("@{}", path.display())]
+        }
+    };
+    Ok(args)
+}
+
+/// [`PromptDelivery::FileRef`] 用の一時 prompt ファイル。drop で削除される。
+///
+/// 生成を `tempfile` に委ねるのは、名前が当てられる temp file を避けるため
+/// (CodeRabbit 指摘)。prompt には user の `config.toml` と plugin README が
+/// そのまま載るので:
+///
+/// - `pid + 連番` のような予測可能な名前だと、共有 temp dir に先回りで symlink を
+///   張られたとき `fs::write` が無関係なファイルを潰しうる。
+/// - default perms のまま置くと同一ホストの他 user から中身を読める。
+///
+/// `tempfile` は `O_EXCL` 相当 + owner-only perms で作るので両方塞がる。
+///
+/// **ハンドルは開いたまま保持する**: agy が読む前に消えないよう、この struct が
+/// 生きている間はファイルも生きている必要がある。tempfile は Windows でも
+/// share-read で開くため、別プロセスからの読み取りは妨げない (E2E テスト
+/// `agy_oneshot_round_trips_through_temp_file` で実証)。
+struct TempPromptFile {
+    inner: tempfile::NamedTempFile,
+}
+
+impl TempPromptFile {
+    /// prompt を安全な一時ファイルに書き出す。
+    fn write(prompt_text: &str) -> Result<Self> {
+        use std::io::Write;
+        let mut inner = tempfile::Builder::new()
+            .prefix("rvpm-ai-oneshot-")
+            .suffix(".md")
+            .tempfile()
+            .context("failed to create a temp file for the AI prompt")?;
+        inner
+            .write_all(prompt_text.as_bytes())
+            .context("failed to write the AI prompt to its temp file")?;
+        // flush してから CLI に渡す。BufWriter ではないので実質 no-op だが、
+        // 「子プロセスが読む時点で中身が揃っている」ことを明示しておく。
+        inner
+            .flush()
+            .context("failed to flush the AI prompt temp file")?;
+        Ok(Self { inner })
+    }
+
+    fn path(&self) -> &Path {
+        self.inner.path()
+    }
+}
+
 /// CLI を一発呼び出しモードで起動して prompt を投げ、応答を文字列で返す。
-/// stdin で prompt を渡す (shell escape & 長文対策)。
+/// prompt は stdin 経由 (shell escape & 長文対策)、agy のみ temp file 経由
+/// ([`prompt_delivery`] 参照)。
 ///
 /// **timeout**: 5 分 (300 秒)。当初 90 秒だったが、chat 2 turn 目以降は
 /// `build_followup_prompt` で `initial + prior_response + feedback` を全部
@@ -237,30 +376,31 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
         prompt_text.lines().count()
     );
 
-    // 各 CLI のフラグは「stdin から prompt を読み、結果を stdout に」のモードを選ぶ:
-    //   - claude: `claude -p` で one-shot non-interactive、stdin で prompt
-    //   - gemini: `gemini -p` 同様
-    //   - codex:  `codex exec`  (or `codex -p`、ver 依存)
-    //   - opencode: `opencode run` で stdin から読み取り
+    let delivery = prompt_delivery(backend);
+    // FileRef の場合だけ temp file を作る。guard は child の wait が終わるまで
+    // 生かす必要がある (先に drop すると agy が読む前にファイルが消える)。
+    let prompt_file = match delivery {
+        PromptDelivery::FileRef => Some(TempPromptFile::write(prompt_text)?),
+        PromptDelivery::Stdin => None,
+    };
+
     let mut cmd = Command::new(&resolved.program);
     cmd.args(&resolved.prefix_args);
-    match backend {
-        Backend::Claude | Backend::Gemini => {
-            cmd.arg("-p").arg("-");
-        }
-        Backend::Opencode => {
-            cmd.arg("run");
-        }
-        Backend::Codex => {
-            cmd.arg("exec").arg("-");
-        }
-    }
-    cmd.stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        // tokio Command の `kill_on_drop` は default false。timeout で future が
-        // drop されたとき子プロセスを残さないように true にする (CodeRabbit Critical)。
-        .kill_on_drop(true);
+    cmd.args(oneshot_args(
+        backend,
+        prompt_file.as_ref().map(|f| f.path()),
+    )?);
+    cmd.stdin(match delivery {
+        PromptDelivery::Stdin => std::process::Stdio::piped(),
+        // agy は stdin を読まないので開けない。piped のまま渡すと閉じ忘れで
+        // 待たれる余地が残るため、null で即 EOF にしておく。
+        PromptDelivery::FileRef => std::process::Stdio::null(),
+    })
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped())
+    // tokio Command の `kill_on_drop` は default false。timeout で future が
+    // drop されたとき子プロセスを残さないように true にする (CodeRabbit Critical)。
+    .kill_on_drop(true);
 
     let mut child = cmd.spawn().with_context(|| {
         format!(
@@ -270,6 +410,8 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
     })?;
 
     // stdin に prompt を書き込んで close (EOF を AI に伝える)。
+    // FileRef backend では stdin が null なので `take()` は None になり、この
+    // ブロックごと skip される。
     if let Some(mut stdin) = child.stdin.take() {
         stdin
             .write_all(prompt_text.as_bytes())
@@ -294,6 +436,10 @@ pub async fn invoke_oneshot(backend: Backend, prompt_text: &str) -> Result<Strin
             )
         })?
         .with_context(|| format!("AI CLI `{}` failed to produce output", backend.cli_name()))?;
+
+    // ここまで来れば CLI は prompt を読み終えている。明示 drop でファイルを消す
+    // (関数末尾までの暗黙 drop に頼ると、意図しない早期 return で寿命が読みづらい)。
+    drop(prompt_file);
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -442,7 +588,9 @@ pub fn should_emit_merged_with(backend: Backend, get_env: impl Fn(&str) -> Optio
     }
     match backend {
         Backend::Gemini => false,
-        Backend::Claude | Backend::Codex | Backend::Opencode => true,
+        // agy は gemini-cli とは別コードベース (Go 実装) で `_recoverFromLoop`
+        // を持たないため、Gemini の merged-OFF 特例は引き継がない。
+        Backend::Agy | Backend::Claude | Backend::Codex | Backend::Opencode => true,
     }
 }
 
@@ -453,8 +601,8 @@ enum FirstMessageStrategy {
     /// `<cli> "<msg>"` — positional arg で interactive を継続したまま最初の
     /// user message を送る。claude / codex / opencode 等。
     Positional,
-    /// `gemini -i "<msg>"` — `--prompt-interactive` 相当の short flag。
-    /// `-p` (non-interactive) と区別して対話継続する。
+    /// `gemini -i "<msg>"` / `agy -i "<msg>"` — `--prompt-interactive` 相当の
+    /// short flag。`-p` (non-interactive) と区別して対話継続する。
     InteractiveFlag,
     /// Auto-send が安全に出来ない backend 用フォールバック。argless で
     /// interactive 起動 + stderr に「コピペしてください」案内を出す。
@@ -469,7 +617,8 @@ fn first_message_strategy(backend: Backend) -> FirstMessageStrategy {
         // opencode: `opencode "<msg>"`
         Backend::Claude | Backend::Codex | Backend::Opencode => FirstMessageStrategy::Positional,
         // gemini: `gemini -i "<msg>"` (`-p` だと one-shot non-interactive)
-        Backend::Gemini => FirstMessageStrategy::InteractiveFlag,
+        // agy:    `agy -i "<msg>"` — `--prompt-interactive` の short alias で同形
+        Backend::Gemini | Backend::Agy => FirstMessageStrategy::InteractiveFlag,
     }
 }
 
@@ -711,6 +860,7 @@ mod tests {
         use crate::config::AiBackend as Cfg;
         assert_eq!(Backend::try_from(Cfg::Claude), Ok(Backend::Claude));
         assert_eq!(Backend::try_from(Cfg::Gemini), Ok(Backend::Gemini));
+        assert_eq!(Backend::try_from(Cfg::Agy), Ok(Backend::Agy));
         assert_eq!(Backend::try_from(Cfg::Codex), Ok(Backend::Codex));
         assert_eq!(Backend::try_from(Cfg::Opencode), Ok(Backend::Opencode));
         assert_eq!(Backend::try_from(Cfg::Off), Err(()));
@@ -725,6 +875,99 @@ mod tests {
         assert!(should_emit_merged_with(Backend::Codex, no_env));
         assert!(should_emit_merged_with(Backend::Opencode, no_env));
         assert!(!should_emit_merged_with(Backend::Gemini, no_env));
+        // agy は gemini-cli とは別実装 (Go) で `_recoverFromLoop` を持たないので、
+        // Gemini の merged-OFF 特例は引き継がない。
+        assert!(should_emit_merged_with(Backend::Agy, no_env));
+    }
+
+    #[test]
+    fn oneshot_args_per_backend() {
+        // stdin 経由の backend は prompt path を渡されても無視する。
+        assert_eq!(
+            oneshot_args(Backend::Claude, None).unwrap(),
+            vec!["-p", "-"]
+        );
+        assert_eq!(
+            oneshot_args(Backend::Gemini, None).unwrap(),
+            vec!["-p", "-"]
+        );
+        assert_eq!(
+            oneshot_args(Backend::Codex, None).unwrap(),
+            vec!["exec", "-"]
+        );
+        assert_eq!(oneshot_args(Backend::Opencode, None).unwrap(), vec!["run"]);
+        // agy は stdin を読まないので `@<path>` 参照で渡す。
+        assert_eq!(
+            oneshot_args(Backend::Agy, Some(Path::new("/tmp/p.md"))).unwrap(),
+            vec!["-p", "@/tmp/p.md"]
+        );
+    }
+
+    #[test]
+    fn oneshot_args_errors_when_file_ref_backend_has_no_path() {
+        // 空参照 `-p @` を組み立てると agy は「文脈の無い prompt」として普通に
+        // 応答してしまい、静かに誤動作する。loud に落ちることを固定する。
+        let err = oneshot_args(Backend::Agy, None).unwrap_err().to_string();
+        assert!(err.contains("agy"), "unexpected error message: {err}");
+        assert!(
+            !oneshot_args(Backend::Agy, Some(Path::new("/tmp/p.md")))
+                .unwrap()
+                .contains(&"@".to_string()),
+            "empty `@` reference must never be produced"
+        );
+    }
+
+    #[test]
+    fn prompt_delivery_is_file_ref_only_for_agy() {
+        assert_eq!(prompt_delivery(Backend::Agy), PromptDelivery::FileRef);
+        for b in [
+            Backend::Claude,
+            Backend::Gemini,
+            Backend::Codex,
+            Backend::Opencode,
+        ] {
+            assert_eq!(prompt_delivery(b), PromptDelivery::Stdin);
+        }
+    }
+
+    #[test]
+    fn temp_prompt_file_writes_then_deletes_on_drop() {
+        let path = {
+            let f = TempPromptFile::write("hello prompt").expect("write temp prompt");
+            // ハンドルを保持したままでも中身が読めること (agy が読む前提)。
+            assert_eq!(std::fs::read_to_string(f.path()).unwrap(), "hello prompt");
+            f.path().to_path_buf()
+        };
+        assert!(!path.exists(), "temp prompt file should be removed on drop");
+    }
+
+    #[test]
+    fn temp_prompt_file_names_are_unique_within_a_process() {
+        // chat loop は 1 プロセスで何度も呼ぶので、名前が被ると後続の呼び出しが
+        // 前の prompt を上書き/共有してしまう。
+        let a = TempPromptFile::write("a").unwrap();
+        let b = TempPromptFile::write("b").unwrap();
+        assert_ne!(a.path(), b.path());
+    }
+
+    /// agy backend の実 subprocess 経路 (temp file 書き出し → `@<path>` 参照 →
+    /// stdout 回収) を通しで確認する。
+    ///
+    /// `agy` の install と sign-in が要るので通常の `cargo test` からは外す。
+    /// 手動実行: `cargo test -- --ignored --nocapture agy_oneshot`
+    #[tokio::test]
+    #[ignore = "requires an installed, authenticated `agy` on PATH"]
+    async fn agy_oneshot_round_trips_through_temp_file() {
+        let prompt = "Reply with EXACTLY this line and nothing else, and do not \
+                      edit any files:\n<rvpm:explanation>ok</rvpm:explanation>";
+        let out = invoke_oneshot(Backend::Agy, prompt)
+            .await
+            .expect("agy one-shot invocation");
+        assert_eq!(
+            extract_tag(&out, "explanation").map(|s| s.trim().to_string()),
+            Some("ok".to_string()),
+            "unexpected agy response: {out}"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,9 +156,10 @@ enum Commands {
         no_lazy: bool,
 
         /// AI backend for this `add`. Replaces the static-scan + auto-lazy path:
-        /// the chosen CLI (`claude` / `gemini` / `codex`) reads the plugin's
-        /// README + your config and proposes the full `[[plugins]]` block plus
-        /// any per-plugin hook files. Overrides `options.ai` for this call.
+        /// the chosen CLI (`claude` / `agy` / `codex` / `opencode`) reads the
+        /// plugin's README + your config and proposes the full `[[plugins]]`
+        /// block plus any per-plugin hook files. Overrides `options.ai` for this
+        /// call. `gemini` is deprecated — prefer `agy`, its successor.
         #[arg(long, value_enum, conflicts_with = "no_ai")]
         ai: Option<crate::config::AiBackend>,
 
@@ -193,6 +194,7 @@ enum Commands {
         query: Option<String>,
 
         /// AI backend for this `tune`. Overrides `options.ai` for this call.
+        /// `gemini` is deprecated — prefer `agy`, its successor.
         #[arg(long, value_enum, conflicts_with = "no_ai")]
         ai: Option<crate::config::AiBackend>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,8 +231,14 @@ pub enum AiBackend {
     Off,
     /// Spawn the `claude` CLI as a subprocess.
     Claude,
-    /// Spawn the `gemini` CLI as a subprocess.
+    /// Spawn the `gemini` CLI as a subprocess (deprecated — see `agy`).
+    ///
+    /// Google retired Gemini CLI for Free / AI Pro / Ultra personal accounts on
+    /// 2026-06-18 in favour of Antigravity CLI (`agy`). Kept because paid Google
+    /// Cloud API keys and Enterprise licences still work against it.
     Gemini,
+    /// Spawn the `agy` (Antigravity) CLI as a subprocess — the Gemini CLI successor.
+    Agy,
     /// Spawn the `codex` CLI as a subprocess.
     Codex,
     /// Spawn the `opencode` CLI as a subprocess.


### PR DESCRIPTION
## Why

Google retired Gemini CLI for Free / AI Pro / Ultra personal accounts on
**2026-06-18** and replaced it with **Antigravity CLI (`agy`)**.

`gemini` is kept rather than removed — paid Google Cloud API keys and Enterprise
licences still work against the legacy CLI — but selecting it now prints a
one-time migration notice.

## The interesting part: `agy` cannot take the prompt on stdin

Every other backend gets its prompt piped to stdin. `agy` cannot:

- Its `-p` is a Go `flag` that **requires a value**, and `-p -` is parsed as the
  literal prompt `-` (stdin is never read). Verified on v1.1.7.
- Inlining the prompt as an argument does not scale: chat follow-up prompts grow
  to 50–100 KB, while Windows caps a whole command line at 32767 chars.

So rvpm writes the prompt to a temp file and passes `agy -p "@<path>"` using
agy's file-context syntax. agy has granted read access to the system temp dir by
default since v1.1.6, so this does not trip a permission prompt mid-run. The
temp file is deleted on drop.

This is modelled as a `PromptDelivery` split (`Stdin` vs `FileRef`) so the
per-backend difference stays in one place instead of leaking into `invoke_oneshot`.

## Other backend-specific wiring

| Aspect | Choice | Reason |
|---|---|---|
| `should_emit_merged` | `agy` → ON (the default) | The Gemini merged-OFF case exists for gemini-cli v0.39's `_recoverFromLoop` loop guard. agy is a separate Go implementation and does not carry it. |
| `first_message_strategy` | `InteractiveFlag` | `agy -i "<msg>"` matches gemini's shape (`--prompt-interactive` short alias). |
| install hint | `https://antigravity.google/cli` | |

## Verification

- `cargo make check` — 893 tests pass, clippy + rustfmt + lock-check clean.
- New unit tests: arg builder per backend, delivery-strategy split, temp-file
  write/uniqueness/cleanup-on-drop.
- New `#[ignore]`d end-to-end test driving a **real `agy` subprocess** through
  the actual `invoke_oneshot` path (`cargo test -- --ignored agy_oneshot`) —
  passes locally against agy v1.1.7.
- Separately verified that `@<path>` reads the file **in full**: a 181 KB prompt
  file returned both its head and tail markers, so rvpm-sized prompts are safe.

## Note on public issue reports

Upstream issues [#76](https://github.com/google-antigravity/antigravity-cli/issues/76)
(stdout dropped under non-TTY) and [#318](https://github.com/google-antigravity/antigravity-cli/issues/318)
(print mode hangs headless) would both be fatal here. Neither reproduces on
v1.1.7 — piped/subprocess invocations return stdout and exit 0 in every check
above. The reports are against v1.0.0 / v1.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKN1kShkv3DgPn9rAdabNf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity (`agy`) as a supported AI backend.
  * Added backend-specific prompt handling for `agy`.
  * Updated AI-powered commands to support `agy`.

* **Documentation**
  * Marked Gemini CLI as deprecated and documented migration guidance to `agy`.
  * Updated configuration references, supported backend lists, and usage examples.

* **Bug Fixes**
  * Improved hook file handling when files are removed or overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->