### PR TITLE
feat(git): recover from stale lockfile pins and broken clones on sync

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,22 @@ Implementation notes:
 - `LockFile::save` performs a stable sort by name → minimizes dotfile diffs.
 - Malformed / missing files emit a warning on stderr and fall back to an empty
   LockFile (resilience).
+- **Shallow-clone recovery** (`checkout_with_pin_fetch_retry` in `src/git.rs`):
+  clones are depth 1 and fetches only `Deepen(1)`, so a lockfile pin more than
+  ~2 commits behind the remote tip is absent from the local object DB — e.g.
+  right after the user deletes `repos/` and re-syncs (fresh depth-1 clone vs.
+  an old lockfile pin). When checkout fails for a full 40-hex SHA, rvpm fetches
+  just that commit from origin (object-id want, equivalent to
+  `git fetch origin <sha>`, done in-process via a one-sided gix refspec) and
+  retries the checkout. Requires the server to allow SHA wants (GitHub allows
+  it for reachable commits); if the fetch also fails, the original
+  `rev '<sha>' not found` error is returned. Non-SHA revs (branch / tag /
+  `/regex/`) never trigger the retry and fail as before.
+- **Broken-clone recovery** (`sync_impl`): if `repos/<plug>/` exists but has no
+  valid `.git` (e.g. partially deleted by hand), sync removes the leftover dir
+  and re-clones instead of failing with "does not appear to be a git
+  repository". The auto-remove applies to **remote URLs only** — a local-path
+  dst (potential dev / mirror dir) is never deleted and keeps the old error.
 - `dev = true` plugins are excluded from the lockfile (they are local
   works-in-progress, so pinning a commit hash is meaningless).
 - When `options.chezmoi = true`, the lockfile — like config.toml / hooks —

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -222,11 +222,11 @@ pub(crate) async fn run_generate(force: bool) -> Result<()> {
                     PluginMergeMode::ViewWithDoc => {}
                 }
             }
-            if let Some(s) = &merged_stamp {
-                if let Err(e) = crate::view_stamp::write(tmp_merged, s) {
-                    // stamp が書けなくても merged 自体は有効 — 次回 rebuild に倒れるだけ。
-                    eprintln!("\u{26a0} failed to write merged stamp: {}", e);
-                }
+            if let Some(s) = &merged_stamp
+                && let Err(e) = crate::view_stamp::write(tmp_merged, s)
+            {
+                // stamp が書けなくても merged 自体は有効 — 次回 rebuild に倒れるだけ。
+                eprintln!("\u{26a0} failed to write merged stamp: {}", e);
             }
             Ok(())
         });

--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -245,11 +245,11 @@ pub fn humanize_duration(d: Duration) -> String {
     if secs == 0 {
         return "0".to_string();
     }
-    if secs % 86400 == 0 {
+    if secs.is_multiple_of(86400) {
         format!("{}d", secs / 86400)
-    } else if secs % 3600 == 0 {
+    } else if secs.is_multiple_of(3600) {
         format!("{}h", secs / 3600)
-    } else if secs % 60 == 0 {
+    } else if secs.is_multiple_of(60) {
         format!("{}m", secs / 60)
     } else {
         format!("{}s", secs)

--- a/src/git.rs
+++ b/src/git.rs
@@ -182,6 +182,14 @@ fn resolve_url(url: &str) -> String {
     }
 }
 
+/// URL が remote (https://... / git@... / file://... 等) かどうか。
+/// local path (`/`, `~`, `.`, `\`, `C:\` 始まり) は false。判定ルールは
+/// `resolve_url` の local 判定と揃える。壊れた clone の自動削除が local path
+/// (= user の dev dir の可能性) を巻き込まないためのガードに使う。
+fn is_remote_url(url: &str) -> bool {
+    url.contains("://") || url.contains('@')
+}
+
 // ======================================================
 // clone / fetch — gix で in-process 実行
 // checkout — gix の checkout API は複雑なため git コマンドにフォールバック
@@ -190,11 +198,29 @@ fn resolve_url(url: &str) -> String {
 
 fn sync_impl(url: &str, dst: &Path, rev: Option<&str>) -> Result<Option<GitChange>> {
     if dst.exists() {
+        // `.git` が欠損した壊れた clone (disk 節約で dir だけ消した残骸、user
+        // 報告の LuaSnip ケース) は、このままだと fetch_impl が
+        // "does not appear to be a git repository" でコケるだけなので、ここで
+        // 検知して fresh clone に fall through させる。
+        // 削除は **remote URL の場合に限る** — local path URL の dst は user の
+        // dev 作業 dir の可能性があり絶対に消せない。なお dev = true プラグ
+        // インは run_sync / run_update が Repo::sync に到達する前に skip する
+        // ので通常この経路には来ない (非 dev の local-path plugin = ミラー等
+        // への保険ガード)。
+        let broken = !dst.join(".git").exists() || gix::open(dst).is_err();
+        if broken && is_remote_url(url) {
+            eprintln!(
+                "Warning: '{}' is not a valid git repository; removing it and re-cloning",
+                dst.display()
+            );
+            std::fs::remove_dir_all(dst)?;
+        }
+    }
+    if dst.exists() {
         let before = read_head(dst).ok();
         fetch_impl(dst)?;
         if let Some(rev) = rev {
-            let resolved = resolve_rev_for_checkout(dst, rev)?;
-            gix_checkout(dst, &resolved)?;
+            checkout_with_pin_fetch_retry(dst, rev)?;
         } else {
             gix_reset_to_remote(dst)?;
         }
@@ -213,8 +239,7 @@ fn sync_impl(url: &str, dst: &Path, rev: Option<&str>) -> Result<Option<GitChang
             // でも `refs/tags/*` として一緒に降りてくるので、resolve_rev_for_checkout
             // が local DB から正しい候補を選べる。
             fetch_impl(dst)?;
-            let resolved = resolve_rev_for_checkout(dst, rev)?;
-            gix_checkout(dst, &resolved)?;
+            checkout_with_pin_fetch_retry(dst, rev)?;
         }
         let after = read_head(dst)?;
         // 新規 clone は from = None。subjects は空のまま。
@@ -235,13 +260,84 @@ fn update_impl(_url: &str, dst: &Path, rev: Option<&str>) -> Result<Option<GitCh
     let before = read_head(dst).ok();
     fetch_impl(dst)?;
     if let Some(rev) = rev {
-        let resolved = resolve_rev_for_checkout(dst, rev)?;
-        gix_checkout(dst, &resolved)?;
+        checkout_with_pin_fetch_retry(dst, rev)?;
     } else {
         gix_reset_to_remote(dst)?;
     }
     let after = read_head(dst)?;
     Ok(build_change(dst, before, after))
+}
+
+/// `rev` を local DB で解決して checkout する。
+/// checkout 失敗時、`rev` (解決後) が **full 40 桁 lowercase hex SHA** (= rvpm.lock
+/// の pin commit) の場合に限り、その commit を origin から depth 1 で個別 fetch
+/// してから retry する。
+///
+/// 背景: clone は depth 1、fetch も Deepen(1) ずつなので、tip から 2 commit 以上
+/// 離れた pin commit は local DB に存在しない。user が clone dir を削除してから
+/// `rvpm sync` すると、再 clone 直後に rvpm.lock の古い commit へ checkout できず
+/// "rev '<sha>' not found" が大量発生した (user 報告)。
+///
+/// branch 名 / tag / `/regex/` pattern が失敗した場合は従来どおり即エラー
+/// (remote に無い branch を毎回 fetch しに行く等の無駄な往復を避ける)。
+fn checkout_with_pin_fetch_retry(dst: &Path, rev: &str) -> Result<()> {
+    let resolved = resolve_rev_for_checkout(dst, rev)?;
+    match gix_checkout(dst, &resolved) {
+        Ok(()) => Ok(()),
+        Err(e) if is_full_hex_sha(&resolved) => {
+            // pin commit だけを object id want で fetch してから retry。
+            // fetch 自体が失敗した場合 (remote に commit が存在しない、server が
+            // SHA want を許可していない等) は元の "rev not found" エラーに
+            // fetch 失敗の情報を添えて返す。
+            if let Err(fetch_err) = fetch_commit_by_sha(dst, &resolved) {
+                return Err(e.context(format!(
+                    "(also failed to fetch pinned commit from origin: {fetch_err:#})"
+                )));
+            }
+            gix_checkout(dst, &resolved)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// `s` が full 40 桁 lowercase hex SHA (= lockfile pin) かどうか。
+/// short SHA / 大文字混じりは対象外 (fetch-and-retry fallback は lockfile pin の
+/// ケースだけに限定する)。
+fn is_full_hex_sha(s: &str) -> bool {
+    s.len() == 40
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// 特定 commit を SHA 指定で depth 1 fetch する (`git fetch --depth 1 origin <sha>` 相当)。
+///
+/// **gix の in-process fetch で実現している理由**: gix-refspec は one-sided fetch
+/// refspec の src が full hex なら object id want として扱う
+/// (`match_group::util::Needle::Object` — `git fetch origin <sha>` と同じ protocol
+/// 上の振る舞い) ので、git CLI への shell out は不要。local ref は一切書かれず、
+/// object DB に commit だけが降りる (detached HEAD への checkout は
+/// `rev_parse_single(sha)` で直接解決できる)。
+///
+/// 注意: server 側が `uploadpack.allowAnySHA1InWant` (pin が ref から reachable なら
+/// `allowReachableSHA1InWant`) を許可していないと失敗する。GitHub は reachable
+/// commit の SHA fetch を許可している。test の local origin は git CLI の
+/// upload-pack を使うため `uploadpack.allowAnySHA1InWant true` が必要。
+fn fetch_commit_by_sha(dst: &Path, sha: &str) -> Result<()> {
+    let repo = gix::open(dst)?;
+    let remote = repo
+        .find_default_remote(gix::remote::Direction::Fetch)
+        .ok_or_else(|| anyhow::anyhow!("no remote configured"))??;
+    let spec = gix::refspec::parse(sha.into(), gix::refspec::parse::Operation::Fetch)
+        .map_err(|e| anyhow::anyhow!("failed to build refspec for pinned commit: {}", e))?
+        .to_owned();
+    let mut opts = gix::remote::ref_map::Options::default();
+    opts.extra_refspecs.push(spec);
+    remote
+        .connect(gix::remote::Direction::Fetch)?
+        .prepare_fetch(gix::progress::Discard, opts)?
+        .with_shallow(gix::remote::fetch::Shallow::Deepen(1))
+        .receive(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)?;
+    Ok(())
 }
 
 /// clone path の HEAD commit hash を同期 (in-process gix) で読む。
@@ -2655,6 +2751,203 @@ mod tests {
             err.to_string().contains("matched no parseable semver tag"),
             "actual: {}",
             err
+        );
+    }
+
+    // ─── shallow clone × lockfile pin 救済 (#shallow-pin-fallback) ──────────
+    // depth-1 clone + Deepen(1) fetch では tip から 2 commit 以上離れた pin
+    // commit が local DB に無い。checkout 失敗時に pin commit を object id
+    // want で個別 fetch して retry する fallback の回帰テスト群。
+
+    /// SHA fetch を許可する設定を origin repo に入れる。
+    /// gix の file transport は `git upload-pack` を spawn するが、git CLI の
+    /// upload-pack はデフォルトで非 advertise の SHA want を拒否する。
+    /// (GitHub は reachable commit の SHA fetch を許可しているので本番では
+    /// 問題にならないが、local origin のテストでは明示が必要。)
+    async fn allow_any_sha1_in_want(dir: &Path) {
+        git_cmd(dir)
+            .args(["config", "uploadpack.allowAnySHA1InWant", "true"])
+            .output()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sync_fetches_pinned_sha_missing_from_fresh_clone() {
+        // user 報告の再現: clone dir を削除 → rvpm sync が depth-1 で再 clone
+        // → rvpm.lock の古い pin commit が local DB に無く "rev not found"。
+        // fresh clone 経路でも fallback が発動して pin commit に checkout
+        // できることを確認。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        allow_any_sha1_in_want(&src).await;
+        let pinned = commit_to(&src, "v1", "init").await;
+        commit_to(&src, "v2", "bump-2").await;
+        let tip = commit_to(&src, "v3", "bump-3").await;
+
+        // depth-1 clone (= tip のみ) + fetch_impl の Deepen(1) (= 1 commit
+        // 深掘り) では pinned (2 commit 前) は降りてこない。
+        let repo = Repo::new(src.to_str().unwrap(), &dst, Some(pinned.as_str()));
+        repo.sync()
+            .await
+            .expect("sync must recover the pinned commit via per-SHA fetch");
+        assert_eq!(repo.head_commit().await.unwrap(), pinned);
+        assert_ne!(repo.head_commit().await.unwrap(), tip);
+        assert_eq!(fs::read_to_string(dst.join("hello.txt")).unwrap(), "v1");
+    }
+
+    #[tokio::test]
+    async fn test_sync_existing_clone_fetches_missing_pinned_sha() {
+        // 既存 clone 経路でも同じ fallback が効くこと。rev=None で sync した
+        // depth-1 clone (= tip のみ保持) に対し、2 commit 前の pin を指定して
+        // 再 sync すると、Deepen(1) だけでは pin commit は降りてこない。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        allow_any_sha1_in_want(&src).await;
+        let pinned = commit_to(&src, "v1", "init").await;
+        commit_to(&src, "v2", "bump-2").await;
+        commit_to(&src, "v3", "bump-3").await;
+
+        let repo = Repo::new(src.to_str().unwrap(), &dst, None);
+        repo.sync().await.unwrap();
+
+        let pinned_repo = Repo::new(src.to_str().unwrap(), &dst, Some(pinned.as_str()));
+        pinned_repo
+            .sync()
+            .await
+            .expect("existing clone must also recover the pinned commit");
+        assert_eq!(pinned_repo.head_commit().await.unwrap(), pinned);
+        assert_eq!(fs::read_to_string(dst.join("hello.txt")).unwrap(), "v1");
+    }
+
+    #[tokio::test]
+    async fn test_update_fetches_missing_pinned_sha() {
+        // update_impl 経路でも同じ fallback が効くこと。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        allow_any_sha1_in_want(&src).await;
+        let pinned = commit_to(&src, "v1", "init").await;
+        commit_to(&src, "v2", "bump-2").await;
+        commit_to(&src, "v3", "bump-3").await;
+
+        let repo = Repo::new(src.to_str().unwrap(), &dst, None);
+        repo.sync().await.unwrap();
+
+        let pinned_repo = Repo::new(src.to_str().unwrap(), &dst, Some(pinned.as_str()));
+        pinned_repo
+            .update()
+            .await
+            .expect("update must recover the pinned commit via per-SHA fetch");
+        assert_eq!(pinned_repo.head_commit().await.unwrap(), pinned);
+    }
+
+    #[tokio::test]
+    async fn test_sync_missing_branch_rev_keeps_original_error() {
+        // 40-hex SHA 以外 (branch 名等) の checkout 失敗は fetch-and-retry を
+        // 発動せず、従来どおりの "rev not found" エラーを返す。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        commit_to(&src, "v1", "init").await;
+
+        let repo = Repo::new(src.to_str().unwrap(), &dst, Some("no-such-branch"));
+        let err = repo.sync().await.unwrap_err();
+        assert!(
+            err.to_string().contains("rev 'no-such-branch' not found"),
+            "actual: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_unfetchable_pinned_sha_surfaces_error() {
+        // remote に存在しない 40-hex SHA は fallback の fetch 自体も失敗する
+        // ので、最終的にエラーが表面化する (silent success しない)。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        allow_any_sha1_in_want(&src).await;
+        commit_to(&src, "v1", "init").await;
+
+        let repo = Repo::new(
+            src.to_str().unwrap(),
+            &dst,
+            Some("ffffffffffffffffffffffffffffffffffffffff"),
+        );
+        assert!(repo.sync().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_sync_reclones_when_dst_is_not_a_git_repo() {
+        // user 報告の LuaSnip ケース: dir だけ残って `.git` が無い壊れた clone
+        // は、fetch_impl が "not a git repository" でコケる代わりに、削除して
+        // fresh clone に fall through する。remote URL (file:// 含む) 限定 —
+        // local path URL は user の dev dir の可能性があるので絶対に消さない。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        commit_to(&src, "hello", "init").await;
+
+        let url = format!("file://{}", src.display());
+        let repo = Repo::new(&url, &dst, None);
+        repo.sync().await.unwrap();
+        assert!(dst.join(".git").exists());
+
+        // `.git` を消して壊れた状態を再現。
+        fs::remove_dir_all(dst.join(".git")).unwrap();
+        repo.sync()
+            .await
+            .expect("broken clone must be removed and re-cloned");
+        assert!(dst.join(".git").exists());
+        assert_eq!(fs::read_to_string(dst.join("hello.txt")).unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn test_sync_keeps_local_path_dst_even_if_broken() {
+        // local path URL (= dev / mirror の可能性) の dst は壊れていても絶対に
+        // 削除しない — 従来どおりのエラーで止まる (データ損壊防止ガード)。
+        let root = tempdir().unwrap();
+        let src = root.path().join("src");
+        let dst = root.path().join("dst");
+
+        fs::create_dir_all(&src).unwrap();
+        git_init_with_user(&src).await;
+        commit_to(&src, "hello", "init").await;
+
+        // dst を「.git の無い壊れた dir」として作る。
+        fs::create_dir_all(&dst).unwrap();
+        fs::write(dst.join("hello.txt"), "precious user data").unwrap();
+
+        let repo = Repo::new(src.to_str().unwrap(), &dst, None);
+        assert!(
+            repo.sync().await.is_err(),
+            "local-path dst must not be auto-removed"
+        );
+        // 中身が消えていないこと。
+        assert_eq!(
+            fs::read_to_string(dst.join("hello.txt")).unwrap(),
+            "precious user data"
         );
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -402,12 +402,11 @@ pub(crate) fn build_view_if_needed(
     conflicts: &mut Vec<crate::merge_conflicts::MergeConflictReport>,
     merge_view_fn: fn(&Path, &Path) -> anyhow::Result<crate::link::MergeResult>,
 ) -> bool {
-    if !force {
-        if let Some(expected) = expected_stamp {
-            if crate::view_stamp::is_current(view_dir, expected) {
-                return false;
-            }
-        }
+    if !force
+        && let Some(expected) = expected_stamp
+        && crate::view_stamp::is_current(view_dir, expected)
+    {
+        return false;
     }
     build_view_atomically(
         src,
@@ -452,15 +451,15 @@ pub(crate) fn build_view_atomically(
         }
         // stamp は build 完走後の tmp に書く → atomic rename で view と一緒に
         // 公開される。 「stamp が在る ⟺ その fingerprint で build 完走済」を保つ。
-        if let Some(s) = stamp {
-            if let Err(e) = crate::view_stamp::write(tmp, s) {
-                // stamp が書けなくても view 自体は有効 — 次回 rebuild に倒れるだけ。
-                eprintln!(
-                    "\u{26a0} failed to write view stamp {}: {}",
-                    view_dir.display(),
-                    e
-                );
-            }
+        if let Some(s) = stamp
+            && let Err(e) = crate::view_stamp::write(tmp, s)
+        {
+            // stamp が書けなくても view 自体は有効 — 次回 rebuild に倒れるだけ。
+            eprintln!(
+                "\u{26a0} failed to write view stamp {}: {}",
+                view_dir.display(),
+                e
+            );
         }
         merge_result = Some(Ok(m));
         Ok(())


### PR DESCRIPTION
## Summary

Clones are depth-1 and fetches only `Deepen(1)`, so a lockfile pin more than ~2 commits behind the remote tip is missing from the local object DB. When a user deletes `repos/` to free disk and re-syncs, every pinned plugin failed with `rev '<sha>' not found`, and a partially deleted dir (no `.git`) failed with `does not appear to be a git repository`. This PR adds two recoveries in `src/git.rs`:

- **`checkout_with_pin_fetch_retry`**: on checkout failure of a full 40-hex SHA (i.e. a lockfile pin), fetch just that commit from origin via an object-id want — a one-sided gix refspec, the in-process equivalent of `git fetch origin <sha>` (gix-refspec treats a full-hex one-sided fetch refspec as `Needle::Object`) — then retry the checkout. Requires the server to allow SHA wants (GitHub allows it for reachable commits); if the fetch also fails, the original `rev '<sha>' not found` error is returned with the fetch error attached. Non-SHA revs (branch / tag / `/regex/`) never trigger the retry.
- **Broken-clone recovery in `sync_impl`**: a leftover dir without a valid `.git` is removed and re-cloned. Auto-remove applies to **remote URLs only** (`is_remote_url`) — a local-path dst (potential dev / mirror dir) is never deleted and keeps the old error. (`dev = true` plugins never reach `Repo::sync`; this is a belt-and-braces guard.)

Also included: a separate `chore` commit with mechanical `cargo clippy --fix` output — the floating stable toolchain (1.97) started flagging `collapsible_if` / `is_multiple_of` on existing code, which broke the `cargo make check` gate on main.

## Test plan

- [x] `cargo make check` (fmt --check + clippy + test + lock-check) green
- [x] New regression tests in `src/git.rs`:
  - `test_sync_fetches_pinned_sha_missing_from_fresh_clone` — fresh depth-1 clone + old pin
  - `test_sync_existing_clone_fetches_missing_pinned_sha` — existing clone + old pin
  - `test_update_fetches_missing_pinned_sha` — same fallback via `rvpm update`
  - `test_sync_missing_branch_rev_keeps_original_error` — non-SHA rev still errors
  - `test_sync_unfetchable_pinned_sha_surfaces_error` — truly-gone SHA still errors
  - `test_sync_reclones_when_dst_is_not_a_git_repo` — broken clone re-cloned
  - `test_sync_keeps_local_path_dst_even_if_broken` — local-path dst never deleted

Docs: both behaviors documented in `docs/architecture.md` (lockfile section).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository recovery for shallow clones by fetching missing pinned commits and retrying checkout.
  - Automatically replaces broken remote clone directories instead of failing, while preserving local-path directories.
  - Corrected zero-duration display to show `0`.
- **Documentation**
  - Documented the new lockfile recovery and broken-clone behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->