### PR TITLE
fix(git): held-back detection on gix 0.86 (detached-HEAD remote_head)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bisync"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7"
+dependencies = [
+ "bisync_macros",
+]
+
+[[package]]
+name = "bisync_macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +548,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1150,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.84.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
+checksum = "bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -1200,6 +1224,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
+ "gix-zlib",
  "nonempty",
  "smallvec",
  "thiserror 2.0.20",
@@ -1218,16 +1243,16 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
+checksum = "c31c593692ebdc1e38858d9a2b56f6a594c501e24a38971fe6685571f5a07be0"
 dependencies = [
  "bstr",
+ "gix-features",
  "gix-glob",
  "gix-path",
  "gix-quote",
  "gix-trace",
- "kstring",
  "smallvec",
  "thiserror 2.0.20",
  "unicode-bom",
@@ -1266,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+checksum = "a2cd7f054ae2727223fe46dd39c012f066b12f532962d336d29ee193261787da"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -1280,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.57.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
+checksum = "103d11bef95c467577ecfa8b7b86a22e65af3507b2c9bfa3809a4afbae7df301"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1291,6 +1316,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
+ "gix-utils",
  "smallvec",
  "thiserror 2.0.20",
  "unicode-bom",
@@ -1298,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+checksum = "6f6af5321bfd3711a279d6b244d58532ba1cfabf9eb6374791f19929d8970082"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1311,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.38.2"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a0fcfcd73229d1a9c34e04edd05dbcb80364ec6f3788d24c546de2916671eb"
+checksum = "f9fbdb1c417980d05d547c19fc2b63344b5257c2387048d69ffe957bda142b59"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1321,6 +1347,7 @@ dependencies = [
  "gix-date",
  "gix-path",
  "gix-prompt",
+ "gix-quote",
  "gix-sec",
  "gix-trace",
  "gix-url",
@@ -1341,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.64.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
+checksum = "fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1365,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bb2a53a6fd917ec499ed0bfb5b6887de7a15bd79197dcea7c987938749a9f1"
+checksum = "f24bc78f283946ac64757c8a61ffa71f0230aa1e8d98cbb0771db479871dd5b6"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -1385,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7"
+checksum = "b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf"
 dependencies = [
  "bstr",
  "dunce",
@@ -1409,28 +1436,28 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+checksum = "20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc"
 dependencies = [
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "gix-path",
  "gix-trace",
  "gix-utils",
  "libc",
  "once_cell",
+ "parking_lot",
  "prodash",
- "thiserror 2.0.20",
  "walkdir",
- "zlib-rs",
 ]
 
 [[package]]
 name = "gix-filter"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
+checksum = "5e7b5dbf524d97e839f642930c76d7f011c0791e7d11d8148989ac5af7c76aa8"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1449,12 +1476,11 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+checksum = "865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80"
 dependencies = [
  "bstr",
- "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
@@ -1463,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+checksum = "421e92a711554fa5827d1b0599d3389acdd0f6729e97a8c5a57d79af1e50bf36"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1475,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+checksum = "13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -1487,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+checksum = "78fccd6fea3bcf0b39c076bae60ae49b08daaf538b950202101a981f9d3c01d3"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -1498,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+checksum = "12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1521,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
+checksum = "5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1549,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.1"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1560,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
+checksum = "2fa5aa789990f124e4f559b142cecfb60662cb4ae17006684ea9d668f4f07689"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -1574,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
+checksum = "0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1593,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.81.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
+checksum = "8dd494ffb5037e62b8220109e894d2861ff2150a2cacbfccdba57ae1ebab2b96"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -1606,6 +1632,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "gix-zlib",
  "memmap2",
  "parking_lot",
  "tempfile",
@@ -1614,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.71.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
+checksum = "6d5446127b269706e85998065267ddd2ccc3550179da6780b22fe496175ccb20"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -1627,6 +1654,7 @@ dependencies = [
  "gix-object",
  "gix-path",
  "gix-tempfile",
+ "gix-zlib",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -1635,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
+checksum = "3766025c72319c4accdd854a18e6f0dd176c8eb0f3bc8a60a7765be2b50cabf2"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -1659,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+checksum = "49f6fa5f8007f008187c3f60b4373209ca83d1cc947f35ede03e16cd15a4d137"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1674,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
+checksum = "5cb1f1eb92d6f4c9d4c105a6ca912cff637fbd5cacbcbafa5deccd88bfaa3565"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -1687,10 +1715,11 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.62.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
+checksum = "dede40e89c1e90f548415f50636bb051f6d9c60f68b8b710bc07825722d19588"
 dependencies = [
+ "bisync",
  "bstr",
  "gix-credentials",
  "gix-date",
@@ -1706,7 +1735,6 @@ dependencies = [
  "gix-trace",
  "gix-transport",
  "gix-utils",
- "maybe-async",
  "nonempty",
  "thiserror 2.0.20",
 ]
@@ -1724,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.64.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
+checksum = "eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -1744,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
+checksum = "7406282cc0259b51f6aee299ca3d31279a020530363152a2e6c96e8a7f7bbc83"
 dependencies = [
  "bstr",
  "gix-error",
@@ -1760,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
+checksum = "e55e09d4a1ecf2beecc8c09cafcad37979e805b31f588b0e957e191df5783681"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -1779,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6"
+checksum = "36c113c0a53294dc6280ffc06cbcc4f50f820397e97d6a00b429a44b8db26e29"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1807,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+checksum = "1ecc9f4b40537043e4bbd7d3d1760e74fb8e7b07a546166b558acaa73ad97f4a"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -1820,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22042e385d28a34275e029d98f4970285045be14b9073658ca897923f2ed8700"
+checksum = "5f83b1c74e69b90411fbfe89ccebc47aa49457ce4eb9b942b1311258fc863d22"
 dependencies = [
  "bstr",
  "filetime",
@@ -1837,15 +1865,17 @@ dependencies = [
  "gix-path",
  "gix-pathspec",
  "gix-worktree",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
+checksum = "5fd98077a56d08886112e6b08dc94076d03539f4bc0b9d7880e4be2b8a640d8c"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1858,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.2"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
+checksum = "b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -1877,9 +1907,9 @@ checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.2"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
+checksum = "3f36d045b840f8aeee1a527e677eab1fbebfbbe94bf2e708fa81d0b4b742d5fc"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -1887,18 +1917,20 @@ dependencies = [
  "gix-credentials",
  "gix-features",
  "gix-packetline",
+ "gix-path",
  "gix-quote",
  "gix-sec",
  "gix-url",
+ "parking_lot",
  "reqwest",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-traverse"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
+checksum = "008c5cd879e46e86b5c2469e633611978b18775d53d05668d691bc13088bd409"
 dependencies = [
  "bitflags 2.13.1",
  "gix-commitgraph",
@@ -1913,12 +1945,13 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.36.2"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29"
+checksum = "31bdfc93aa880cda3272718a5879ce3aa7723fa13514320dd6608151607afe72"
 dependencies = [
  "bstr",
  "gix-path",
+ "gix-utils",
  "percent-encoding",
  "thiserror 2.0.20",
 ]
@@ -1946,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.53.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
+checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1964,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bffae8b3ca258fdd50370cd51f06deb4c76a3b43db3868bc28dde45ffa77d69"
+checksum = "bc47372fc12b9fbea51b257bcc8d4970326cf5c7e42135bbfb5d72871bb30bd4"
 dependencies = [
  "bstr",
  "gix-features",
@@ -1982,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
+checksum = "3b088c8724e7be120c4798dd86925cf05332c9d356a463542578600c50c7a549"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -1996,6 +2029,16 @@ dependencies = [
  "gix-path",
  "gix-traverse",
  "parking_lot",
+]
+
+[[package]]
+name = "gix-zlib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c"
+dependencies = [
+ "thiserror 2.0.20",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2574,15 +2617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b609e7ca5ea38f093c20a4a102335b247221c9643b7a6bc3510f196f99499a9e"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,17 +2720,6 @@ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ dirs = "6.0"
 walkdir = "2.5"
 
 # Git (in-process, no fork)
-gix = { version = "0.84.0", default-features = false, features = [
+gix = { version = "0.86.0", default-features = false, features = [
     "sha1",
     "blocking-network-client",
     "blocking-http-transport-reqwest-rust-tls",

--- a/src/git.rs
+++ b/src/git.rs
@@ -413,6 +413,14 @@ fn resolve_revision_impl(dst: &Path, rev: &str) -> Result<Option<String>> {
 /// remote tracking branch の tip を読み取る。HEAD は動かさない。
 /// tracking branch (`refs/remotes/<remote>/<branch>`) が見つからなければ
 /// `refs/remotes/<remote>/HEAD` に fallback。それも無ければ `Ok(None)`。
+///
+/// detached HEAD (rev pin による checkout) では `head_name()` が `None` に
+/// なるため、まず `.git/config` の `[branch "<name>"]` (remote がこの remote、
+/// merge が refs/heads/<name>) から「この clone が追跡している branch」を
+/// 解決して tracking ref を読む。pinned checkout 後の held-back 判定はこの
+/// 経路に依存する — `refs/remotes/<remote>/HEAD` は gix >= 0.85 で clone 時点の
+/// snapshot として **direct ref** で書かれるようになり (git の symbolic
+/// `origin/HEAD` と違い追従しない)、stale な値しか返せないため。
 fn read_remote_head(dst: &Path) -> Result<Option<String>> {
     let repo = gix::open(dst)?;
     let remote_name = repo
@@ -432,6 +440,30 @@ fn read_remote_head(dst: &Path) -> Result<Option<String>> {
         {
             return Ok(Some(id.detach().to_string()));
         }
+    } else if let Some(tracked_branch) = tracked_branch_from_config(&repo, &remote_name) {
+        // detached HEAD: config の追跡 branch の tracking ref を読む。
+        // 期待される「ref が無い」(branch が削除された等) は静かに fallback へ、
+        // それ以外の運用エラー (破損した ref 等) は警告して held-back 判定を
+        // 黙って無効化しない (resilience: 警告は出すが処理は続行)。
+        let tracking = format!("refs/remotes/{}/{}", remote_name, tracked_branch);
+        match repo.find_reference(&tracking) {
+            Ok(mut tr) => match tr.peel_to_id() {
+                Ok(id) => return Ok(Some(id.detach().to_string())),
+                Err(e) => eprintln!(
+                    "Warning: failed to peel tracking ref {} in {}: {}",
+                    tracking,
+                    dst.display(),
+                    e
+                ),
+            },
+            Err(gix::reference::find::existing::Error::NotFound { .. }) => {}
+            Err(e) => eprintln!(
+                "Warning: failed to read tracking ref {} in {}: {}",
+                tracking,
+                dst.display(),
+                e
+            ),
+        }
     }
 
     let remote_head_ref = format!("refs/remotes/{}/HEAD", remote_name);
@@ -441,6 +473,29 @@ fn read_remote_head(dst: &Path) -> Result<Option<String>> {
         return Ok(Some(id.detach().to_string()));
     }
     Ok(None)
+}
+
+/// `.git/config` から「この clone の追跡 branch」を取り出す。
+/// clone は default branch について `[branch "<name>"]` (`remote` + `merge =
+/// refs/heads/<name>`) を書く。detached HEAD (pinned) 時の held-back 判定に使う。
+/// 見つからない場合は `None` (判定不能 → 呼び出し側で `origin/HEAD` fallback)。
+///
+/// 実装は gix の config 解決に丸投げする (`branch_remote_tracking_ref_name` は
+/// `branch.<name>.remote` / `branch.<name>.merge` を key の順序や `=` 周辺の空白
+/// に依存せず解決する — 手書き INI 解析は fragile で CodeRabbit / Claude 指摘に
+/// なったため使わない)。複数 branch が同一 remote を追跡する場合は
+/// branch 名のソート順で最初のものを返す (決定的)。
+fn tracked_branch_from_config(repo: &gix::Repository, remote_name: &str) -> Option<String> {
+    let remote_prefix = format!("refs/remotes/{}/", remote_name);
+    repo.branch_names().into_iter().find_map(|short_name| {
+        let full_name = format!("refs/heads/{short_name}");
+        let full_ref: &gix::refs::FullNameRef = full_name.as_str().try_into().ok()?;
+        let tracking = repo
+            .branch_remote_tracking_ref_name(full_ref, gix::remote::Direction::Fetch)?
+            .ok()?;
+        let tracking = tracking.as_bstr().to_string();
+        tracking.strip_prefix(&remote_prefix).map(str::to_string)
+    })
 }
 
 /// `rev` の committer date を読む。失敗系はすべて `Ok(None)` に丸める
@@ -3240,5 +3295,91 @@ mod tests {
         let held = outcome.unwrap().held.expect("tip itself is still held");
         assert_eq!(held.tip, new_tip);
         assert_eq!(held.fallback.as_deref(), Some(mid.as_str()));
+    }
+
+    fn config_repo(config_body: &str) -> tempfile::TempDir {
+        // clone 後の .git/config 相当: 追跡 branch 解決は `branch.<name>.remote/merge` に
+        // 加えて `[remote "origin"]` (url + fetch spec) が存在して初めて成立する
+        // (gix の branch_remote_tracking_ref_name 経由)。なので remote セクションを
+        // 常に含める。
+        let root = tempdir().unwrap();
+        let dst = root.path().join("dst");
+        std::fs::create_dir_all(&dst).unwrap();
+        std::process::Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(&dst)
+            .status()
+            .unwrap();
+        fs::write(
+            dst.join(".git").join("config"),
+            format!(
+                "[remote \"origin\"]\n\turl = /dev/null\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n{}",
+                config_body
+            ),
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn tracked_branch_from_config_reads_merge_before_remote() {
+        // git config key order is not semantic; `merge` may precede `remote`.
+        let root = config_repo("[branch \"main\"]\n\tmerge = refs/heads/main\n\tremote = origin\n");
+        let repo = gix::open(root.path().join("dst")).unwrap();
+        assert_eq!(
+            tracked_branch_from_config(&repo, "origin").as_deref(),
+            Some("main"),
+            "key order within a branch section must not matter",
+        );
+    }
+
+    #[test]
+    fn tracked_branch_from_config_skips_other_remotes() {
+        let root = config_repo(
+            "[branch \"main\"]\n\tremote = upstream\n\tmerge = refs/heads/main\n\
+             [branch \"dev\"]\n\tremote = origin\n\tmerge = refs/heads/dev\n",
+        );
+        let repo = gix::open(root.path().join("dst")).unwrap();
+        assert_eq!(
+            tracked_branch_from_config(&repo, "origin").as_deref(),
+            Some("dev"),
+            "only sections tracking the requested remote are considered",
+        );
+    }
+
+    #[test]
+    fn tracked_branch_from_config_picks_deterministic_first_section() {
+        // 複数 branch が同一 remote を追跡していても、branch 名ソート順で
+        // 最初の1つに決まる (ファイル順・key 順に依存しない)。
+        let root = config_repo(
+            "[branch \"main\"]\n\tremote = origin\n\tmerge = refs/heads/main\n\
+             [branch \"dev\"]\n\tremote = origin\n\tmerge = refs/heads/dev\n",
+        );
+        let repo = gix::open(root.path().join("dst")).unwrap();
+        assert_eq!(
+            tracked_branch_from_config(&repo, "origin").as_deref(),
+            Some("dev"),
+            "one deterministic origin-tracking branch is selected",
+        );
+    }
+
+    #[test]
+    fn tracked_branch_from_config_tolerates_loose_spacing() {
+        let root =
+            config_repo("[branch \"main\"]\n\tremote\t=\torigin\n\tmerge = refs/heads/main\n");
+        let repo = gix::open(root.path().join("dst")).unwrap();
+        assert_eq!(
+            tracked_branch_from_config(&repo, "origin").as_deref(),
+            Some("main"),
+            "whitespace around '=' in git config is not semantic",
+        );
+    }
+
+    #[test]
+    fn tracked_branch_from_config_none_when_unmatched() {
+        let root =
+            config_repo("[branch \"main\"]\n\tremote = upstream\n\tmerge = refs/heads/main\n");
+        let repo = gix::open(root.path().join("dst")).unwrap();
+        assert_eq!(tracked_branch_from_config(&repo, "origin"), None);
     }
 }


### PR DESCRIPTION
## What

gix 0.86 update (renovate/gix-0.x) broke `remote_head()` for pinned (detached-HEAD) checkouts, so the "held back by lockfile pin" warning stopped firing. This PR restores the detection.

## Root cause

- The fetch itself works: `refs/remotes/origin/<branch>` is updated correctly by `fetch_impl`.
- gix >= 0.85 changed `update_refs` so born **symbolic** remote refs are written as **direct refs** ("Born symbolic remote refs are written as direct refs to the advertised target object id"). `refs/remotes/origin/HEAD` is now a snapshot taken at clone time instead of a symbolic ref to the default branch.
- `read_remote_head` resolves the tracking branch from `repo.head_name()`. A pinned checkout (rev = commit SHA) leaves HEAD **detached**, `head_name()` returns `None`, and the code fell back to stale `refs/remotes/origin/HEAD` — always the clone-time commit, so held-back was never detected after the remote advanced.

## Fix

When HEAD is detached, resolve the tracked branch from the config `[branch "<name>"]` section (`remote` + `merge = refs/heads/<name>`, written by clone for the default branch) and read `refs/remotes/<remote>/<name>`, the ref the fetch actually updates. Resolution delegates to gix (`branch_names` + `branch_remote_tracking_ref_name`) so key order, whitespace and multiple branch sections are handled by gix's INI parser; operational ref-read/peel failures now warn instead of silently disabling held-back detection. `origin/HEAD` remains the last-resort fallback.

## Verification

- `test_remote_head_reports_tracking_branch_tip` — passed on gix 0.84, **failed on 0.86**, now green again
- 5 new `tracked_branch_from_config` unit tests (reversed key order, loose whitespace, multiple branch sections, foreign remotes, no match)
- full `cargo make check` (fmt + clippy + 937 tests + lock-check) passes on Windows