### PR TITLE
chore: release v3.45.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvpm"
-version = "3.44.0"
+version = "3.45.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.44.0"
+version = "3.45.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump only: 3.44.0 → 3.45.0.

Ships #352 — per-plugin `opts` / `main`, so a plugin documented as "call `require('x').setup({})` yourself" needs only `opts = {}` in `config.toml` instead of a setup-only `after.lua`. Module resolution and the Lua literal are computed at generate time (zero startup cost), the call runs immediately before the plugin's `after.lua` on every trigger path, and it is `pcall`-wrapped so one failing `setup()` cannot take down the rest of loader.lua.

Diff is `[package].version` + `Cargo.lock`, so per AGENTS.md this skips the bot-review gate: CI green + owner approval is enough. On merge, `auto-tag.yml` pushes `v3.45.0`, which fires `release.yml` (three-target binaries + `cargo publish`).