### PR TITLE
perf(list): cache hook stats and redraw only on change

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -378,7 +378,7 @@ Resilience: if `nvim` is not on PATH, only a warning is emitted and rvpm continu
 
 ## Parallel execution and Semaphore
 
-`run_sync()` and `run_update()` spawn parallel tasks via `tokio::task::JoinSet`. When `config.options.concurrency` is set, task count is bounded by `tokio::sync::Semaphore`.
+`run_sync()` and `run_update()` spawn parallel tasks via `tokio::task::JoinSet`. When `config.options.concurrency` is set, task count is bounded by `tokio::sync::Semaphore`. `run_list()`'s background status check uses the same bound: `Repo::get_status()` runs on `spawn_blocking`, so an unbounded fan-out would start one OS thread per plugin and have them fight over the disk.
 
 ```rust
 let concurrency = resolve_concurrency(config.options.concurrency);
@@ -386,6 +386,26 @@ let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
 // At the top of each task:
 let _permit = sem.acquire_owned().await.unwrap();
 ```
+
+## `rvpm list` TUI latency (`src/tui.rs::HookCache`, `src/commands/list.rs`)
+
+The list TUI used to rebuild every row on a fixed 50ms tick, and each row ran
+three `exists()` calls for `init.lua` / `before.lua` / `after.lua` (the `I B A`
+column). At 233 plugins that is ~700 stats per frame — measured at ~50ms warm
+and ~150ms under Windows real-time scanning, so `j` / `k` visibly lagged: the
+redraw monopolised the loop and key events queued behind it.
+
+Two changes fix it, both in the "don't recompute what didn't change" family:
+
+- **`HookCache::scan()`** walks the hooks once per config load (startup and
+  after every `reload!()`), and `draw_list` only reads the cached `HookFlags`.
+  Frame cost drops to ~2.7ms for 233 plugins.
+- **Dirty-flag redraw.** The list TUI has no time-driven element (no spinner),
+  so it draws only when something moved: a key press, a `Resize` event, or a
+  status message arriving from the background check. Idle frames cost nothing.
+
+The sync / update progress TUI (`TuiState::draw`) keeps its unconditional
+redraw — its spinner and elapsed-time display are time-driven.
 
 ## TOML config templating
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -57,6 +57,17 @@ pub(crate) async fn run_list(no_tui: bool) -> Result<bool> {
     let (mut rx, mut set) = spawn_status_check(&config, &cache_root);
     let mut bg_done = false;
 
+    // env vars (RVPM_APPNAME / NVIM_APPNAME) は run_list 実行中に変わらないので
+    // ループ外で 1 回だけ resolve。
+    let init_lua = nvim_init_lua_path();
+    // hook (init/before/after.lua) の存在は config 読み込み時に 1 度だけ走査
+    // する。毎フレーム stat すると 252 plugin × 3 file で 1 描画 150ms 級に
+    // なり、j/k のカーソル移動が目に見えてもたつく (#list-tui-latency)。
+    let mut hooks = crate::tui::HookCache::scan(&config, &config_root, Some(&init_lua));
+    // 再描画が必要かどうか。list TUI にはアニメーション要素が無いので、キー
+    // 入力 / リサイズ / ステータス受信が無い限り描き直す意味が無い。
+    let mut dirty = true;
+
     // `b` キーで browse TUI に遷移したいフラグ。ループ終了後 main.rs 側に返す。
     let mut goto_browse = false;
 
@@ -83,7 +94,9 @@ pub(crate) async fn run_list(no_tui: bool) -> Result<bool> {
             rx = new_rx;
             set = new_set;
             config_root = new_config_root;
+            hooks = crate::tui::HookCache::scan(&config, &config_root, Some(&init_lua));
             bg_done = false;
+            dirty = true;
         }};
     }
 
@@ -178,15 +191,12 @@ pub(crate) async fn run_list(no_tui: bool) -> Result<bool> {
         Ok((config, tui_state, rx, set, config_root))
     }
 
-    // env vars (RVPM_APPNAME / NVIM_APPNAME) は run_list 実行中に変わらないので
-    // ループ外で 1 回だけ resolve。draw_list の毎フレーム再呼び出しを避ける。
-    let init_lua = nvim_init_lua_path();
-
     loop {
         // バックグラウンドのステータス更新を非ブロッキングで受信
         if !bg_done {
             while let Ok((url, status)) = rx.try_recv() {
                 tui_state.update_status(&url, status);
+                dirty = true;
             }
             if set.is_empty() {
                 bg_done = true;
@@ -195,15 +205,36 @@ pub(crate) async fn run_list(no_tui: bool) -> Result<bool> {
             while let Some(Ok(_)) = set.try_join_next() {}
         }
 
-        terminal
-            .draw(|f| tui_state.draw_list(f, &config, &config_root, &icons, Some(&init_lua)))?;
+        // list TUI はスピナー等の時間駆動要素を持たないので、状態が動いた
+        // ときだけ描く。無条件 redraw だと 50ms ごとに全 plugin 分の Row を
+        // 組み直すことになり、キー入力の処理が後ろに詰まる。
+        if dirty {
+            terminal.draw(|f| tui_state.draw_list(f, &config, &icons, &hooks))?;
+            dirty = false;
+        }
 
-        if crossterm::event::poll(std::time::Duration::from_millis(50))?
-            && let crossterm::event::Event::Key(key) = crossterm::event::read()?
-        {
-            if key.kind != crossterm::event::KeyEventKind::Press {
-                continue;
+        let key = if crossterm::event::poll(std::time::Duration::from_millis(50))? {
+            match crossterm::event::read()? {
+                crossterm::event::Event::Key(k)
+                    if k.kind == crossterm::event::KeyEventKind::Press =>
+                {
+                    Some(k)
+                }
+                // リサイズはレイアウト再計算が要るので再描画だけ発火させる。
+                crossterm::event::Event::Resize(..) => {
+                    dirty = true;
+                    None
+                }
+                _ => None,
             }
+        } else {
+            None
+        };
+
+        if let Some(key) = key {
+            // キー入力は選択位置・検索状態のいずれかを動かしうるので、
+            // 個別ハンドラで判定せずまとめて再描画対象にする。
+            dirty = true;
 
             // ── 検索モード: インライン入力 ──
             if tui_state.search_mode {
@@ -420,11 +451,18 @@ fn spawn_status_check(
             .iter()
             .map(|e| (e.name.as_str(), e))
             .collect();
+    // gix の status は spawn_blocking 経由なので、無制限に spawn すると plugin
+    // 数だけ OS スレッドが立ち上がってディスクを叩き合う (252 plugin の実配置で
+    // 起動が体感で重くなる)。sync と同じ concurrency 上限で絞る。
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(resolve_concurrency(
+        config.options.concurrency,
+    )));
     let mut set = JoinSet::new();
     for plugin in config.plugins.iter() {
         let plugin = plugin.clone();
         let cache_root = cache_root.to_path_buf();
         let tx = tx.clone();
+        let semaphore = Arc::clone(&semaphore);
         // この plugin の update エラー記録 (URL 一致時のみ有効 — 同名で別 repo に
         // 差し替えられたケースは別物なので無視する。lockfile / fetch_state と同思想)。
         let update_err_msg = error_lookup
@@ -432,6 +470,8 @@ fn spawn_status_check(
             .filter(|e| urls_match(&e.url, &plugin.url))
             .map(|e| e.message.clone());
         set.spawn(async move {
+            // Semaphore は close されないので acquire は失敗しない。
+            let _permit = semaphore.acquire().await;
             let dst_path = resolve_plugin_dst(&plugin, &cache_root);
             let repo = Repo::new(&plugin.url, &dst_path, plugin.rev.as_deref());
             let git_status = repo.get_status().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,8 +749,13 @@ fn write_loader_to_path(
 /// デフォルト並列数。GitHub の rate limit を避けるため控えめに。
 const DEFAULT_CONCURRENCY: usize = 13;
 
+/// `options.concurrency` を Semaphore の permit 数に落とす。
+///
+/// `0` は `Semaphore::new(0)` になり、permit を待つ全タスクが永久に
+/// `acquire().await` で止まる (sync / update / generate / list 全経路が無反応に
+/// なる)。設定ミスで固まるより逐次実行に落ちる方が親切なので 1 に丸める。
 fn resolve_concurrency(config_value: Option<usize>) -> usize {
-    config_value.unwrap_or(DEFAULT_CONCURRENCY)
+    config_value.unwrap_or(DEFAULT_CONCURRENCY).max(1)
 }
 
 pub(crate) fn plural_s(n: usize) -> &'static str {
@@ -1478,6 +1483,13 @@ url = "owner/repo"
     fn test_resolve_concurrency_uses_config_value() {
         let result = resolve_concurrency(Some(5));
         assert_eq!(result, 5);
+    }
+
+    #[test]
+    fn test_resolve_concurrency_clamps_zero_to_one() {
+        // `Semaphore::new(0)` は全タスクが acquire() で永久に待つデッドロック
+        // になるので、`concurrency = 0` は逐次実行 (1) に丸める。
+        assert_eq!(resolve_concurrency(Some(0)), 1);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -91,6 +91,80 @@ pub enum PluginStatus {
     UpdateFailed(String),
 }
 
+/// `init.lua` / `before.lua` / `after.lua` の存在フラグ。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HookFlags {
+    pub init: bool,
+    pub before: bool,
+    pub after: bool,
+}
+
+impl HookFlags {
+    fn any(&self) -> bool {
+        self.init || self.before || self.after
+    }
+
+    /// `I B A` 列の表示テキストと色。
+    fn render(&self, icons: &Icons) -> (String, Color) {
+        let mark = |on: bool| if on { icons.hook_on } else { icons.hook_off };
+        (
+            format!(
+                "{} {} {}",
+                mark(self.init),
+                mark(self.before),
+                mark(self.after)
+            ),
+            if self.any() {
+                Color::Green
+            } else {
+                Color::DarkGray
+            },
+        )
+    }
+}
+
+/// `draw_list` が使う hook 存在フラグのスナップショット。
+///
+/// `exists()` は Windows の NTFS + リアルタイムスキャン下では 1 回あたり
+/// 0.1ms 規模かかる。252 plugin × 3 file を毎フレーム叩くと 1 描画で 150ms
+/// 近くになり、j/k のカーソル移動が体感で詰まる (#list-tui-latency)。
+/// config を読んだタイミングで 1 度だけ走査して、描画側は参照するだけにする。
+pub struct HookCache {
+    /// `[ Global hooks ]` sentinel 行の分。`None` なら sentinel を描かない。
+    pub global: Option<HookFlags>,
+    /// `config.plugins` と同じ並び / 同じ長さ。
+    pub plugins: Vec<HookFlags>,
+}
+
+impl HookCache {
+    /// `config_root` 配下の per-plugin hook と、global hook の存在を走査する。
+    /// `nvim_init_lua` に `Some` を渡したときだけ sentinel 行の分を作る。
+    pub fn scan(
+        config: &crate::config::Config,
+        config_root: &std::path::Path,
+        nvim_init_lua: Option<&std::path::Path>,
+    ) -> Self {
+        let global = nvim_init_lua.map(|init_lua| HookFlags {
+            init: init_lua.exists(),
+            before: config_root.join("before.lua").exists(),
+            after: config_root.join("after.lua").exists(),
+        });
+        let plugins = config
+            .plugins
+            .iter()
+            .map(|p| {
+                let dir = crate::paths::resolve_plugin_config_dir(config_root, p);
+                HookFlags {
+                    init: dir.join("init.lua").exists(),
+                    before: dir.join("before.lua").exists(),
+                    after: dir.join("after.lua").exists(),
+                }
+            })
+            .collect();
+        Self { global, plugins }
+    }
+}
+
 pub struct TuiState {
     pub plugins: Vec<String>,
     pub status_map: HashMap<String, PluginStatus>,
@@ -601,13 +675,12 @@ impl TuiState {
         &mut self,
         f: &mut Frame,
         config: &crate::config::Config,
-        config_root: &std::path::Path,
         icons: &Icons,
-        // 一番上に [ Global hooks ] sentinel 行を描く。`None` を渡せば従来通り
-        // plugin だけを描く (将来 list 以外の用途を想定して Option にしてある)。
-        // Some の場合、`tui_state.plugins[0]` は空文字 sentinel で、selected_url()
-        // が `Some("")` を返す前提。
-        nvim_init_lua_path: Option<&std::path::Path>,
+        // hook 存在フラグは `HookCache::scan` で config 読み込み時に 1 度だけ
+        // 走査したものを受け取る。`hooks.global` が `Some` のときだけ一番上に
+        // `[ Global hooks ]` sentinel 行を描く (その場合 `tui_state.plugins[0]`
+        // は空文字 sentinel で、`selected_url()` が `Some("")` を返す前提)。
+        hooks: &HookCache,
     ) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -686,22 +759,11 @@ impl TuiState {
 
         let mut rows: Vec<Row> = Vec::with_capacity(config.plugins.len() + 1);
 
-        if let Some(init_lua_path) = nvim_init_lua_path {
+        if let Some(global) = hooks.global {
             // [ Global hooks ] sentinel 行: per-plugin の I/B/A 表記と揃えて、
-            // init.lua は Neovim 本体の path、before/after は <config_root> 配下を見る。
-            // exists() を 1 ファイルにつき 1 回だけ叩く (TUI ループは ~50ms ごと
-            // に redraw されるので、毎フレーム重複 stat を避ける)。
-            let has_i = init_lua_path.exists();
-            let has_b = config_root.join("before.lua").exists();
-            let has_a = config_root.join("after.lua").exists();
-            let hook_i = if has_i { icons.hook_on } else { icons.hook_off };
-            let hook_b = if has_b { icons.hook_on } else { icons.hook_off };
-            let hook_a = if has_a { icons.hook_on } else { icons.hook_off };
-            let hooks_color = if has_i || has_b || has_a {
-                Color::Green
-            } else {
-                Color::DarkGray
-            };
+            // init.lua は Neovim 本体の path、before/after は <config_root> 配下。
+            // 存在チェックは HookCache::scan 済みなので、ここでは stat しない。
+            let (hooks_text, hooks_color) = global.render(icons);
             rows.push(Row::new(vec![
                 Cell::from(icons.installed).style(Style::default().fg(Color::Cyan)),
                 Cell::from("[ Global hooks ]").style(
@@ -712,14 +774,13 @@ impl TuiState {
                 Cell::from("-").style(Style::default().fg(Color::DarkGray)),
                 Cell::from("-").style(Style::default().fg(Color::DarkGray)),
                 Cell::from("-").style(Style::default().fg(Color::DarkGray)),
-                Cell::from(format!("{} {} {}", hook_i, hook_b, hook_a))
-                    .style(Style::default().fg(hooks_color)),
+                Cell::from(hooks_text).style(Style::default().fg(hooks_color)),
                 Cell::from("nvim init.lua + global before/after.lua")
                     .style(Style::default().fg(Color::DarkGray)),
             ]));
         }
 
-        rows.extend(config.plugins.iter().map(|p| {
+        rows.extend(config.plugins.iter().enumerate().map(|(idx, p)| {
             // インストール状態アイコン
             let install_status = self
                 .status_map
@@ -784,23 +845,15 @@ impl TuiState {
             };
             let rev = p.rev.as_deref().unwrap_or("-");
 
-            // I B A 列: init/before/after.lua の存在チェック
-            // per-plugin hook は <config_root>/plugins/<host>/<owner>/<repo>/
-            // exists() は 1 ファイルにつき 1 回だけ叩く (TUI ループの redraw 頻度
-            // で N プラグイン × 6 stat → N × 3 stat に削減)。
-            let pcdir = config_root.join("plugins").join(p.canonical_path());
-            let has_i = pcdir.join("init.lua").exists();
-            let has_b = pcdir.join("before.lua").exists();
-            let has_a = pcdir.join("after.lua").exists();
-            let hook_i = if has_i { icons.hook_on } else { icons.hook_off };
-            let hook_b = if has_b { icons.hook_on } else { icons.hook_off };
-            let hook_a = if has_a { icons.hook_on } else { icons.hook_off };
-            let hooks_text = format!("{} {} {}", hook_i, hook_b, hook_a);
-            let hooks_color = if has_i || has_b || has_a {
-                Color::Green
-            } else {
-                Color::DarkGray
-            };
+            // I B A 列: init/before/after.lua の存在チェック。stat は
+            // HookCache::scan で config 読み込み時に済ませてある。cache 長が
+            // config とズレていても行は落とさず、hook 無しとして描く (resilience)。
+            let (hooks_text, hooks_color) = hooks
+                .plugins
+                .get(idx)
+                .copied()
+                .unwrap_or_default()
+                .render(icons);
 
             Row::new(vec![
                 Cell::from(inst_icon).style(Style::default().fg(inst_color)),
@@ -1057,6 +1110,64 @@ mod tests {
         assert_eq!(TuiState::progress_color(0.74), Color::Cyan);
         assert_eq!(TuiState::progress_color(0.75), Color::Green);
         assert_eq!(TuiState::progress_color(1.0), Color::Green);
+    }
+
+    #[test]
+    fn hook_cache_scan_reflects_files_on_disk() {
+        use crate::config::{Config, Plugin};
+        let tmp = tempfile::tempdir().unwrap();
+        let config_root = tmp.path();
+
+        // global: before.lua だけ置く (init.lua は nvim 側の path を別に渡す)
+        std::fs::write(config_root.join("before.lua"), "").unwrap();
+
+        // plugin A: init.lua と after.lua あり / plugin B: hook 無し
+        let a = Plugin {
+            url: "owner/a.nvim".to_string(),
+            ..Default::default()
+        };
+        let b = Plugin {
+            url: "owner/b.nvim".to_string(),
+            ..Default::default()
+        };
+        let adir = crate::paths::resolve_plugin_config_dir(config_root, &a);
+        std::fs::create_dir_all(&adir).unwrap();
+        std::fs::write(adir.join("init.lua"), "").unwrap();
+        std::fs::write(adir.join("after.lua"), "").unwrap();
+
+        let config = Config {
+            vars: None,
+            options: crate::config::Options::default(),
+            plugins: vec![a, b],
+        };
+
+        let init_lua = config_root.join("nvim-init.lua");
+        std::fs::write(&init_lua, "").unwrap();
+        let hooks = HookCache::scan(&config, config_root, Some(&init_lua));
+
+        assert_eq!(
+            hooks.global,
+            Some(HookFlags {
+                init: true,
+                before: true,
+                after: false,
+            })
+        );
+        assert_eq!(
+            hooks.plugins,
+            vec![
+                HookFlags {
+                    init: true,
+                    before: false,
+                    after: true,
+                },
+                HookFlags::default(),
+            ]
+        );
+
+        // sentinel を出さない呼び出しでは global を走査しない
+        let no_global = HookCache::scan(&config, config_root, None);
+        assert_eq!(no_global.global, None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`rvpm list` felt heavy on Windows, and `j`/`k` navigation visibly lagged.

Two independent causes:

1. **`draw_list` stat'd the filesystem every frame.** Each row runs three `exists()` calls for `init.lua` / `before.lua` / `after.lua` (the `I B A` column). At 233 plugins that is ~700 stats per frame — measured ~50ms warm on NTFS, ~150ms under real-time scanning. The loop also redrew unconditionally every 50ms tick, so the redraw monopolised the loop and key events queued behind it.
2. **Unbounded status-check fan-out.** `spawn_status_check` spawned one task per plugin with no semaphore, and `Repo::get_status()` runs on `spawn_blocking` — 252 OS threads fighting over the disk at startup.

## Changes

- `tui::HookCache::scan()` walks the hooks once per config load (startup + every `reload!()`); `draw_list` takes `&HookCache` and only reads cached `HookFlags`. `config_root` and `nvim_init_lua_path` drop out of the draw signature.
- Dirty-flag redraw in `run_list`: the list TUI has no time-driven element (no spinner), so it draws only on key press, `Resize`, or an incoming status message. The sync/update progress TUI keeps its unconditional redraw — its spinner is time-driven.
- `spawn_status_check` bounds its tasks with the same `Semaphore` / `resolve_concurrency` pattern `run_sync` uses.

## Measurements (Windows 11, 252 configured / 233 active plugins)

| | before | after |
|---|---|---|
| `draw_list` frame | ~50ms warm (~150ms cold) | 2.7ms |
| `rvpm list --no-tui` wall, warm | 1.28-1.51s | 1.16-1.23s |

Frame timing measured with `TestBackend` at 160x50 over 100 draws against the real config.

## Verification

- `cargo make check` green.
- New test `hook_cache_scan_reflects_files_on_disk` covers `HookCache::scan` against a tempdir (global sentinel + per-plugin flags + `None` = no global scan).
- Smoke: launched the release binary's list TUI in a PTY, sent 10 `j` presses, confirmed the cursor walked 10 rows and background statuses filled in progressively.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved list view responsiveness by caching plugin hook indicators and avoiding unnecessary redraws.
  * Reduced rendering overhead for large plugin lists.
  * Limited concurrent background status checks to improve stability and disk performance.

* **Bug Fixes**
  * The list view now refreshes correctly after resizing, reloading, or receiving status updates.

* **Documentation**
  * Added documentation explaining concurrency controls and TUI performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->