### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-17T03:33:22.607659364Z"
+applied_at = "2026-08-18T03:30:45.437207666Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "00be9d5dc530de2a6bbde59c1867d58f58b1bdfc"
+rev = "1a7c2be1758fd01c875b3d503201145f64df42ea"
 version = "0.14.0"
 
 [[templates]]


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the applied preset timestamp.
  * Advanced the project template revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->