### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-28T05:56:39.131316177Z"
+applied_at = "2026-08-29T03:27:30.879082572Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "6b66bd5112f42490d972b282585040f19d09ede4"
+rev = "10cd49c09b95af8add4daf71c5151835821cb670"
 version = "0.18.0"
 
 [[templates]]


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project maintenance records and refreshed the applied template revision.
  * No user-facing features, behavior, or public interfaces were changed.
  * This update does not alter the application’s functionality or visible experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->