### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,6 +45,30 @@ name: claude-review
 #    Pay-as-you-go alternative: store `ANTHROPIC_API_KEY` instead
 #    and swap the input below to `anthropic_api_key`.
 #
+# The credential check below exists because step 2 fails SILENTLY
+# otherwise: handed an empty token, claude-code-action exits 0
+# without posting anything, so the check turns green and the PR
+# looks reviewed when nothing ran. That is worse than a red X — it
+# went unnoticed on yukimemi/rvpm.nvim until the run log was read
+# by hand. Fail loudly instead.
+#
+# EXPECTED whenever a PR's copy of this file differs from the one
+# on the default branch: the action logs "Skipping action due to
+# workflow validation" and exits 0 without reviewing.
+# claude-code-action requires byte-identical content on the default
+# branch, otherwise a PR could rewrite the workflow to exfiltrate
+# the token. Two cases hit it:
+#   1. the PR that first adopts these templates, and
+#   2. any later PR that EDITS this file — e.g. hand-pulling an
+#      upstream fix into a consumer repo.
+# The second is the surprising one and reads like a regression; it
+# is not. Either way the check is green with no review attached.
+# Nothing to fix; merge on CI + owner approval, and reviews resume
+# on the next PR that leaves the workflows alone.
+#
+# Telling the two silent-green cases apart: no credential -> RED
+# (the guard below), workflow validation -> GREEN with no review.
+#
 # `when = "always"` (in template.toml): every consumer wants
 # identical review behaviour; fixes to the workflow itself flow
 # automatically on next apply.
@@ -82,6 +106,30 @@ jobs:
     # GHA's 360-minute default.
     timeout-minutes: 30
     steps:
+      # Fail fast when the consumer never set a credential. Without
+      # this the run is a green no-op (see header) — the one failure
+      # mode of this workflow that produces no visible signal at all.
+      #
+      # Accepts EITHER credential: `CLAUDE_CODE_OAUTH_TOKEN` (the
+      # subscription path this workflow wires up by default) or
+      # `ANTHROPIC_API_KEY` (the pay-as-you-go path the header
+      # documents, where the consumer also swaps the input below to
+      # `anthropic_api_key`). Checking only the former would hard-fail
+      # a consumer who followed the documented alternative.
+      #
+      # Read via env rather than inlining the expressions into the
+      # script, so the values are never substituted into the shell
+      # source.
+      - name: Check review credentials
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ] && [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "::error title=claude-review is not configured::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set on ${{ github.repository }}. Subscription path: generate a token with 'claude setup-token' and store it with 'gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo ${{ github.repository }}'. Pay-as-you-go path: set ANTHROPIC_API_KEY instead and swap the action input to anthropic_api_key. Either way, also install the Claude GitHub App (github.com/apps/claude). Until then no PR in this repo is being reviewed."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,26 @@ jobs:
     # GHA's 360-minute default.
     timeout-minutes: 30
     steps:
+      # Same guard as claude-review.yml.tera: an empty credential
+      # makes claude-code-action exit 0 without responding, so a
+      # mention would silently go unanswered with a green check next
+      # to it. Accepts either `CLAUDE_CODE_OAUTH_TOKEN` (subscription)
+      # or `ANTHROPIC_API_KEY` (pay-as-you-go, where the consumer also
+      # swaps the input below to `anthropic_api_key`).
+      #
+      # Read via env rather than inlining the expressions into the
+      # script, so the values are never substituted into the shell
+      # source.
+      - name: Check responder credentials
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ] && [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "::error title=claude responder is not configured::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set on ${{ github.repository }}. Subscription path: generate a token with 'claude setup-token' and store it with 'gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo ${{ github.repository }}'. Pay-as-you-go path: set ANTHROPIC_API_KEY instead and swap the action input to anthropic_api_key. Until then @claude mentions in this repo go unanswered."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 1

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-07-26T04:26:42.007095063Z"
+applied_at = "2026-07-27T04:29:12.015304731Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "8226510d21d7211eec3ce4fd03e18915a4e0326e"
+rev = "937c2e75f75e20fe40554a50b4977926590e2ef8"
 version = "0.13.0"
 
 [[templates]]
@@ -41,10 +41,10 @@ content_hash = "406943795e69542d92d37a0d70051f22a899956dc0cbd1d70ebc16aea13d655a
 content_hash = "917be127933843d794f8f3074472b8d9e90cdb22ec90c025b5a8aa2607d1778f"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "8804c503c1960abdda86578c0bb0bdd727daf41c0d482975d45947d27768b2ec"
+content_hash = "9a01bd5fc1f418da1da9a304e86a780989e22ef05375d05d4e73b90c2e282817"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "81eb918f932e08a95f3deb8e64c13e57976691bc5723c4d7cb56501d6566994c"
+content_hash = "615406a64ab9faed907078fee7c31d17812d893f2d84c48dcec71c2456716c3f"
 
 [files.".github/workflows/kata-apply.yml"]
 content_hash = "45e8fc324f046621343be84f99ed8f3a338fa6d0ea007e87f5ce0c81b0ae2335"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,32 @@ here so each tool's auto-load behaviour still finds something.
   `chore/release-*`, `kata-apply/auto`, `apm-bump/auto`, and
   Renovate / Dependabot authors) — a missing Claude review on
   those PRs is expected, not a failure.
+- **Any PR that touches the Claude workflow files goes
+  unreviewed.** `claude-code-action` requires the workflow file to
+  already exist on the default branch **with identical content** —
+  otherwise a PR could rewrite the workflow to exfiltrate the
+  token. When the content differs it logs "Skipping action due to
+  workflow validation" and exits 0 without reviewing: a green
+  check with no review attached. This covers two cases, and the
+  second is the one that keeps surprising people:
+  - the PR that first adopts these templates (the workflow does
+    not exist on the default branch yet), and
+  - any later PR that **edits** `claude-review.yml` / `claude.yml`,
+    e.g. hand-pulling an upstream template fix.
+
+  Not fixable from this side — it is the mechanism that makes the
+  token safe to hand to the action at all. Expected: merge on CI +
+  owner approval; reviews resume on the next PR that leaves the
+  workflows alone. The `kata-apply/auto` branch is already excluded
+  by the job-level `if:`, so the daily template-refresh PRs do not
+  add noise here.
+- **A missing credential fails loudly instead.** If the repo has
+  neither `CLAUDE_CODE_OAUTH_TOKEN` nor `ANTHROPIC_API_KEY` set,
+  the guard step fails the job — set one and re-run (subscription
+  path: `claude setup-token` → `gh secret set`; pay-as-you-go:
+  store `ANTHROPIC_API_KEY` and swap the action input to
+  `anthropic_api_key`). Distinguishing the two: **red** means no
+  credential, **green with no review** means workflow validation.
 - **The Claude full review fires once, at PR open** (plus
   `ready_for_review` / `reopened`) — fix pushes do **not** re-trigger
   it (`synchronize` is deliberately off the trigger list; a full


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->