### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,11 @@
 lockfile_version: '1'
-generated_at: '2026-08-24T04:16:11.481857+00:00'
-apm_version: 0.28.0
+generated_at: '2026-08-31T04:09:25.382869+00:00'
+apm_version: 0.29.0
 dependencies:
 - repo_url: yukimemi/renri
   name: renri
   host: github.com
-  resolved_commit: 8516699247412a0262303e9f17049d053878963d
+  resolved_commit: 9b554eb1224ecc0401ad077a7416693b9e8709d2
   resolved_ref: main
   version: 0.1.17
   package_type: apm_package
@@ -17,7 +17,7 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
     .claude/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
-  content_hash: sha256:779ec501a96486c4e8f227a387e99eab26480948ac0984f0a213cdd03a8f4f16
+  content_hash: sha256:e6ba4596d4f56aaf86f6d3da1ece18777f2510ab31b5a1312a844df96e1f1581
 deployments:
 - kind: project-relative
   target: claude


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package lockfile metadata and resolved dependency information.
  * Refreshed integrity data to reflect the latest locked package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->