### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-14T03:58:18.282952218Z"
+applied_at = "2026-08-15T03:28:42.654403626Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recorded application timestamp to August 15, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->