### PR TITLE
chore: release v3.43.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rvpm"
-version = "3.42.1"
+version = "3.43.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.42.1"
+version = "3.43.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Release v3.43.0.

Minor bump — this release adds a new AI backend.

## Highlights

**`agy` (Antigravity CLI) is now a supported `options.ai` backend** (#309). Google
retired Gemini CLI for Free / AI Pro / Ultra personal accounts on 2026-06-18 and
replaced it with Antigravity CLI. `gemini` still works (paid Google Cloud API keys
and Enterprise licences are unaffected) but is deprecated and now prints a one-time
migration notice.

```toml
[options]
ai = "agy"
```

Version-bump-only PR: the entire diff is `package.version` + `Cargo.lock`, so the
bot-review gate does not apply per AGENTS.md. On merge, `auto-tag.yml` pushes the
`v3.43.0` tag, which fires `release.yml` for the binary builds and the crates.io
publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKN1kShkv3DgPn9rAdabNf