### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-24T03:35:54.685521647Z"
+applied_at = "2026-08-25T03:32:56.936461294Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "d32d2b5417b0e999bdefd311c21faaee18f2f1aa"
+rev = "67b51ca20a19ec8347d7c2504585391725e7892f"
 version = "0.18.0"
 
 [[templates]]


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project template revision and applied timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->