### PR TITLE
chore: release v3.49.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3723,7 +3723,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rvpm"
-version = "3.48.0"
+version = "3.49.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpm"
-version = "3.48.0"
+version = "3.49.0"
 edition = "2024"
 description = "Fast Neovim plugin manager with pre-compiled loader and merge optimization"
 license = "MIT"


### PR DESCRIPTION
Version bump only (`package.version` + `Cargo.lock`). Skips the bot-review gate per AGENTS.md.

## v3.49.0

- perf(list): cache hook stats and redraw only on change (#375)
  - `HookCache::scan()` walks `init`/`before`/`after.lua` once per config load instead of ~700 `exists()` calls per frame; `draw_list` frame cost at 233 plugins drops ~50ms → 2.7ms.
  - Dirty-flag redraw: the list TUI now draws only on key press, `Resize`, or an incoming status message.
  - `spawn_status_check` is bounded by the same `Semaphore` `sync` uses, instead of spawning one blocking OS thread per plugin.
  - `resolve_concurrency` clamps `options.concurrency = 0` to 1 — `Semaphore::new(0)` previously froze `sync` / `update` / `generate`.
