### PR TITLE
chore: release v3.47.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvpm"
-version = "3.46.0"
+version = "3.47.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.46.0"
+version = "3.47.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump to v3.47.0 (double-setup detection tightening for per-plugin `opts`, #356). CI green + owner approval only; version-bump PR skips the bot-review gate per repo conventions.