### PR TITLE
chore: release v3.44.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,7 +3681,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvpm"
-version = "3.43.0"
+version = "3.44.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.43.0"
+version = "3.44.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump for v3.44.0 — ships #318 (recover from stale lockfile pins and broken clones on sync).