### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,11 @@
 lockfile_version: '1'
-generated_at: '2026-08-03T05:12:40.782651+00:00'
-apm_version: 0.27.0
+generated_at: '2026-08-10T04:31:18.080327+00:00'
+apm_version: 0.28.0
 dependencies:
 - repo_url: yukimemi/renri
   name: renri
   host: github.com
-  resolved_commit: 584df0b76be8792e12effb22f8f501fb946b5f31
+  resolved_commit: 7122eb0ec069d4c9ccd888b4547ece6965b941a1
   resolved_ref: main
   version: 0.1.17
   package_type: apm_package
@@ -17,7 +17,7 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
     .claude/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
-  content_hash: sha256:1ed5a63afecb1567063e3d97875af6a8e7a627b8c8d2db56687b67861921eefe
+  content_hash: sha256:545b68ed54fb34e91c3d3be9c675ee4fc15ad2e4388684e7b51e48a51756dc7e
 deployments:
 - kind: project-relative
   target: claude


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->