### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,35 @@ indent_size = 4
 
 [Makefile,*.mk]
 indent_style = tab
+# kata:editorconfig:base:begin
+# kata-managed universal EditorConfig rules (yukimemi/pj-base). Normalizes
+# indentation and line endings at edit time so contributors on different
+# editors/OSes converge instead of round-tripping CRLF/LF or mixed indent
+# widths. Companion to `.gitattributes` (`* text=auto eol=lf`, which
+# normalizes at commit time) — this file targets the editor instead.
+# Language layers (pj-rust, ...) append file-type sections via
+# merge-section; see `# kata:editorconfig:*:begin/end` markers in the
+# rendered `.editorconfig`.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Markdown: two trailing spaces is a hard line break, not noise.
+[*.md]
+trim_trailing_whitespace = false
+# kata:editorconfig:base:end
+# kata:editorconfig:rust:begin
+# Rust-layer EditorConfig section — appended (via kata merge-section) to
+# the `[*]` defaults pj-base ships. `indent_size = 4` matches rustfmt's
+# default `tab_spaces` (`rustfmt.toml` only pins `edition`, so the 4-space
+# default stands); everything else (TOML/YAML/JSON/Markdown at 2 spaces,
+# LF, trimmed trailing whitespace) is inherited from pj-base's `[*]`.
+[*.rs]
+indent_size = 4
+# kata:editorconfig:rust:end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  editorconfig:
+    # Enforces the repo's `.editorconfig` (LF, trimmed trailing
+    # whitespace, per-filetype indent width) across every tracked file,
+    # not just Rust sources. `cargo make check`'s `editorconfig-check`
+    # task runs the same tool locally but skips gracefully when the
+    # `editorconfig-checker` binary isn't on PATH (it isn't a Rust
+    # crate, so `cargo install` can't fetch it) — this job is the
+    # actual enforcement gate.
+    name: editorconfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
+      - run: editorconfig-checker
+
   clippy:
     # Matrix across all three OSes so OS-specific dead code (e.g. helpers
     # gated under `cfg(target_os = "windows")`) is caught everywhere, not

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,8 +85,8 @@ jobs:
     # `issues`.
     if: |
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-               github.event.comment.author_association ||
-               github.event.issue.author_association) &&
+        github.event.comment.author_association ||
+        github.event.issue.author_association) &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,14 +1,14 @@
 preset = "github.com/yukimemi/pj-presets:rust-cli"
-applied_at = "2026-08-30T03:29:47.787146436Z"
+applied_at = "2026-08-31T03:32:51.354286994Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "10cd49c09b95af8add4daf71c5151835821cb670"
+rev = "b205d49d8676a2d3b78efa020749b7f012921159"
 version = "0.18.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-rust"
-rev = "e9ed48b62025bbe80e1d35cdccca11ec2ee88d3e"
+rev = "148d044fd11530b1f92bf0c5a7f9563049710a14"
 version = "0.8.1"
 
 [[templates]]
@@ -23,6 +23,7 @@ once_applied = true
 once_applied = true
 
 [files.".editorconfig"]
+content_hash = "f50ceb17e736856f0a6d3ddbcbcc251e7df3d7c1542dd143dd0d228b834697e0"
 once_applied = true
 
 [files.".gemini/settings.json"]
@@ -38,13 +39,13 @@ content_hash = "0ac5ed2847ab6e1041e34209dcc2396a582722ea9537d03bd950e1db1851a4b7
 content_hash = "4e2735f40c2ae61014810159a2458da2edc1646589f5f65d9f2f3d099366c9a8"
 
 [files.".github/workflows/ci.yml"]
-content_hash = "db97d026a267859e3b93bcac29f69e7ae65be5ad760cf739b2f7622c77d27f6f"
+content_hash = "bbc5b62bfe5f37033ea9d4d5fb9f0ef4e4df460a6a7920e1408b43dbb87b9304"
 
 [files.".github/workflows/claude-review.yml"]
 content_hash = "4a8e47aabb3cdf2a59030d5194467022f0efb53bb1819d4495752020d10be773"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "c83b52d5f483fdec494028b932facf98018500ce757718cc2e3703328688f5ad"
+content_hash = "7bb6c538ec5c2688e01b54e983232fa99f65e24ee16172c4270341345cbdac34"
 
 [files.".github/workflows/kata-apply.yml"]
 content_hash = "7000353151b01b5d14cb8f56e314b1a25b020e22bdf5842dcaf5686efb59facb"
@@ -57,7 +58,7 @@ once_applied = true
 content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef"
 
 [files.".kata/vars.toml"]
-content_hash = "8e573305bc9b45b40e4c4c24c0da7728771a12d81c4c1631d6e35f25a189cf84"
+content_hash = "84daa3d716a28510f2dba69e3c95eb43936d89916df8f16c39b60d0473f9e818"
 once_applied = true
 
 [files."AGENTS.md"]
@@ -73,7 +74,7 @@ content_hash = "3670f70a2f0be4013926bab6e878b90a42ad64c17899080aef4d193b246fa390
 once_applied = true
 
 [files."Makefile.toml"]
-content_hash = "930554e54d2c4090b4e0ba6014dd0692a05884ff6af803897f9d1c1647818b94"
+content_hash = "23145feefcd54c44e8b8fee83baab72b6b5114ea076022c5cb81decda34f358f"
 
 [files."OPENCODE.md"]
 content_hash = "11993dc7feec5fca8e83934f135de33879b88f100c48aeba0729de2f57a11a48"

--- a/.kata/vars.toml
+++ b/.kata/vars.toml
@@ -21,3 +21,6 @@ create_pull_request = "v8.1.1"
 swatinem_rust_cache = "v2.9.2"
 # renovate: datasource=github-tags depName=anthropics/claude-code-action
 claude_code_action = "v1.0.195"
+
+# renovate: datasource=github-tags depName=editorconfig-checker/action-editorconfig-checker
+editorconfig_checker = "v2"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,7 +560,7 @@ covers git workflow, PR review cycle, and worktree usage.
 ### Build / lint / test
 
 ```sh
-cargo make check                    # fmt --check + clippy + test + lock-check (the pre-push gate)
+cargo make check                    # editorconfig-check + fmt --check + clippy + test + lock-check (the pre-push gate)
 cargo make setup                    # one-time hook install + apm install
 cargo build                         # debug build
 cargo build --release               # release build

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,13 +2,25 @@
 alias = "check"
 
 [tasks.check]
-description = "Run fmt + clippy + test + lock-check (same as CI)"
-dependencies = ["fmt-check", "clippy", "test", "lock-check"]
+description = "Run editorconfig-check + fmt + clippy + test + lock-check (same as CI)"
+dependencies = ["editorconfig-check", "fmt-check", "clippy", "test", "lock-check"]
 
 [tasks.fmt-check]
 description = "Check formatting"
 command = "cargo"
 args = ["fmt", "--all", "--", "--check"]
+
+[tasks.editorconfig-check]
+description = "Check tracked files against .editorconfig (skipped locally if the `editorconfig-checker` binary isn't on PATH — CI always enforces it via editorconfig-checker/action-editorconfig-checker). Install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+script_runner = "@duckscript"
+script = '''
+ec_path = which editorconfig-checker
+if is_empty ${ec_path}
+    echo "editorconfig-checker not on PATH; skipping editorconfig-check locally (still enforced in CI). Install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+    exit 0
+end
+exec --fail-on-error editorconfig-checker
+'''
 
 [tasks.fmt]
 description = "Apply formatting"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent formatting rules for project files, including Rust-specific indentation.
  * Added automated checks to enforce formatting standards in CI and local validation.
  * Local checks gracefully skip the formatting validator when it is unavailable.

* **Documentation**
  * Updated build and validation guidance to include the new formatting check.

* **Chores**
  * Updated project template metadata and formatting-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->